### PR TITLE
refactor: throw if soft reset is called when not enabled

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -102,7 +102,7 @@ Since it might be necessary to control a node **before** its supported CC versio
 
 ```ts
 async softReset(): Promise<void>
-async maybeSoftReset(): Promise<void>
+async trySoftReset(): Promise<void>
 ```
 
 Instruct the controller to soft-reset (restart). The returned Promise will resolve after the controller has restarted and can be used again.
@@ -110,7 +110,7 @@ Instruct the controller to soft-reset (restart). The returned Promise will resol
 > [!NOTE] Soft-reset is known to cause problems in Docker containers where a reconnection of the serial device will prevent it from being connected again. There are ways around this, but they require host configuration or changes to how the container is started.  
 > Therefore soft-reset is disabled in Docker unless the `ZWAVEJS_ENABLE_SOFT_RESET` environment variable or the `enableSoftReset` driver option is set.
 
-`softReset` will throw when called while soft-reset is not enabled. Consider using `maybeSoftReset` instead, which only performs a soft-reset when enabled.
+`softReset` will throw when called while soft-reset is not enabled. Consider using `trySoftReset` instead, which only performs a soft-reset when enabled.
 
 > [!WARNING] USB modules will reconnect, meaning that they might get a new address. Make sure to configure your device address in a way that prevents it from changing, e.g. by using `/dev/serial/by-id/...` on Linux.
 

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -102,13 +102,17 @@ Since it might be necessary to control a node **before** its supported CC versio
 
 ```ts
 async softReset(): Promise<void>
+async maybeSoftReset(): Promise<void>
 ```
 
 Instruct the controller to soft-reset (restart). The returned Promise will resolve after the controller has restarted and can be used again.
 
-> [!WARNING] USB modules will reconnect, meaning that they might get a new address. Make sure to configure your device address in a way that prevents it from changing, e.g. by using `/dev/serial/by-id/...` on Linux.
+> [!NOTE] Soft-reset is known to cause problems in Docker containers where a reconnection of the serial device will prevent it from being connected again. There are ways around this, but they require host configuration or changes to how the container is started.  
+> Therefore soft-reset is disabled in Docker unless the `ZWAVEJS_ENABLE_SOFT_RESET` environment variable or the `enableSoftReset` driver option is set.
 
-> [!NOTE] This method is known to cause problems in Docker containers where a reconnection of the serial device will prevent it from being connected again. There are ways around this, but they require host configuration or changes to how the container is started. Therefore this method won't do anything inside Docker unless the `ZWAVEJS_ENABLE_SOFT_RESET` environment variable or the `enableSoftReset` driver option is set.
+`softReset` will throw when called while soft-reset is not enabled. Consider using `maybeSoftReset` instead, which only performs a soft-reset when enabled.
+
+> [!WARNING] USB modules will reconnect, meaning that they might get a new address. Make sure to configure your device address in a way that prevents it from changing, e.g. by using `/dev/serial/by-id/...` on Linux.
 
 ### `hardReset`
 

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -1,5 +1,5 @@
 /**
- * Used to identify errors from this library without relying on the error message
+ * Used to identify errors from this library without relying on the specific wording of the error message
  */
 export enum ZWaveErrorCodes {
 	PacketFormat_Truncated,
@@ -11,7 +11,7 @@ export enum ZWaveErrorCodes {
 	PacketFormat_DecryptionFailed,
 
 	/** The driver failed to start */
-	Driver_Failed,
+	Driver_Failed = 100,
 	Driver_Reset,
 	Driver_Destroyed,
 	Driver_NotReady,
@@ -23,9 +23,10 @@ export enum ZWaveErrorCodes {
 	/** The driver tried to do something that requires security */
 	Driver_NoSecurity,
 	Driver_NoErrorHandler,
+	Driver_FeatureDisabled,
 
 	/** The controller has timed out while waiting for a report from the node */
-	Controller_Timeout,
+	Controller_Timeout = 200,
 	Controller_NodeTimeout,
 	Controller_MessageDropped,
 	Controller_ResponseNOK,
@@ -54,17 +55,17 @@ export enum ZWaveErrorCodes {
 	/** A Serial API command resulted in an error response */
 	Controller_CommandError,
 
-	CC_Invalid,
+	CC_Invalid = 300,
 	CC_NoNodeID,
 	CC_NotSupported,
 	CC_NotImplemented,
 	CC_NoAPI,
 
-	Deserialization_NotImplemented,
+	Deserialization_NotImplemented = 320,
 	Arithmetic,
 	Argument_Invalid,
 
-	Config_Invalid,
+	Config_Invalid = 340,
 	Config_NotFound,
 	/** A compound config file has circular imports */
 	Config_CircularImport,
@@ -79,7 +80,7 @@ export enum ZWaveErrorCodes {
 	// Here follow message specific errors
 
 	/** The removal process could not be started or completed due to one or several reasons */
-	RemoveFailedNode_Failed,
+	RemoveFailedNode_Failed = 360,
 	/** The removal process was aborted because the node has responded */
 	RemoveFailedNode_NodeOK,
 	/** The replace process could not be started or completed due to one or several reasons */

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -3497,7 +3497,7 @@ ${associatedNodes.join(", ")}`,
 			);
 		}
 
-		if (result.success) await this.driver.maybeSoftReset();
+		if (result.success) await this.driver.trySoftReset();
 		return result.success;
 	}
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -3497,7 +3497,7 @@ ${associatedNodes.join(", ")}`,
 			);
 		}
 
-		if (result.success) await this.driver.softReset();
+		if (result.success) await this.driver.maybeSoftReset();
 		return result.success;
 	}
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -739,7 +739,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 
 			// Perform initialization sequence
 			await this.writeHeader(MessageHeaders.NAK);
-			await this.maybeSoftReset();
+			await this.trySoftReset();
 
 			// Try to create the cache directory. This can fail, in which case we should expose a good error message
 			try {
@@ -1571,7 +1571,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 	/**
 	 * Soft-resets the controller if the feature is enabled
 	 */
-	public async maybeSoftReset(): Promise<void> {
+	public async trySoftReset(): Promise<void> {
 		if (this.options.enableSoftReset) {
 			await this.softReset();
 		} else {


### PR DESCRIPTION
With this PR, `driver.softReset()` will throw an error with code `Driver_FeatureDisabled` if the soft reset feature is not enabled.

To avoid this, use `maybeSoftReset`, which only performs a soft-reset when enabled.