### PR TITLE
fix: avoid force-adding Supervision support, remove encapsulation CCs from mandatory

### DIFF
--- a/packages/config/config/deviceClasses.json
+++ b/packages/config/config/deviceClasses.json
@@ -80,16 +80,16 @@
 					"supportedCCs": [
 						"Association", // V2+
 						"Association Group Information",
-						"CRC-16 Encapsulation",
+						// "CRC-16 Encapsulation", (trust the NIF! Assuming support would break communication)
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Inclusion Controller",
 						"Powerlevel",
 						"Manufacturer Specific",
 						// "Security", (some devices only support S2)
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
+						// "Supervision", (trust the NIF! Assuming support would break communication)
 						"Simple AV Control",
-						"Transport Service", // V2+
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					],
@@ -97,7 +97,7 @@
 						"Anti-Theft Unlock", // V1
 						"Association", // V2+
 						"Basic",
-						"CRC-16 Encapsulation",
+						// "CRC-16 Encapsulation", (trust the NIF! Assuming support would break communication)
 						"Multi Channel", // V4+
 						"Multi Channel Association", // V3+
 						// "Security", (some devices only support S2)
@@ -111,20 +111,20 @@
 					"supportedCCs": [
 						"Association", // V2+
 						"Association Group Information",
-						"CRC-16 Encapsulation",
+						// "CRC-16 Encapsulation", (trust the NIF! Assuming support would break communication)
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Inclusion Controller",
 						"Manufacturer Specific",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					],
 					"controlledCCs": [
 						"Basic",
-						"CRC-16 Encapsulation",
+						// "CRC-16 Encapsulation", (trust the NIF! Assuming support would break communication)
 						"Multi Channel", // V4+
 						"Wake Up" // V2+
 					]
@@ -135,16 +135,16 @@
 					"supportedCCs": [
 						"Association", // V2+
 						"Association Group Information",
-						"CRC-16 Encapsulation",
+						// "CRC-16 Encapsulation", (trust the NIF! Assuming support would break communication)
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Inclusion Controller",
 						"Manufacturer Specific",
 						"Powerlevel",
 						// "Security", (some devices only support S2)
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
+						// "Supervision", (trust the NIF! Assuming support would break communication)
 						"Simple AV Control",
-						"Transport Service", // V2+
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					],
@@ -153,7 +153,7 @@
 						"Association", // V2+
 						"Association Group Information",
 						"Basic",
-						"CRC-16 Encapsulation",
+						// "CRC-16 Encapsulation", (trust the NIF! Assuming support would break communication)
 						"Multi Channel", // V4+
 						"Multi Channel Association", // V3+
 						// "Security", (some devices only support S2)
@@ -194,8 +194,8 @@
 						"Manufacturer Specific",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -340,8 +340,8 @@
 						"Manufacturer Specific",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -370,8 +370,8 @@
 						"Manufacturer Specific",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -399,8 +399,8 @@
 						"Multi Channel Association", // V3+
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -418,8 +418,8 @@
 						"Manufacturer Specific",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -437,8 +437,8 @@
 						"Manufacturer Specific",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -455,8 +455,8 @@
 						"Manufacturer Specific",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -485,8 +485,8 @@
 						"Multilevel Switch",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -546,8 +546,8 @@
 						"Multilevel Switch",
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -676,14 +676,14 @@
 						"Association", // V2+
 						"Association Group Information",
 						"Battery",
-						"CRC-16 Encapsulation",
+						// "CRC-16 Encapsulation", (trust the NIF! Assuming support would break communication)
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Manufacturer Specific",
 						"Meter", // V2+
 						"Powerlevel",
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Wake Up", // V2+
 						"Z-Wave Plus Info" // V2+
@@ -731,8 +731,8 @@
 						"Powerlevel",
 						// "Security", (some devices only support S2)
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -753,8 +753,8 @@
 						"Powerlevel",
 						// "Security", (some devices only support S2)
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -775,8 +775,8 @@
 						"Powerlevel",
 						// "Security", (some devices only support S2)
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -797,8 +797,8 @@
 						"Powerlevel",
 						// "Security", (some devices only support S2)
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]
@@ -819,8 +819,8 @@
 						"Powerlevel",
 						// "Security", (some devices only support S2)
 						// "Security 2", (older devices don't always support S2)
-						"Supervision",
-						"Transport Service", // V2+
+						// "Supervision", (trust the NIF! Assuming support would break communication)
+						// "Transport Service", // V2+ (trust the NIF! Assuming support would break communication)
 						"Version", // V2+
 						"Z-Wave Plus Info" // V2+
 					]

--- a/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SupervisionCC.ts
@@ -86,8 +86,11 @@ export class SupervisionCCAPI extends PhysicalCCAPI {
 	public async sendReport(
 		options: SupervisionCCReportOptions & { secure?: boolean },
 	): Promise<void> {
+		// Here we don't assert support - some devices only half-support Supervision, so we treat them
+		// as if they don't support it. We still need to be able to respond to the Get command though.
+
 		// Ask the node if it needs Wake Up On Demand,
-		// unless it's overriden in `options`
+		// unless it's overridden in `options`
 		const requestWakeUpOnDemand =
 			options.requestWakeUpOnDemand ??
 			this.endpoint.getNodeUnsafe()?.shouldRequestWakeUpOnDemand;

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -1828,7 +1828,11 @@ export class Driver extends TypedEventEmitter<DriverEventCallbacks> {
 								// If it was, we need to notify the sender that we couldn't decode the command
 								await msg
 									.getNodeUnsafe()
-									?.commandClasses.Supervision.sendReport({
+									?.createAPI(
+										CommandClasses.Supervision,
+										false,
+									)
+									.sendReport({
 										sessionId: supervisionSessionId,
 										moreUpdatesFollow: false,
 										status: SupervisionStatus.NoSupport,
@@ -2610,16 +2614,8 @@ ${handlers.length} left`,
 				);
 				const secure = msg.command.secure;
 
-				if (
-					supervisionSessionId !== undefined &&
-					!node.supportsCC(CommandClasses.Supervision)
-				) {
-					// When a node sends us a command that's supervision encapsulated, it must support Supervision CC
-					node.addCC(CommandClasses.Supervision, {
-						isSupported: true,
-						version: 1,
-					});
-				}
+				// DO NOT force-add support for the Supervision CC here. Some devices only support Supervision when sending,
+				// so we need to trust the information we already have.
 
 				// check if someone is waiting for this command
 				for (const entry of this.awaitedCommands) {
@@ -2629,12 +2625,14 @@ ${handlers.length} left`,
 
 						// send back a Supervision Report if the command was received via Supervision Get
 						if (supervisionSessionId !== undefined) {
-							await node.commandClasses.Supervision.sendReport({
-								sessionId: supervisionSessionId,
-								moreUpdatesFollow: false,
-								status: SupervisionStatus.Success,
-								secure,
-							});
+							await node
+								.createAPI(CommandClasses.Supervision, false)
+								.sendReport({
+									sessionId: supervisionSessionId,
+									moreUpdatesFollow: false,
+									status: SupervisionStatus.Success,
+									secure,
+								});
 						}
 						return;
 					}
@@ -2646,19 +2644,23 @@ ${handlers.length} left`,
 					try {
 						await node.handleCommand(msg.command);
 
-						await node.commandClasses.Supervision.sendReport({
-							sessionId: supervisionSessionId,
-							moreUpdatesFollow: false,
-							status: SupervisionStatus.Success,
-							secure,
-						});
+						await node
+							.createAPI(CommandClasses.Supervision, false)
+							.sendReport({
+								sessionId: supervisionSessionId,
+								moreUpdatesFollow: false,
+								status: SupervisionStatus.Success,
+								secure,
+							});
 					} catch (e) {
-						await node.commandClasses.Supervision.sendReport({
-							sessionId: supervisionSessionId,
-							moreUpdatesFollow: false,
-							status: SupervisionStatus.Fail,
-							secure,
-						});
+						await node
+							.createAPI(CommandClasses.Supervision, false)
+							.sendReport({
+								sessionId: supervisionSessionId,
+								moreUpdatesFollow: false,
+								status: SupervisionStatus.Fail,
+								secure,
+							});
 
 						// In any case we don't want to swallow the error
 						throw e;

--- a/packages/zwave-js/src/lib/node/Endpoint.test.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.test.ts
@@ -5,7 +5,6 @@ import {
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
 import { BatteryCCAPI } from "../commandclass/BatteryCC";
-import type { BinarySensorCCAPI } from "../commandclass/BinarySensorCC";
 import "../commandclass/index";
 import { VersionCCAPI } from "../commandclass/VersionCC";
 import type { Driver } from "../driver/Driver";
@@ -29,9 +28,7 @@ describe("lib/node/Endpoint", () => {
 		it("the returned API throws when trying to access a non-supported CC", async () => {
 			const endpoint = new Endpoint(1, fakeDriver, 1);
 			// We must not use Basic CC here, because that is assumed to be always supported
-			const api = endpoint.createAPI(
-				CommandClasses["Binary Sensor"],
-			) as BinarySensorCCAPI;
+			const api = endpoint.createAPI(CommandClasses["Binary Sensor"]);
 
 			// this does not throw
 			api.isSupported();


### PR DESCRIPTION
With this PR, we no longer force-add Supervision support when receiving a `Supervision CC::Get` because of some devices that only actually support Supervision when sending.

In addition, we remove the non-essential encapsulation CCs from the list of mandatory CCs to avoid running into situations where a device doesn't list the CC in its NIF, we force-add it and then are unable to communicate.

fixes: #3536
fixes: #3543 