### PR TITLE
Update iblindsv3.json

### DIFF
--- a/packages/config/config/devices/0x0287/iblindsv3.json
+++ b/packages/config/config/devices/0x0287/iblindsv3.json
@@ -114,7 +114,7 @@
 		},
 		{
 			"#": "7",
-			"$if": "firmwareVersion >= 3.6",
+			"$if": "firmwareVersion >= 3.06",
 			"label": "Remote Calibration",
 			"valueSize": 1,
 			"minValue": 0,


### PR DESCRIPTION
Corrected required firmware version for Remote Calibration. There is no 3.6 version of iBlinds firmware. Correct version is 3.06.

 https://support.myiblinds.com/knowledge-base/iblinds-v3-firmware/

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/node-zwave-js
-->

PR description here
