### PR TITLE
fix: abort S2 bootstrapping on decode failure after public key exchange

### DIFF
--- a/packages/zwave-js/src/index.ts
+++ b/packages/zwave-js/src/index.ts
@@ -9,7 +9,7 @@ import { install as installSourceMapSupport } from "source-map-support";
 installSourceMapSupport();
 
 import * as path from "path";
-import { initSentry } from "./lib/telemetry/sentry.js";
+import { initSentry } from "./lib/telemetry/sentry";
 
 /** The version of zwave-js, exported for your convenience */
 const packageJsonPath = require.resolve("zwave-js/package.json");

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -1088,6 +1088,23 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 		}
 	}
 
+	private _bootstrappingS2NodeId: number | undefined;
+	/**
+	 * @internal
+	 * Returns which node is currently being bootstrapped with S2
+	 */
+	public get bootstrappingS2NodeId(): number | undefined {
+		return this._bootstrappingS2NodeId;
+	}
+
+	private cancelBootstrapS2Promise: DeferredPromise<KEXFailType> | undefined;
+	public cancelSecureBootstrapS2(reason: KEXFailType): void {
+		if (this.cancelBootstrapS2Promise) {
+			this.cancelBootstrapS2Promise.resolve(reason);
+			this.cancelBootstrapS2Promise = undefined;
+		}
+	}
+
 	private async secureBootstrapS2(
 		node: ZWaveNode,
 		assumeSupported: boolean = false,
@@ -1125,6 +1142,10 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 			this.driver.securityManager2?.tempKeys.delete(node.id);
 		};
 
+		// Allow canceling the bootstrapping process
+		this._bootstrappingS2NodeId = node.id;
+		this.cancelBootstrapS2Promise = createDeferredPromise();
+
 		try {
 			const api = node.commandClasses["Security 2"];
 			const abort = async (failType?: KEXFailType): Promise<void> => {
@@ -1138,6 +1159,9 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 				// Un-grant S2 security classes we might have granted
 				unGrantSecurityClasses();
 				deleteTempKey();
+				// We're no longer bootstrapping
+				this._bootstrappingS2NodeId = undefined;
+				this.cancelBootstrapS2Promise = undefined;
 			};
 
 			const abortUser = () => {
@@ -1334,14 +1358,22 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 				return abortUser();
 			}
 
-			const keySetEcho = await this.driver.waitForCommand<
-				Security2CCKEXSet | Security2CCKEXFail
-			>(
-				(cc) =>
-					cc instanceof Security2CCKEXSet ||
-					cc instanceof Security2CCKEXFail,
-				tai2RemainingMs,
-			);
+			const keySetEcho = await Promise.race([
+				this.driver.waitForCommand<
+					Security2CCKEXSet | Security2CCKEXFail
+				>(
+					(cc) =>
+						cc instanceof Security2CCKEXSet ||
+						cc instanceof Security2CCKEXFail,
+					tai2RemainingMs,
+				),
+				this.cancelBootstrapS2Promise,
+			]);
+			if (typeof keySetEcho === "number") {
+				// The bootstrapping process was canceled - this is most likely because the PIN was incorrect
+				// and the node's commands cannot be decoded
+				return abort(keySetEcho);
+			}
 			// Validate that the received command contains the correct list of keys
 			if (keySetEcho instanceof Security2CCKEXFail || !keySetEcho.echo) {
 				this.driver.controllerLog.logNode(node.id, {
@@ -1511,6 +1543,9 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 		} finally {
 			// Whatever happens, no further communication needs the temporary key
 			deleteTempKey();
+			// And we're no longer bootstrapping
+			this._bootstrappingS2NodeId = undefined;
+			this.cancelBootstrapS2Promise = undefined;
 		}
 	}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -72,6 +72,7 @@ import {
 } from "../commandclass/ICommandClassContainer";
 import { MultiChannelCC } from "../commandclass/MultiChannelCC";
 import { messageIsPing } from "../commandclass/NoOperationCC";
+import { KEXFailType } from "../commandclass/Security2/shared";
 import {
 	SecurityCC,
 	SecurityCCCommandEncapsulationNonceGet,
@@ -1941,7 +1942,17 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 					? "Message authentication failed"
 					: "No SPAN is established yet";
 
-			if (!this.hasPendingTransactions(isS2NonceReport)) {
+			if (this.controller.bootstrappingS2NodeId === nodeId) {
+				// The node is currently being bootstrapped. Us not being able to decode the command means we need to abort the bootstrapping process
+				this.controllerLog.logNode(nodeId, {
+					message: `${message}, cannot decode command. Aborting the S2 bootstrapping process...`,
+					level: "error",
+					direction: "inbound",
+				});
+				this.controller.cancelSecureBootstrapS2(
+					KEXFailType.BootstrappingCanceled,
+				);
+			} else if (!this.hasPendingTransactions(isS2NonceReport)) {
 				this.controllerLog.logNode(nodeId, {
 					message: `${message}, cannot decode command. Requesting a nonce...`,
 					level: "verbose",


### PR DESCRIPTION
fixes: #3421

I'm not sure if `BootstrappingCanceled` is the correct `KEXFailType`, but the specs don't seem to account for human error (wrong PIN).