### PR TITLE
fix: remove securityClasses property from SecurityClassOwner interface

### DIFF
--- a/packages/core/src/security/SecurityClass.ts
+++ b/packages/core/src/security/SecurityClass.ts
@@ -42,7 +42,6 @@ export const securityClassOrder = [
 
 export interface SecurityClassOwner {
 	readonly id: number;
-	readonly securityClasses: Map<SecurityClass, boolean>;
 	getHighestSecurityClass(): SecurityClass | undefined;
 	hasSecurityClass(securityClass: SecurityClass): Maybe<boolean>;
 }


### PR DESCRIPTION
It was never actually used and meant to be internal, but snuck out into the open somehow.

fixes: #3503