### PR TITLE
feat: add `getDefinedValueIDs` for virtual nodes

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,7 @@
     -   [Controller](api/controller.md)
     -   [ZWaveNode](api/node.md)
     -   [Endpoint](api/endpoint.md)
+    -   [Virtual nodes and endpoints](api/virtual-node-endpoint.md)
     -   [Values and Metadata](api/valueid.md)
     -   [ConfigManager](api/config-manager.md)
     -   [Command Classes](api/CCs/index.md)

--- a/docs/api/virtual-node-endpoint.md
+++ b/docs/api/virtual-node-endpoint.md
@@ -10,6 +10,40 @@ Like in physical nodes, the endpoint 0 of a virtual node represents its root end
 
 See [`ZWaveNode.setValue`](api/node.md#setValue) for a description. Behind the scenes, multicast and broadcast commands are used automatically when necessary.
 
+### `getDefinedValueIDs`
+
+```ts
+getDefinedValueIDs(): VirtualValueID[]
+```
+
+Similar to [`ZWaveNode.getDefinedValueIDs`](api/node.md#getDefinedValueIDs), this returns an array of all possible value IDs that can be used to control the physical node(s) this virtual node represents using [`setValue`](#setValue). Because these value IDs are only virtual and can change over time, they are not stored in the database and this method returns the corresponding metadata and CC version along with the value ID itself:
+
+```ts
+interface VirtualValueID extends TranslatedValueID {
+	/** The metadata that belongs to this virtual value ID */
+	metadata: ValueMetadata;
+	/** The maximum supported CC version among all nodes targeted by this virtual value ID */
+	ccVersion: number;
+}
+```
+
+> [!NOTE] The returned array will include values for the `Basic CC`, which is the preferred way to control different heterogeneous devices like Binary Switches and Multilevel Switches together.
+
+This method and its return values need to be re-evaluated whenever the underlying physical nodes change. This is the case when:
+
+-   **Broadcast node**:
+    -   All nodes are ready for the first time
+    -   A new node is added to the network and becomes ready
+    -   An existing node is re-interviewed and becomes ready again
+    -   A node is removed from the network
+-   **Multicast groups**:
+    -   All members of the multicast group are ready for the first time
+    -   A (ready) node is added to a multicast group
+    -   A member of a multicast group is re-interviewed and becomes ready again
+    -   A node is removed from a multicast group
+
+> [!NOTE] Values of virtual nodes/endpoints are only writable. They don't store a value in the value DB and their value is never updated.
+
 ### `getEndpoint`
 
 ```ts

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -14,4 +14,4 @@ export {
 	ZWaveNodeEvents,
 } from "./lib/node/Types";
 export { VirtualEndpoint } from "./lib/node/VirtualEndpoint";
-export { VirtualNode } from "./lib/node/VirtualNode";
+export { VirtualNode, VirtualValueID } from "./lib/node/VirtualNode";

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -1,13 +1,27 @@
 import {
+	actuatorCCs,
+	CommandClasses,
 	isZWaveError,
+	TranslatedValueID,
 	ValueID,
+	valueIdToString,
+	ValueMetadata,
+	ValueMetadataNumeric,
 	ZWaveError,
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
+import { distinct } from "alcalzone-shared/arrays";
 import type { CCAPI, SetValueAPIOptions } from "../commandclass/API";
 import type { Driver } from "../driver/Driver";
 import type { ZWaveNode } from "./Node";
 import { VirtualEndpoint } from "./VirtualEndpoint";
+
+export interface VirtualValueID extends TranslatedValueID {
+	/** The metadata that belongs to this virtual value ID */
+	metadata: ValueMetadata;
+	/** The maximum supported CC version among all nodes targeted by this virtual value ID */
+	ccVersion: number;
+}
 
 export class VirtualNode extends VirtualEndpoint {
 	public constructor(
@@ -94,6 +108,80 @@ export class VirtualNode extends VirtualEndpoint {
 			}
 			throw e;
 		}
+	}
+
+	/**
+	 * Returns a list of all value IDs and their metadata that can be used to
+	 * control the physical node(s) this virtual node represents.
+	 */
+	public getDefinedValueIDs(): VirtualValueID[] {
+		// If all nodes are secure, we can't use broadcast/multicast commands
+		if (this.physicalNodes.every((n) => n.isSecure === true)) return [];
+
+		// In order to compare value ids, we need them to be strings
+		const ret = new Map<string, VirtualValueID>();
+
+		for (const pNode of this.physicalNodes) {
+			// Secure nodes cannot be used for broadcast
+			if (pNode.isSecure === true) continue;
+
+			// Take only the actuator values
+			const valueIDs: TranslatedValueID[] = pNode
+				.getDefinedValueIDs()
+				.filter((v) => actuatorCCs.includes(v.commandClass));
+			// And add them to the returned array if they aren't included yet or if the version is higher
+
+			for (const valueId of valueIDs) {
+				const mapKey = valueIdToString(valueId);
+				const ccVersion = pNode.getCCVersion(valueId.commandClass);
+				const metadata = pNode.getValueMetadata(valueId);
+				// Don't expose read-only values for virtual nodes, they won't ever have any value
+				if (!metadata.writeable) continue;
+
+				const needsUpdate =
+					!ret.has(mapKey) || ret.get(mapKey)!.ccVersion < ccVersion;
+				if (needsUpdate) {
+					ret.set(mapKey, {
+						...valueId,
+						ccVersion,
+						metadata: {
+							...metadata,
+							// Metadata of virtual nodes is only writable
+							readable: false,
+						},
+					});
+				}
+			}
+		}
+
+		// Basic CC is not exposed, but virtual nodes need it to control multiple different devices together
+		const exposedEndpoints = distinct(
+			[...ret.values()]
+				.map((v) => v.endpoint)
+				.filter((e): e is number => e !== undefined),
+		);
+		for (const endpoint of exposedEndpoints) {
+			// TODO: This should be defined in the Basic CC file
+			const valueId: TranslatedValueID = {
+				commandClass: CommandClasses.Basic,
+				commandClassName: "Basic",
+				endpoint,
+				property: "targetValue",
+				propertyName: "Target value",
+			};
+			const ccVersion = 1;
+			const metadata: ValueMetadataNumeric = {
+				...ValueMetadata.WriteOnlyUInt8,
+				label: "Target value",
+			};
+			ret.set(valueIdToString(valueId), {
+				...valueId,
+				ccVersion,
+				metadata,
+			});
+		}
+
+		return [...ret.values()];
 	}
 
 	/** Cache for this node's endpoint instances */


### PR DESCRIPTION
With this PR, it is possible to expose the existing value IDs of virtual nodes. To make it possible to control heterogenous device groups, this list will include `Basic CC` values, whether they are normally hidden or not.

fixes: #3191