### PR TITLE
feat(config): add Heatit Z-Push Button 4

### DIFF
--- a/packages/config/config/devices/0x019b/heatit_z_push_button_4.json
+++ b/packages/config/config/devices/0x019b/heatit_z_push_button_4.json
@@ -1,0 +1,16 @@
+{
+	"manufacturer": "Heatit",
+	"manufacturerId": "0x019b",
+	"label": "Z Push Button 4",
+	"description": "Wall Mounted Switch",
+	"devices": [
+		{
+			"productType": "0x0300",
+			"productId": "0xa306"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	}
+}


### PR DESCRIPTION
Not shure if the "productId": "0xa306" is correct.
Just a guess since push 8 has 305 and push 2 has 307

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
