### PR TITLE
fix(config): work around Configuration Info reporting bug in ZEN17/ZEN32

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -397,9 +397,13 @@ Many devices unnecessarily use endpoints when they could (or do) provide all fun
 
 The Z-Wave+ specs mandate that the root endpoint must **mirror** the application functionality of endpoint 1 (and potentially others). For this reason, `zwave-js` hides these superfluous values. However, some legacy devices offer additional functionality through the root endpoint, which should not be hidden. To achive this, set `preserveRootApplicationCCValueIDs` to `true`.
 
+### `skipConfigurationNameQuery`
+
+Some devices spam the network with lots of `ConfigurationCC::NameReport`s in response to the `NameGet` command. Set this flag to `true` to skip this query for affected devices.
+
 ### `skipConfigurationInfoQuery`
 
-Some devices spam the network with hundreds of invalid `ConfigurationCC::InfoReport`s when one is requested. Set this flag to `true` to skip this query for affected devices.
+Some devices spam the network with lots of (sometimes invalid) `ConfigurationCC::InfoReport`s in response to the `InfoGet` command. Set this flag to `true` to skip this query for affected devices.
 
 ### `treatBasicSetAsEvent`
 

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -631,6 +631,9 @@
 						}
 					}
 				},
+				"skipConfigurationNameQuery": {
+					"const": true
+				},
 				"skipConfigurationInfoQuery": {
 					"const": true
 				},

--- a/packages/config/config/devices/0x027a/zen17.json
+++ b/packages/config/config/devices/0x027a/zen17.json
@@ -513,6 +513,7 @@
 		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
 		"preserveRootApplicationCCValueIDs": true,
 		// The device sends Configuration CC info reports in 4-byte chunks, causing each query to block the network for roughly 1.5 seconds.
+		"skipConfigurationNameQuery": true,
 		"skipConfigurationInfoQuery": true
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen17.json
+++ b/packages/config/config/devices/0x027a/zen17.json
@@ -511,7 +511,9 @@
 	],
 	"compat": {
 		// This device improperly reports the state of R2 (endpoint 2) through the root endpoint in a way that also changes the state of R1 (endpoint 1)
-		"preserveRootApplicationCCValueIDs": true
+		"preserveRootApplicationCCValueIDs": true,
+		// The device sends Configuration CC info reports in 4-byte chunks, causing each query to block the network for roughly 1.5 seconds.
+		"skipConfigurationInfoQuery": true
 	},
 	"metadata": {
 		"inclusion": "INCLUSION\n1. Initiate inclusion (pairing) in the app (or web interface).\n2. TAP THE Z-WAVE BUTTON 3 TIMES QUICKLY if using traditional Z-Wave inclusion.\n3. The LED indicator will blink to signal communication and remain on for 2 seconds to confirm inclusion.",

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -523,6 +523,7 @@
 	],
 	"compat": {
 		// The device sends Configuration CC info reports in 4-byte chunks, causing each query to block the network for roughly 1.5 seconds.
+		"skipConfigurationNameQuery": true,
 		"skipConfigurationInfoQuery": true
 	},
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -521,6 +521,10 @@
 			]
 		}
 	],
+	"compat": {
+		// The device sends Configuration CC info reports in 4-byte chunks, causing each query to block the network for roughly 1.5 seconds.
+		"skipConfigurationInfoQuery": true
+	},
 	"metadata": {
 		"inclusion": "INCLUSION\n1. Initiate inclusion (pairing) in the app (or web interface).\n2. TAP THE SWITCH BUTTON 3 TIMES QUICKLY if using traditional Z-Wave inclusion.\n3. The LED indicator will blink blue to signal communication and turn green for 3 seconds if inclusion is successful or turn red for 3 seconds if the pairing attempt fails.",
 		"exclusion": "EXCLUSION\n1. Bring your Z-Wave gateway (hub) close to the switch if possible\n2. Put the Z-Wave hub into exclusion mode (not sure how to do that? ask@getzooz.com) \n3. TAP THE SWITCH BUTTON 3 TIMES QUICKLY (the LED indicator will start blinking blue)\n4. Your hub will confirm exclusion, the LED indicator on the switch will turn green for 3 seconds, and the device will disappear from your controller's device list\nreset",

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -183,6 +183,19 @@ compat option preserveEndpoints must be "*" or an array of positive integers`,
 			this.preserveEndpoints = definition.preserveEndpoints;
 		}
 
+		if (definition.skipConfigurationNameQuery != undefined) {
+			if (definition.skipConfigurationNameQuery !== true) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option skipConfigurationNameQuery`,
+				);
+			}
+
+			this.skipConfigurationNameQuery =
+				definition.skipConfigurationNameQuery;
+		}
+
 		if (definition.skipConfigurationInfoQuery != undefined) {
 			if (definition.skipConfigurationInfoQuery !== true) {
 				throwInvalidConfig(
@@ -492,6 +505,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 	};
 	public readonly preserveRootApplicationCCValueIDs?: boolean;
 	public readonly preserveEndpoints?: "*" | readonly number[];
+	public readonly skipConfigurationNameQuery?: boolean;
 	public readonly skipConfigurationInfoQuery?: boolean;
 	public readonly treatBasicSetAsEvent?: boolean;
 	public readonly treatMultilevelSwitchSetAsEvent?: boolean;
@@ -526,6 +540,7 @@ compat option alarmMapping must be an array where all items are objects!`,
 			"overrideFloatEncoding",
 			"preserveRootApplicationCCValueIDs",
 			"preserveEndpoints",
+			"skipConfigurationNameQuery",
 			"skipConfigurationInfoQuery",
 			"treatBasicSetAsEvent",
 			"treatMultilevelSwitchSetAsEvent",

--- a/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
+++ b/packages/zwave-js/src/lib/commandclass/ConfigurationCC.ts
@@ -1007,8 +1007,14 @@ export class ConfigurationCC extends CommandClass {
 				if (properties.valueSize === 0) {
 					logMessage = `Parameter #${param} is unsupported. Next parameter: ${nextParameter}`;
 				} else {
-					// Query name and info only if the parameter is supported
-					const name = (await api.getName(param)) ?? "(unknown)";
+					// Query name and info only if the parameter is supported, but skip the query for bugged devices
+					let name: string | undefined;
+					if (
+						!node.deviceConfig?.compat?.skipConfigurationNameQuery
+					) {
+						name = await api.getName(param);
+					}
+
 					// Skip the info query for bugged devices
 					if (
 						!node.deviceConfig?.compat?.skipConfigurationInfoQuery
@@ -1016,8 +1022,12 @@ export class ConfigurationCC extends CommandClass {
 						await api.getInfo(param);
 					}
 
-					logMessage = `received information for parameter #${param}:
-parameter name:      ${name}
+					logMessage = `received information for parameter #${param}:`;
+					if (name) {
+						logMessage += `
+parameter name:      ${name}`;
+					}
+					logMessage += `
 value format:        ${getEnumMemberName(
 						ConfigValueFormat,
 						properties.valueFormat,


### PR DESCRIPTION
These devices respond with lots of unnecessarily short reports in response to the NameGet and InfoGet commands.

This PR implements a compat flag to skip the NameGet query and adds both these flags to Zooz ZEN17 and ZEN32.

fixes: #4585