### PR TITLE
fix(config): update lifeline config and parameters for Philio PAN06 v1

### DIFF
--- a/packages/config/config/devices/0x013c/pan06_0.0-1.7.json
+++ b/packages/config/config/devices/0x013c/pan06_0.0-1.7.json
@@ -22,14 +22,19 @@
 			"label": "Relay 1 + 2",
 			"maxNodes": 1,
 			"isLifeline": true
+			// Corresponds to endpoint 1 (both relays)
 		},
 		"2": {
 			"label": "Relay 1",
-			"maxNodes": 1
+			"maxNodes": 1,
+			"isLifeline": true
+			// Corresponds to endpoint 2
 		},
 		"3": {
 			"label": "Relay 2",
-			"maxNodes": 1
+			"maxNodes": 1,
+			"isLifeline": true
+			// Corresponds to endpoint 3
 		}
 	},
 	"paramInformation": [
@@ -80,6 +85,28 @@
 				{
 					"label": "Edge-Toggle mode",
 					"value": 3
+				}
+			]
+		},
+		{
+			// This parameter is undocumented, but necessary for endpoint reporting
+			"#": "11",
+			"label": "Multi Channel Functionality",
+			"description": "This must be enabled for the device to work properly",
+			"valueSize": 1,
+			"minValue": 1,
+			"maxValue": 2,
+			"defaultValue": 1,
+			"unsigned": true,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 1
+				},
+				{
+					"label": "Enable",
+					"value": 2
 				}
 			]
 		}

--- a/packages/config/config/devices/0x013c/pan06_0.0-1.7.json
+++ b/packages/config/config/devices/0x013c/pan06_0.0-1.7.json
@@ -91,8 +91,8 @@
 		{
 			// This parameter is undocumented, but necessary for endpoint reporting
 			"#": "11",
-			"label": "Multi Channel Functionality",
-			"description": "This must be enabled for the device to work properly",
+			"label": "Send Reports From Endpoints",
+			"description": "Enable this to distinguish between the relays.",
 			"valueSize": 1,
 			"minValue": 1,
 			"maxValue": 2,


### PR DESCRIPTION
This PR auto-assigns all relays and adds the undocumented parameter 11 to enable multi channel functionality.

fixes: #3541