### PR TITLE
fix(config): add fingerprint to BeNext Energy switch

### DIFF
--- a/packages/config/config/devices/0x008a/energy_switch.json
+++ b/packages/config/config/devices/0x008a/energy_switch.json
@@ -10,6 +10,10 @@
 			"zwaveAllianceId": 73
 		},
 		{
+			"productType": "0x0006",
+			"productId": "0x0200"
+		},
+		{
 			"productType": "0x0020",
 			"productId": "0x0001"
 		}


### PR DESCRIPTION
I have a slightly different BeNext Energy Switch that uses a different productID and is not currently recognised as such.
I've added it to the list of devices.

Let me know if any other info is needed to add it to the device database.