### PR TITLE
refactor: reverse functionality of soft reset env var, enable by default

### DIFF
--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -107,8 +107,7 @@ async trySoftReset(): Promise<void>
 
 Instruct the controller to soft-reset (restart). The returned Promise will resolve after the controller has restarted and can be used again.
 
-> [!NOTE] Soft-reset is known to cause problems in Docker containers where a reconnection of the serial device will prevent it from being connected again. There are ways around this, but they require host configuration or changes to how the container is started.  
-> Therefore soft-reset is disabled in Docker unless the `ZWAVEJS_ENABLE_SOFT_RESET` environment variable or the `enableSoftReset` driver option is set.
+> [!NOTE] Soft-reset may cause problems in Docker containers with certain Z-Wave sticks if they disconnect and reconnect too quickly so that the stick's address changes. Therefore, soft-reset may be disabled by setting the ZWAVEJS_DISABLE_SOFT_RESET environment variable. It is also possible to workaround this issue with more advanced udev configurations.
 
 `softReset` will throw when called while soft-reset is not enabled. Consider using `trySoftReset` instead, which only performs a soft-reset when enabled.
 

--- a/docs/api/driver.md
+++ b/docs/api/driver.md
@@ -609,8 +609,8 @@ interface ZWaveOptions {
 
 	/**
 	 * Soft Reset is required after some commands like changing the RF region or restoring an NVM backup.
-	 * Because it may be problematic in certain environments like Docker, the functionality must be opted into.
-	 * Default: `false` in Docker, `true` when ZWAVEJS_ENABLE_SOFT_RESET env variable is set or outside Docker.
+	 * Because it may be problematic in certain environments, we provide the user with an option to opt out.
+	 * Default: `true,` except when ZWAVEJS_DISABLE_SOFT_RESET env variable is set.
 	 */
 	enableSoftReset?: boolean;
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1594,7 +1594,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 	 */
 	public async softReset(): Promise<void> {
 		if (!this.options.enableSoftReset) {
-			const message = `The soft reset feature has been disabled with the ZWAVEJS_DISABLE_SOFT_RESET environment variable`;
+			const message = `The soft reset feature has been disabled with a config option or the ZWAVEJS_DISABLE_SOFT_RESET environment variable.`;
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -192,8 +192,8 @@ const defaultOptions: ZWaveOptions = {
 	},
 	preserveUnknownValues: false,
 	disableOptimisticValueUpdate: false,
-	// By default enable soft reset outside Docker or if the env variable is set
-	enableSoftReset: !isDocker() || !!process.env.ZWAVEJS_ENABLE_SOFT_RESET,
+	// By default enable soft reset unless the env variable is set
+	enableSoftReset: !process.env.ZWAVEJS_DISABLE_SOFT_RESET,
 	interview: {
 		skipInterview: false,
 		queryAllUserCodes: false,
@@ -1594,8 +1594,7 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 	 */
 	public async softReset(): Promise<void> {
 		if (!this.options.enableSoftReset) {
-			const message = `The soft reset feature is not enabled. To enable it, set the corresponding driver option or the ZWAVEJS_ENABLE_SOFT_RESET environment variable.
-Note that soft reset from within Docker requires special configuration of the container and/or host system.`;
+			const message = `The soft reset feature has been disabled with the ZWAVEJS_DISABLE_SOFT_RESET environment variable`;
 			this.controllerLog.print(message, "error");
 			throw new ZWaveError(
 				message,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -193,7 +193,7 @@ const defaultOptions: ZWaveOptions = {
 	preserveUnknownValues: false,
 	disableOptimisticValueUpdate: false,
 	// By default enable soft reset unless the env variable is set
-	enableSoftReset: !!process.env.ZWAVEJS_DISABLE_SOFT_RESET,
+	enableSoftReset: !process.env.ZWAVEJS_DISABLE_SOFT_RESET,
 	interview: {
 		skipInterview: false,
 		queryAllUserCodes: false,

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -193,7 +193,7 @@ const defaultOptions: ZWaveOptions = {
 	preserveUnknownValues: false,
 	disableOptimisticValueUpdate: false,
 	// By default enable soft reset unless the env variable is set
-	enableSoftReset: !process.env.ZWAVEJS_DISABLE_SOFT_RESET,
+	enableSoftReset: !!process.env.ZWAVEJS_DISABLE_SOFT_RESET,
 	interview: {
 		skipInterview: false,
 		queryAllUserCodes: false,

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -138,8 +138,8 @@ export interface ZWaveOptions {
 
 	/**
 	 * Soft Reset is required after some commands like changing the RF region or restoring an NVM backup.
-	 * Because it may be problematic in certain environments like Docker, the functionality must be opted into.
-	 * Default: `false` in Docker, `true` when ZWAVEJS_ENABLE_SOFT_RESET env variable is set or outside Docker.
+	 * Because it may be problematic in certain environments, we provide the user with an option to opt out.
+	 * Default: `true,` except when ZWAVEJS_DISABLE_SOFT_RESET env variable is set.
 	 */
 	enableSoftReset?: boolean;
 


### PR DESCRIPTION
After further testing, it appears the docker issue is largely a non-issue. This PR enables soft reset on startup by default and reverses the functionality of the environment variable.

@robertslando this will require a change to the UI too.