### PR TITLE
fix(config): auto-assign `Binary Sensor Report` association group for FortrezZ MIMOLite

### DIFF
--- a/packages/config/config/devices/0x0084/mimolite.json
+++ b/packages/config/config/devices/0x0084/mimolite.json
@@ -51,7 +51,8 @@
 		},
 		"4": {
 			"label": "Binary Sensor report",
-			"maxNodes": 2
+			"maxNodes": 2,
+			"isLifeline": true
 		},
 		"5": {
 			"label": "Pulse Meter Sensor report",


### PR DESCRIPTION
See: https://community.home-assistant.io/t/zwavejs2mqtt-fotrezz-mimolite-configuration/346084

The current configuration does not setup the Binary Sensor report association and as a result the input contact does not update unless polled.
