### PR TITLE
fix: disable optimistic update for unsupervised `Barrier Operator CC` cmds

### DIFF
--- a/packages/cc/api.md
+++ b/packages/cc/api.md
@@ -14626,7 +14626,7 @@ export type SetValueImplementationHooks = AllOrNone_2<{
     supervisionOnSuccess: () => void | Promise<void>;
     supervisionOnFailure: () => void | Promise<void>;
 }> & {
-    optimisticallyUpdateRelatedValues?: () => void;
+    optimisticallyUpdateRelatedValues?: (supervisedAndSuccessful: boolean) => void;
     forceVerifyChanges?: () => boolean;
     verifyChanges?: () => void | Promise<void>;
 };

--- a/packages/cc/src/cc/BarrierOperatorCC.ts
+++ b/packages/cc/src/cc/BarrierOperatorCC.ts
@@ -307,7 +307,12 @@ export class BarrierOperatorCCAPI extends CCAPI {
 					}
 				},
 
-				optimisticallyUpdateRelatedValues: () => {
+				optimisticallyUpdateRelatedValues: (
+					supervisedAndSuccessful,
+				) => {
+					// For barriers, do not update the current value unless we actually know the command was successful
+					if (!supervisedAndSuccessful) return;
+
 					if (this.isSinglecast()) {
 						this.tryGetValueDB()?.setValue(
 							currentStateValueId,

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -140,7 +140,9 @@ export class BasicCCAPI extends CCAPI {
 				this.endpoint.index,
 			);
 			return {
-				optimisticallyUpdateRelatedValues: () => {
+				optimisticallyUpdateRelatedValues: (
+					_supervisedAndSuccessful,
+				) => {
 					// Only update currentValue for valid target values
 					if (
 						typeof value === "number" &&

--- a/packages/cc/src/cc/BinarySwitchCC.ts
+++ b/packages/cc/src/cc/BinarySwitchCC.ts
@@ -165,7 +165,9 @@ export class BinarySwitchCCAPI extends CCAPI {
 				BinarySwitchCCValues.currentValue.endpoint(this.endpoint.index);
 
 			return {
-				optimisticallyUpdateRelatedValues: () => {
+				optimisticallyUpdateRelatedValues: (
+					_supervisedAndSuccessful,
+				) => {
 					// After setting targetValue, optimistically update currentValue
 					if (this.isSinglecast()) {
 						this.tryGetValueDB()?.setValue(

--- a/packages/cc/src/cc/MultilevelSwitchCC.ts
+++ b/packages/cc/src/cc/MultilevelSwitchCC.ts
@@ -406,7 +406,9 @@ export class MultilevelSwitchCCAPI extends CCAPI {
 						// ignore
 					}
 				},
-				optimisticallyUpdateRelatedValues: () => {
+				optimisticallyUpdateRelatedValues: (
+					_supervisedAndSuccessful,
+				) => {
 					// Only update currentValue for valid target values
 					if (
 						typeof value === "number" &&

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -361,7 +361,9 @@ export class WindowCoveringCCAPI extends CCAPI {
 					}
 				},
 
-				optimisticallyUpdateRelatedValues: () => {
+				optimisticallyUpdateRelatedValues: (
+					_supervisedAndSuccessful,
+				) => {
 					// Only update currentValue for valid target values
 					if (
 						typeof value === "number" &&

--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -54,7 +54,9 @@ export type SetValueImplementationHooks = AllOrNone<{
 	supervisionOnFailure: () => void | Promise<void>;
 }> & {
 	// Optimistically update related cached values (if allowed)
-	optimisticallyUpdateRelatedValues?: () => void;
+	optimisticallyUpdateRelatedValues?: (
+		supervisedAndSuccessful: boolean,
+	) => void;
 	// Check if a verification of the set value is required, even if the API response suggests otherwise
 	forceVerifyChanges?: () => boolean;
 	// Verify the changes

--- a/packages/zwave-js/src/lib/node/VirtualNode.ts
+++ b/packages/zwave-js/src/lib/node/VirtualNode.ts
@@ -168,19 +168,24 @@ export class VirtualNode extends VirtualEndpoint implements IVirtualNode {
 			// Depending on the settings of the SET_VALUE implementation, we may have to
 			// optimistically update a different value and/or verify the changes
 			if (hooks) {
-				// If the command did not fail, assume that it succeeded and update the currentValue accordingly
-				// so UIs have immediate feedback
+				const supervisedAndSuccessful =
+					isSupervisionResult(result) &&
+					result.status === SupervisionStatus.Success;
+
 				const shouldUpdateOptimistically =
 					api.isSetValueOptimistic(valueId) &&
-					// For unsupervised commands, make the choice to update optimistically dependent on the driver options
-					((!this.driver.options.disableOptimisticValueUpdate &&
-						result == undefined) ||
-						(isSupervisionResult(result) &&
-							result.status === SupervisionStatus.Success));
+					// For successful supervised commands, we know that an optimistic update is ok
+					(supervisedAndSuccessful ||
+						// For unsupervised commands that did not fail, we let the applciation decide whether
+						// to update related value optimistically
+						(!this.driver.options.disableOptimisticValueUpdate &&
+							result == undefined));
 
-				// Let the API implementation handle additional optimistic updates
+				// The actual API implementation handles additional optimistic updates
 				if (shouldUpdateOptimistically) {
-					hooks.optimisticallyUpdateRelatedValues?.();
+					hooks.optimisticallyUpdateRelatedValues?.(
+						supervisedAndSuccessful,
+					);
 				}
 
 				// Verify the current value after a delay, unless...


### PR DESCRIPTION
Unconditionally updating `currentState` optimistically was an oversight. We now only do it for successful supervised commands.

fixes: https://github.com/zwave-js/node-zwave-js/issues/5853