### PR TITLE
fix(config): correct identification of Vision ZP3111-5

### DIFF
--- a/packages/config/config/devices/0x0109/zp3111-5.json
+++ b/packages/config/config/devices/0x0109/zp3111-5.json
@@ -1,13 +1,13 @@
 {
 	"manufacturer": "Vision Security",
 	"manufacturerId": "0x0109",
-	"label": "ZSE40",
-	"description": "Zooz 4-in-one motion/temperature/humidity/luminance sensor",
+	"label": "ZP3111-5",
+	"description": "4-in-1 Sensor",
 	"devices": [
 		{
 			"productType": "0x2021",
 			"productId": "0x2101",
-			"zwaveAllianceId": [1572, 2479]
+			"zwaveAllianceId": [1572, 1744, 2479]
 		}
 	],
 	"firmwareVersion": {


### PR DESCRIPTION
This device was being recognized as "Vision Security / Zooz 4-in-one motion/temperature/humidity/luminance". Besides the ridiculous product name, this device is from Vision, not Zooz. Vision manufactures devices for other companies like Zooz, and the device I have is actually a Monoprice 15902, and I presume the ZSE40 is the same thing. The description in this PR is more appropriate for the version with the Vision manufacturer ID. The Zooz version is identified by the Zooz manufacturer ID.

References:
* One of the ZWA product pages: https://products.z-wavealliance.org/products/1744?selectedFrequencyId=-1
* Manufacturer's Page: http://www.visionsecurity.com.tw/index.php?option=product&lang=en&task=pageinfo&id=297&belongid=313&index=1