### PR TITLE
chore(sentry): don't report errors raised in the node REPL, filter based on error message

### DIFF
--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -1,3 +1,5 @@
+import { padStart } from "alcalzone-shared/strings";
+
 /**
  * Used to identify errors from this library without relying on the error message
  */
@@ -150,6 +152,16 @@ export enum ZWaveErrorCodes {
 	Unsupported_Firmware_Format,
 }
 
+export function getErrorSuffix(code: ZWaveErrorCodes): string {
+	return `ZW${padStart(code.toString(), 4, "0")}`;
+}
+
+function appendErrorSuffix(message: string, code: ZWaveErrorCodes): string {
+	const suffix = ` (${getErrorSuffix(code)})`;
+	if (!message.endsWith(suffix)) message += suffix;
+	return message;
+}
+
 /**
  * Errors thrown in this library are of this type. The `code` property identifies what went wrong.
  */
@@ -162,7 +174,10 @@ export class ZWaveError extends Error {
 		/** If this error corresponds to a failed transaction, this contains the stack where it was created */
 		public readonly transactionSource?: string,
 	) {
-		super(message);
+		super();
+
+		// Add the error code to the message to be able to identify it even when the stack trace is garbled somehow
+		this.message = appendErrorSuffix(message, code);
 
 		// We need to set the prototype explicitly
 		Object.setPrototypeOf(this, ZWaveError.prototype);

--- a/packages/zwave-js/src/lib/telemetry/sentry.test.ts
+++ b/packages/zwave-js/src/lib/telemetry/sentry.test.ts
@@ -1,4 +1,4 @@
-import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
+import { getErrorSuffix, ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import path from "path";
 import { createSentryContext } from "./sentry";
 
@@ -150,8 +150,6 @@ describe("The Sentry telemetry", () => {
 										"/home/michel/dashboard/servers/zwave/devices/powerswitch.js",
 									abs_path:
 										"/home/michel/dashboard/servers/zwave/devices/powerswitch.js",
-									lineno: 134,
-									colno: 24,
 								},
 								{
 									function: "new Promise",
@@ -408,6 +406,113 @@ describe("The Sentry telemetry", () => {
 				},
 			} as any;
 			expect(context.shouldIgnore(event)).toBeTrue();
+		});
+
+		it("test 2: clearly a connection issue", () => {
+			const context = createSentryContext(
+				"/home/pi/zwave/node_modules/zwave-js",
+			);
+			const event = {
+				culprit:
+					"Map.<anonymous>(zwave-js.src.lib.controller:Controller.ts)",
+				exception: {
+					values: [
+						{
+							type: "ZWaveError",
+							value: "Failed to send the message after 3 attempts",
+							stacktrace: {
+								frames: [
+									{
+										function: "__awaiter",
+										module: "fn",
+										filename: "/home/pi/zwave/build/fn.js",
+										abs_path: "/home/pi/zwave/build/fn.js",
+										in_app: true,
+									},
+									{
+										function: "new Promise",
+										in_app: true,
+									},
+									{
+										function: "null.<anonymous>",
+										module: "fn",
+										filename: "/home/pi/zwave/build/fn.js",
+										abs_path: "/home/pi/zwave/build/fn.js",
+										in_app: true,
+									},
+									{
+										function: "Generator.next",
+										in_app: true,
+									},
+									{
+										function: "null.<anonymous>",
+										module: "fn.ts",
+										filename: "/home/pi/zwave/fn.ts",
+										abs_path: "/home/pi/zwave/fn.ts",
+										in_app: true,
+									},
+									{
+										function: "ZWaveNode.setValue",
+										module: "zwave-js.src.lib.node:Node.ts",
+										filename:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/node/Node.ts",
+										abs_path:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/node/Node.ts",
+										in_app: false,
+									},
+									{
+										function:
+											"Proxy.ConfigurationCCAPI.<computed>",
+										module: "zwave-js.src.lib.commandclass:ConfigurationCC.ts",
+										filename:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/commandclass/ConfigurationCC.ts",
+										abs_path:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/commandclass/ConfigurationCC.ts",
+										in_app: false,
+									},
+									{
+										function: "ConfigurationCCAPI.set",
+										module: "zwave-js.src.lib.commandclass:ConfigurationCC.ts",
+										filename:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/commandclass/ConfigurationCC.ts",
+										abs_path:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/commandclass/ConfigurationCC.ts",
+										in_app: false,
+									},
+									{
+										function: "Driver.sendCommand",
+										module: "zwave-js.src.lib.driver:Driver.ts",
+										filename:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/driver/Driver.ts",
+										abs_path:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/driver/Driver.ts",
+										in_app: false,
+									},
+									{
+										function: "Driver.sendMessage",
+										module: "zwave-js.src.lib.driver:Driver.ts",
+										filename:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/driver/Driver.ts",
+										abs_path:
+											"/home/pi/zwave/node_modules/zwave-js/src/lib/driver/Driver.ts",
+										in_app: false,
+									},
+								],
+							},
+							mechanism: {
+								type: "onunhandledrejection",
+								handled: false,
+							},
+						},
+					],
+				},
+			} as any;
+			const hint = {
+				originalException: `Failed to send the message after 3 attempts (${getErrorSuffix(
+					ZWaveErrorCodes.Controller_MessageDropped,
+				)})`,
+			} as any;
+			expect(context.shouldIgnore(event, hint)).toBeTrue();
 		});
 	});
 });

--- a/packages/zwave-js/src/lib/telemetry/sentry.test.ts
+++ b/packages/zwave-js/src/lib/telemetry/sentry.test.ts
@@ -1,14 +1,12 @@
 import { ZWaveError, ZWaveErrorCodes } from "@zwave-js/core";
 import path from "path";
-import { createSentryContext, SentryContext } from "./sentry";
+import { createSentryContext } from "./sentry";
 
 describe("The Sentry telemetry", () => {
-	let context: SentryContext;
-	beforeAll(() => {
-		context = createSentryContext(path.join(__dirname, "../../.."));
-	});
+	const defaultRootDir = path.join(__dirname, "../../..");
 
 	it("should ignore errors that are caused outside zwave-js", () => {
+		const context = createSentryContext(defaultRootDir);
 		const event = {
 			exception: {
 				values: [
@@ -49,6 +47,9 @@ describe("The Sentry telemetry", () => {
 	});
 
 	it("should NOT ignore errors that are explicitly whitelisted", () => {
+		const context = createSentryContext(
+			"/opt/iobroker/node_modules/zwave-js",
+		);
 		const event = {
 			exception: {
 				values: [
@@ -105,6 +106,9 @@ describe("The Sentry telemetry", () => {
 	});
 
 	it("should ignore errors that must be handled by the developer", () => {
+		const context = createSentryContext(
+			"/home/michel/dashboard/servers/zwave/node_modules/zwave-js",
+		);
 		const event = {
 			exception: {
 				values: [
@@ -205,6 +209,9 @@ describe("The Sentry telemetry", () => {
 	});
 
 	it("should ignore errors that must be handled by the developer, unless whitelisted", () => {
+		const context = createSentryContext(
+			"/opt/iobroker/node_modules/zwave-js",
+		);
 		const event = {
 			exception: {
 				values: [
@@ -298,5 +305,109 @@ describe("The Sentry telemetry", () => {
 			),
 		} as any;
 		expect(context.shouldIgnore(event, hint)).toBeFalse();
+	});
+
+	describe("regression tests for ignored errors", () => {
+		it("test 1: testing in the REPL", () => {
+			const context = createSentryContext(
+				"/Users/ross/code/temp/zwave/node_modules/zwave-js",
+			);
+			const event = {
+				culprit:
+					"Map.<anonymous>(zwave-js.src.lib.controller:Controller.ts)",
+				exception: {
+					values: [
+						{
+							type: "ZWaveError",
+							value: "Node 255 was not found!",
+							stacktrace: {
+								frames: [
+									{
+										function:
+											"REPLServer.runBound [as eval]",
+										module: "domain",
+										filename: "domain.js",
+										abs_path: "domain.js",
+										in_app: false,
+									},
+									{
+										function: "bound",
+										module: "domain",
+										filename: "domain.js",
+										abs_path: "domain.js",
+										in_app: false,
+									},
+									{
+										function: "REPLServer.defaultEval",
+										module: "repl",
+										filename: "repl.js",
+										abs_path: "repl.js",
+										in_app: false,
+									},
+									{
+										function: "Script.runInContext",
+										module: "vm",
+										filename: "vm.js",
+										abs_path: "vm.js",
+										in_app: false,
+									},
+									{
+										function: "null.<anonymous>",
+										module: "REPL1",
+										filename: "REPL1",
+										abs_path: "REPL1",
+										in_app: false,
+									},
+									{
+										function:
+											"ZWaveController.addAssociations",
+										module: "zwave-js.src.lib.controller:Controller.ts",
+										filename:
+											"/Users/ross/code/temp/zwave/node_modules/zwave-js/src/lib/controller/Controller.ts",
+										abs_path:
+											"/Users/ross/code/temp/zwave/node_modules/zwave-js/src/lib/controller/Controller.ts",
+										in_app: false,
+									},
+									{ function: "Array.filter", in_app: true },
+									{
+										function: "null.<anonymous>",
+										module: "zwave-js.src.lib.controller:Controller.ts",
+										filename:
+											"/Users/ross/code/temp/zwave/node_modules/zwave-js/src/lib/controller/Controller.ts",
+										abs_path:
+											"/Users/ross/code/temp/zwave/node_modules/zwave-js/src/lib/controller/Controller.ts",
+										in_app: false,
+									},
+									{
+										function:
+											"ZWaveController.isAssociationAllowed",
+										module: "zwave-js.src.lib.controller:Controller.ts",
+										filename:
+											"/Users/ross/code/temp/zwave/node_modules/zwave-js/src/lib/controller/Controller.ts",
+										abs_path:
+											"/Users/ross/code/temp/zwave/node_modules/zwave-js/src/lib/controller/Controller.ts",
+										in_app: false,
+									},
+									{
+										function: "Map.<anonymous>",
+										module: "zwave-js.src.lib.controller:Controller.ts",
+										filename:
+											"/Users/ross/code/temp/zwave/node_modules/zwave-js/src/lib/controller/Controller.ts",
+										abs_path:
+											"/Users/ross/code/temp/zwave/node_modules/zwave-js/src/lib/controller/Controller.ts",
+										in_app: false,
+									},
+								],
+							},
+							mechanism: {
+								type: "onunhandledrejection",
+								handled: false,
+							},
+						},
+					],
+				},
+			} as any;
+			expect(context.shouldIgnore(event)).toBeTrue();
+		});
 	});
 });


### PR DESCRIPTION
This should keep a bunch of noise off Sentry. It seems that not every `ZWaveError` instance is detected in `beforeSend`, so we now encode the error code in the error message and filter based on this.