### PR TITLE
feat: track controller status, do not mark nodes as dead when controller is jammed

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1189,6 +1189,29 @@ Returns the ID of the controller in the current network.
 * readonly supportsTimers: boolean
 -->
 
+### `status`
+
+```ts
+readonly status: ControllerStatus
+```
+
+This property tracks the status of the controller. Valid values are:
+
+<!-- #import ControllerStatus from "zwave-js" -->
+
+```ts
+enum ControllerStatus {
+	/** The controller is ready to accept commands and transmit */
+	Ready = 0,
+	/** The controller is unresponsive */
+	Unresponsive = 1,
+	/** The controller is unable to transmit */
+	Jammed = 2,
+}
+```
+
+The status is `ControllerStatus.Ready` by default and should not change unless there is a problem with the controller. Changes to the status are exposed using the [`"status changed"`](#status-changed) event.
+
 ### `isHealNetworkActive`
 
 ```ts
@@ -1365,6 +1388,14 @@ enum RemoveNodeReason {
 ```
 
 > [!NOTE] To comply with the Z-Wave specifications, applications **MUST** indicate that the node was _reset locally and has left the network_ when the `reason` is `RemoveNodeReason.Reset`.
+
+### `"status changed"`
+
+```ts
+(status: ControllerStatus) => void;
+```
+
+This event is used to inform applications about changes in the controller status.
 
 ### `"heal network progress"`
 

--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -784,7 +784,7 @@ The user-defined location of this node. Uses the value reported by `Node Naming 
 readonly status: NodeStatus;
 ```
 
-This property tracks the status a node in the network currently has (or is believed to have). Consumers of this library should treat the status as readonly. Valid values are defined in the `NodeStatus` enumeration:
+This property tracks the status a node in the network currently has (or is believed to have). Valid values are defined in the `NodeStatus` enumeration:
 
 -   `NodeStatus.Unknown (0)` - this is the default status of a node. A node is assigned this status before it is being interviewed (including manual re-interviews when calling `refreshInfo`).
 -   `NodeStatus.Asleep (1)` - Nodes that support the `WakeUp` CC and failed to respond to a message are assumed asleep.

--- a/packages/core/src/consts/ControllerStatus.ts
+++ b/packages/core/src/consts/ControllerStatus.ts
@@ -1,0 +1,8 @@
+export enum ControllerStatus {
+	/** The controller is ready to accept commands and transmit */
+	Ready,
+	/** The controller is unresponsive */
+	Unresponsive,
+	/** The controller is unable to transmit */
+	Jammed,
+}

--- a/packages/core/src/consts/index.ts
+++ b/packages/core/src/consts/index.ts
@@ -21,6 +21,7 @@ export const HOMEID_BYTES = 4;
 /** How many repeaters can appear in a route */
 export const MAX_REPEATERS = 4;
 
+export { ControllerStatus } from "./ControllerStatus";
 export { InterviewStage } from "./InterviewStage";
 export { NodeStatus } from "./NodeStatus";
 export * from "./Transmission";

--- a/packages/core/src/error/ZWaveError.ts
+++ b/packages/core/src/error/ZWaveError.ts
@@ -34,6 +34,7 @@ export enum ZWaveErrorCodes {
 	Controller_MessageDropped,
 	Controller_ResponseNOK,
 	Controller_CallbackNOK,
+	Controller_Jammed,
 	Controller_CommandAborted,
 	Controller_InclusionFailed,
 	Controller_ExclusionFailed,

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -31,7 +31,11 @@ export {
 	Powerlevel,
 	PowerlevelTestStatus,
 } from "@zwave-js/cc/safe";
-export { InterviewStage, NodeStatus } from "@zwave-js/core/safe";
+export {
+	ControllerStatus,
+	InterviewStage,
+	NodeStatus,
+} from "@zwave-js/core/safe";
 
 export type NodeInterviewFailedEventArgs = {
 	errorMessage: string;

--- a/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/controllerJammed.test.ts
@@ -1,0 +1,126 @@
+import { ControllerStatus, NodeStatus, TransmitStatus } from "@zwave-js/core";
+import { type MockControllerBehavior } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import sinon from "sinon";
+import {
+	MockControllerCommunicationState,
+	MockControllerStateKeys,
+} from "../../controller/MockControllerState";
+import {
+	SendDataAbort,
+	SendDataRequest,
+	SendDataRequestTransmitReport,
+	SendDataResponse,
+} from "../../serialapi/transport/SendDataMessages";
+import { integrationTest } from "../integrationTestSuite";
+
+let shouldFail = false;
+
+integrationTest("update the controller status and wait if TX status is Fail", {
+	// debug: true,
+	// provisioningDirectory: path.join(
+	// 	__dirname,
+	// 	"__fixtures/supervision_binary_switch",
+	// ),
+
+	additionalDriverOptions: {
+		testingHooks: {
+			skipNodeInterview: true,
+		},
+	},
+
+	customSetup: async (driver, controller, mockNode) => {
+		// Return a TX status of Fail when desired
+		const handleSendData: MockControllerBehavior = {
+			async onHostMessage(host, controller, msg) {
+				if (msg instanceof SendDataRequest) {
+					if (!shouldFail) {
+						// Defer to the default behavior
+						return false;
+					}
+
+					// Check if this command is legal right now
+					const state = controller.state.get(
+						MockControllerStateKeys.CommunicationState,
+					) as MockControllerCommunicationState | undefined;
+					if (
+						state != undefined &&
+						state !== MockControllerCommunicationState.Idle
+					) {
+						throw new Error(
+							"Received SendDataRequest while not idle",
+						);
+					}
+
+					// Put the controller into sending state
+					controller.state.set(
+						MockControllerStateKeys.CommunicationState,
+						MockControllerCommunicationState.Sending,
+					);
+
+					// Notify the host that the message was sent
+					const res = new SendDataResponse(host, {
+						wasSent: true,
+					});
+					await controller.sendToHost(res.serialize());
+
+					await wait(100);
+
+					controller.state.set(
+						MockControllerStateKeys.CommunicationState,
+						MockControllerCommunicationState.Idle,
+					);
+
+					const cb = new SendDataRequestTransmitReport(host, {
+						callbackId: msg.callbackId,
+						transmitStatus: TransmitStatus.Fail,
+					});
+					await controller.sendToHost(cb.serialize());
+
+					return true;
+				} else if (msg instanceof SendDataAbort) {
+					// Put the controller into sending state
+					controller.state.set(
+						MockControllerStateKeys.CommunicationState,
+						MockControllerCommunicationState.Idle,
+					);
+				}
+			},
+		};
+		controller.defineBehavior(handleSendData);
+	},
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		node.markAsAlive();
+
+		const statusChanges: ControllerStatus[] = [];
+		driver.controller.on("status changed", (status) => {
+			statusChanges.push(status);
+		});
+
+		const nodeDead = sinon.spy();
+		node.on("dead", nodeDead);
+
+		shouldFail = true;
+		const promise = node.ping();
+		await wait(500);
+
+		// The controller should now be jammed, but the node's status must not change
+		t.is(driver.controller.status, ControllerStatus.Jammed);
+		t.is(node.status, NodeStatus.Alive);
+
+		setTimeout(() => {
+			shouldFail = false;
+		}, 2000);
+
+		await promise;
+
+		t.is(driver.controller.status, ControllerStatus.Ready);
+		t.is(node.status, NodeStatus.Alive);
+
+		sinon.assert.notCalled(nodeDead);
+		t.deepEqual(statusChanges, [
+			ControllerStatus.Jammed,
+			ControllerStatus.Ready,
+		]);
+	},
+});


### PR DESCRIPTION
In a lot of cases where nodes get temporarily/randomly marked dead, the issue is actually the controller being unable to transmit. However, until now this was not visible without looking at driver logs.

This PR adds a new `status` property and `"status changed"` event to the controller, which are used to expose the controller's status to applications and highlight potential issues. For now, only the `Ready` and `Jammed` statuses are used, `Unresponsive` is reserved for a future PR.

When sending a command fails with `TransmitStatus.Fail`, the corresponding node is no longer marked dead. Instead, the controller gets marked `Jammed`, and sending the command is retried after a second.

fixes: https://github.com/zwave-js/node-zwave-js/issues/4191
prepares for: https://github.com/zwave-js/node-zwave-js/issues/2723