### PR TITLE
fix: detect soft reset incompatibility and disable it

### DIFF
--- a/packages/config/src/ConfigManager.test.ts
+++ b/packages/config/src/ConfigManager.test.ts
@@ -177,11 +177,12 @@ describe("ConfigManager", () => {
 						min: "0.0",
 						max: "255.255",
 					},
-					paramInformation: {
-						1: {
+					paramInformation: [
+						{
+							"#": "1",
 							$import: "templates/template.json#test",
 						},
-					},
+					],
 				},
 				{ encoding: "utf8", spaces: 4 },
 			);

--- a/packages/config/src/JsonTemplate.test.ts
+++ b/packages/config/src/JsonTemplate.test.ts
@@ -21,6 +21,8 @@ mockFs.restore = async (): Promise<void> => {
 };
 
 describe("readJsonWithTemplate", () => {
+	jest.setTimeout(20000);
+
 	beforeAll(() => mockFs.restore());
 	afterEach(() => mockFs.restore());
 

--- a/packages/core/src/values/ValueDB.ts
+++ b/packages/core/src/values/ValueDB.ts
@@ -114,6 +114,14 @@ export function valueIdToString(valueID: ValueID): string {
 	return JSON.stringify(normalizeValueID(valueID));
 }
 
+/** Returns a Value ID that can be used to store node specific data without relating it to a CC */
+export function getNodeMetaValueID(property: string): ValueID {
+	return {
+		commandClass: CommandClasses._NONE,
+		property,
+	};
+}
+
 export interface SetValueOptions {
 	/** When this is true, no event will be emitted for the value change */
 	noEvent?: boolean;

--- a/packages/zwave-js/src/lib/driver/Driver.test.ts
+++ b/packages/zwave-js/src/lib/driver/Driver.test.ts
@@ -408,6 +408,7 @@ describe("lib/driver/Driver => ", () => {
 					has: () => true,
 					get: () => node2,
 					forEach: () => {},
+					values: () => [node2],
 				},
 				isFunctionSupported,
 				incrementStatistics: () => {},
@@ -483,6 +484,7 @@ describe("lib/driver/Driver => ", () => {
 					has: () => true,
 					get: () => node2,
 					forEach: () => {},
+					values: () => [node2],
 				},
 				isFunctionSupported,
 				incrementStatistics: () => {},
@@ -772,6 +774,7 @@ describe("lib/driver/Driver => ", () => {
 					has: () => true,
 					get: () => node2,
 					forEach: () => {},
+					values: () => [node2],
 				},
 				isFunctionSupported,
 			} as any;

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -12,6 +12,7 @@ import {
 	CommandClassInfo,
 	CRC16_CCITT,
 	getCCName,
+	getNodeMetaValueID,
 	isTransmissionError,
 	isZWaveError,
 	Maybe,
@@ -171,14 +172,6 @@ import type {
 	ZWaveNodeValueEventCallbacks,
 } from "./Types";
 import { InterviewStage, NodeStatus, NodeType, ProtocolVersion } from "./Types";
-
-/** Returns a Value ID that can be used to store node specific data without relating it to a CC */
-function getNodeMetaValueID(property: string): ValueID {
-	return {
-		commandClass: CommandClasses._NONE,
-		property,
-	};
-}
 
 export interface ZWaveNode
 	extends TypedEventEmitter<


### PR DESCRIPTION
Well... this feature is a royal PITA. With this PR we remember when a soft-reset attempt on startup fails, and try to use that information to disable soft reset. Additionally, if the stick has been queried before, we look for known to be incompatible sticks like the UZB1 and do the same.