### PR TITLE
fix: remove Security S0/S2 from mandatory CCs

### DIFF
--- a/packages/config/config/deviceClasses.json
+++ b/packages/config/config/deviceClasses.json
@@ -85,8 +85,8 @@
 						"Inclusion Controller",
 						"Powerlevel",
 						"Manufacturer Specific",
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Simple AV Control",
 						"Transport Service", // V2+
@@ -100,8 +100,8 @@
 						"CRC-16 Encapsulation",
 						"Multi Channel", // V4+
 						"Multi Channel Association", // V3+
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Wake Up" // V2+
 					]
 				},
@@ -116,7 +116,7 @@
 						"Inclusion Controller",
 						"Manufacturer Specific",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -140,8 +140,8 @@
 						"Inclusion Controller",
 						"Manufacturer Specific",
 						"Powerlevel",
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Simple AV Control",
 						"Transport Service", // V2+
@@ -156,16 +156,23 @@
 						"CRC-16 Encapsulation",
 						"Multi Channel", // V4+
 						"Multi Channel Association", // V3+
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Wake Up" // V2+
 					]
 				},
 				"0x07": {
 					"label": "Gateway",
 					"zwavePlusDeviceType": "Gateway",
-					"supportedCCs": ["Manufacturer Specific", "Security", "Version"],
-					"controlledCCs": ["Security", "Multi Channel"]
+					"supportedCCs": [
+						"Manufacturer Specific",
+						// "Security", (some devices only support S2)
+						"Version"
+					],
+					"controlledCCs": [
+						// "Security", (some devices only support S2)
+						"Multi Channel"
+					]
 				}
 			}
 		},
@@ -186,7 +193,7 @@
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Manufacturer Specific",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -332,7 +339,7 @@
 						"IR Repeater",
 						"Manufacturer Specific",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -362,7 +369,7 @@
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Manufacturer Specific",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -391,7 +398,7 @@
 						"Multi Channel", // V4+
 						"Multi Channel Association", // V3+
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -410,7 +417,7 @@
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Manufacturer Specific",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -429,7 +436,7 @@
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Manufacturer Specific",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -447,7 +454,7 @@
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Manufacturer Specific",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -477,7 +484,7 @@
 						"Manufacturer Specific",
 						"Multilevel Switch",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -538,7 +545,7 @@
 						"Manufacturer Specific",
 						"Multilevel Switch",
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -674,7 +681,7 @@
 						"Manufacturer Specific",
 						"Meter", // V2+
 						"Powerlevel",
-						"Security 2",
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -699,7 +706,14 @@
 					"label": "Secure Keypad Door Lock",
 					"zwavePlusDeviceType": "Door Lock - Keypad",
 					"requiresSecurity": true,
-					"supportedCCs": ["Basic", "Door Lock", "User Code", "Manufacturer Specific", "Security", "Version"]
+					"supportedCCs": [
+						"Basic",
+						"Door Lock",
+						"User Code",
+						"Manufacturer Specific",
+						// "Security", (some devices only support S2)
+						"Version"
+					]
 				},
 				"0x05": {
 					"label": "Secure Door",
@@ -715,8 +729,8 @@
 						"Manufacturer Specific",
 						"Notification", // V4+
 						"Powerlevel",
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -737,8 +751,8 @@
 						"Manufacturer Specific",
 						"Notification", // V4+
 						"Powerlevel",
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -759,8 +773,8 @@
 						"Manufacturer Specific",
 						"Notification", // V4+
 						"Powerlevel",
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -781,8 +795,8 @@
 						"Manufacturer Specific",
 						"Notification", // V4+
 						"Powerlevel",
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -803,8 +817,8 @@
 						"Manufacturer Specific",
 						"Notification", // V4+
 						"Powerlevel",
-						"Security",
-						"Security 2",
+						// "Security", (some devices only support S2)
+						// "Security 2", (older devices don't always support S2)
 						"Supervision",
 						"Transport Service", // V2+
 						"Version", // V2+
@@ -821,7 +835,7 @@
 						"Association",
 						"Door Lock",
 						"Manufacturer Specific",
-						"Security",
+						// "Security", (some devices only support S2)
 						"Version"
 					]
 				},
@@ -833,7 +847,7 @@
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Entry Control",
 						"Manufacturer Specific",
-						"Security",
+						// "Security", (some devices only support S2)
 						"Version"
 					]
 				}


### PR DESCRIPTION
Older devices don't necessarily support S2, newer don't always support S0, so going by somewhat recent specs doesn't make a ton of sense here.

fixes: https://github.com/zwave-js/node-zwave-js/issues/3487