### PR TITLE
fix: add additional 1s delay before verifying a transitioned value

### DIFF
--- a/packages/zwave-js/src/lib/commandclass/API.ts
+++ b/packages/zwave-js/src/lib/commandclass/API.ts
@@ -1,4 +1,4 @@
-import type { ValueChangeOptions, ValueID } from "@zwave-js/core";
+import type { Duration, ValueChangeOptions, ValueID } from "@zwave-js/core";
 import {
 	CommandClasses,
 	Maybe,
@@ -82,6 +82,11 @@ export function throwWrongValueType(
 	);
 }
 
+export interface SchedulePollOptions {
+	duration?: Duration;
+	transition?: "fast" | "slow";
+}
+
 /**
  * The base class for all CC APIs exposed via `Node.commandClasses.<CCName>`
  * @publicAPI
@@ -128,8 +133,17 @@ export class CCAPI {
 	 */
 	protected schedulePoll(
 		property: ValueIDProperties,
-		timeoutMs: number = this.driver.options.timeouts.refreshValue,
+		{ duration, transition = "slow" }: SchedulePollOptions = {},
 	): boolean {
+		// Figure out the delay. If a non-zero duration was given or this is a "fast" transition,
+		// use/add the short delay. Otherwise, default to the long delay.
+		const durationMs = duration?.toMilliseconds() ?? 0;
+		const additionalDelay =
+			!!durationMs || transition === "fast"
+				? this.driver.options.timeouts.refreshValueAfterTransition
+				: this.driver.options.timeouts.refreshValue;
+		const timeoutMs = durationMs + additionalDelay;
+
 		if (this.isSinglecast()) {
 			const node = this.endpoint.getNodeUnsafe();
 			if (!node) return false;

--- a/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/BinarySwitchCC.ts
@@ -142,7 +142,14 @@ export class BinarySwitchCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
 			if (property === "targetValue") property = "currentValue";
-			this.schedulePoll({ property }, duration?.toMilliseconds() ?? 1000);
+			this.schedulePoll(
+				{ property },
+				{
+					duration,
+					// on/off "transitions" are usually fast
+					transition: "fast",
+				},
+			);
 		} else if (this.isMulticast()) {
 			if (!this.driver.options.disableOptimisticValueUpdate) {
 				// Figure out which nodes were affected by this command

--- a/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ColorSwitchCC.ts
@@ -385,10 +385,10 @@ export class ColorSwitchCCAPI extends CCAPI {
 				await this.set({ [propertyKey]: value, duration });
 
 				if (this.isSinglecast()) {
-					// Verify the current value after a delay
+					// Verify the current value after a (short) delay
 					this.schedulePoll(
 						{ property, propertyKey },
-						duration?.toMilliseconds(),
+						{ duration, transition: "fast" },
 					);
 				}
 			} else {

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -415,7 +415,8 @@ export class ConfigurationCCAPI extends CCAPI {
 			// Verify the current value after a delay
 			(this as ConfigurationCCAPI).schedulePoll(
 				{ property, propertyKey },
-				1000,
+				// Configuration changes are instant
+				{ transition: "fast" },
 			);
 		}
 	};

--- a/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/MultilevelSwitchCC.ts
@@ -349,10 +349,8 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
 						if (property === "targetValue")
 							property = "currentValue";
-						this.schedulePoll(
-							{ property },
-							duration?.toMilliseconds(),
-						);
+
+						this.schedulePoll({ property }, { duration });
 					}
 				} else if (this.isMulticast()) {
 					// Only update currentValue for valid target values
@@ -382,12 +380,7 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 						// We query currentValue instead of targetValue to make sure that unsolicited updates cancel the scheduled poll
 						if (property === "targetValue")
 							property = "currentValue";
-						// TODO: #1321
-						const duration = undefined as Duration | undefined;
-						this.schedulePoll(
-							{ property },
-							duration?.toMilliseconds(),
-						);
+						this.schedulePoll({ property }, { duration });
 					}
 				}
 			}

--- a/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/SoundSwitchCC.ts
@@ -273,8 +273,8 @@ export class SoundSwitchCCAPI extends CCAPI {
 				await this.stopPlaying();
 			}
 			if (this.isSinglecast()) {
-				// Verify the current value after a delay
-				this.schedulePoll({ property });
+				// Verify the current value after a (short) delay
+				this.schedulePoll({ property }, { transition: "fast" });
 			}
 		} else {
 			throwUnsupportedProperty(this.ccId, property);

--- a/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatFanModeCC.ts
@@ -138,8 +138,8 @@ export class ThermostatFanModeCCAPI extends CCAPI {
 		}
 
 		if (this.isSinglecast()) {
-			// Verify the current value after a delay
-			this.schedulePoll({ property });
+			// Verify the current value after a (short) delay
+			this.schedulePoll({ property }, { transition: "fast" });
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatModeCC.ts
@@ -96,8 +96,8 @@ export class ThermostatModeCCAPI extends CCAPI {
 		await this.set(value);
 
 		if (this.isSinglecast()) {
-			// Verify the current value after a delay
-			this.schedulePoll({ property });
+			// Verify the current value after a (short) delay
+			this.schedulePoll({ property }, { transition: "fast" });
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ThermostatSetpointCC.ts
@@ -180,8 +180,11 @@ export class ThermostatSetpointCCAPI extends CCAPI {
 		await this.set(propertyKey, value, preferredScale ?? 0);
 
 		if (this.isSinglecast()) {
-			// Verify the current value after a delay
-			this.schedulePoll({ property, propertyKey });
+			// Verify the current value after a (short) delay
+			this.schedulePoll(
+				{ property, propertyKey },
+				{ transition: "fast" },
+			);
 		}
 	};
 

--- a/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/UserCodeCC.ts
@@ -432,8 +432,8 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			throwUnsupportedProperty(this.ccId, property);
 		}
 
-		// Verify the current value after a delay
-		this.schedulePoll({ property, propertyKey });
+		// Verify the current value after a (short) delay
+		this.schedulePoll({ property, propertyKey }, { transition: "fast" });
 	};
 
 	protected [POLL_VALUE]: PollValueImplementation = async ({

--- a/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/WakeUpCC.ts
@@ -86,8 +86,8 @@ export class WakeUpCCAPI extends CCAPI {
 		await this.setInterval(value, this.driver.controller.ownNodeId ?? 1);
 
 		if (this.isSinglecast()) {
-			// Verify the current value after a delay
-			this.schedulePoll({ property });
+			// Verify the current value after a (short) delay
+			this.schedulePoll({ property }, { transition: "fast" });
 		}
 	};
 

--- a/packages/zwave-js/src/lib/driver/Driver.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.ts
@@ -184,6 +184,7 @@ const defaultOptions: ZWaveOptions = {
 		nonce: 5000,
 		sendDataCallback: 65000, // as defined in INS13954
 		refreshValue: 5000, // Default should handle most slow devices until we have a better solution
+		refreshValueAfterTransition: 1000, // To account for delays in the device
 		serialAPIStarted: 5000,
 	},
 	attempts: {

--- a/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
+++ b/packages/zwave-js/src/lib/driver/ZWaveOptions.ts
@@ -27,9 +27,15 @@ export interface ZWaveOptions {
 
 		/**
 		 * @internal
-		 * How long to wait for a poll after setting a value
+		 * How long to wait for a poll after setting a value without transition duration
 		 */
 		refreshValue: number;
+
+		/**
+		 * @internal
+		 * How long to wait for a poll after setting a value with transition duration. This doubles as the "fast" delay.
+		 */
+		refreshValueAfterTransition: number;
 
 		/**
 		 * How long to wait for the Serial API Started command after a soft-reset before resorting


### PR DESCRIPTION
fixes: #3582

Coincidentally, this now correctly respects the transition duration when setting Multilevel Switch CC to 255 via multicast.