### PR TITLE
fix: better error when creating a multicast group with missing nodes

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -429,11 +429,8 @@ export class ZWaveController extends TypedEventEmitter<ControllerEventCallbacks>
 
 	/** Creates a virtual node that can be used to send multicast commands to several nodes */
 	public getMulticastGroup(nodeIDs: number[]): VirtualNode {
-		return new VirtualNode(
-			undefined,
-			this.driver,
-			nodeIDs.map((id) => this._nodes.get(id)!),
-		);
+		const nodes = nodeIDs.map((id) => this._nodes.getOrThrow(id));
+		return new VirtualNode(undefined, this.driver, nodes);
 	}
 
 	/**


### PR DESCRIPTION
When `getMulticastGroup` was called with an id for a node that doesn't exist, the error message was quite cryptic:
```
TypeError: Cannot read properties of undefined (reading 'id')
    at C:\iobroker\ioBroker.zwave2\.dev-server\default\node_modules\zwave-js\src\lib\node\VirtualNode.ts:39:13
    at Array.filter (<anonymous>)
    at new VirtualNode (C:\iobroker\ioBroker.zwave2\.dev-server\default\node_modules\zwave-js\src\lib\node\VirtualNode.ts:37:43)
    at ZWaveController.getMulticastGroup (C:\iobroker\ioBroker.zwave2\.dev-server\default\node_modules\zwave-js\src\lib\controller\Controller.ts:432:10)
```

This PR changes it to a ZWaveError `Node ${nodeId} was not found!` with a code of `Controller_NodeNotFound`.