### PR TITLE
fix: only auto-refresh `Meter` and `Multilevel Sensor CC` values if none were updated recently

### DIFF
--- a/packages/cc/src/cc/MeterCC.ts
+++ b/packages/cc/src/cc/MeterCC.ts
@@ -505,15 +505,16 @@ supports reset:       ${suppResp.supportsReset}`;
 		this: SinglecastCC<this>,
 		applHost: ZWaveApplicationHost,
 	): boolean {
-		// Check when any of the supported values was last updated longer than 6 hours ago.
-		// This may lead to some unnecessary queries, but at least the values are up to date then
+		// Poll the device when all of the supported values were last updated longer than 6 hours ago.
+		// This may lead to some values not being updated, but the user may have disabled some unnecessary
+		// reports to reduce traffic.
 		const valueDB = applHost.tryGetValueDB(this.nodeId);
 		if (!valueDB) return true;
 
 		const values = this.getDefinedValueIDs(applHost).filter((v) =>
 			MeterCCValues.value.is(v)
 		);
-		return values.some((v) => {
+		return values.every((v) => {
 			const lastUpdated = valueDB.getTimestamp(v);
 			return (
 				lastUpdated == undefined

--- a/packages/cc/src/cc/MultilevelSensorCC.ts
+++ b/packages/cc/src/cc/MultilevelSensorCC.ts
@@ -544,15 +544,16 @@ value:       ${mlsResponse.value} ${sensorScale.unit || ""}`;
 		this: SinglecastCC<this>,
 		applHost: ZWaveApplicationHost,
 	): boolean {
-		// Check when any of the supported values was last updated longer than 6 hours ago.
-		// This may lead to some unnecessary queries, but at least the values are up to date then
+		// Poll the device when all of the supported values were last updated longer than 6 hours ago.
+		// This may lead to some values not being updated, but the user may have disabled some unnecessary
+		// reports to reduce traffic.
 		const valueDB = applHost.tryGetValueDB(this.nodeId);
 		if (!valueDB) return true;
 
 		const values = this.getDefinedValueIDs(applHost).filter((v) =>
 			MultilevelSensorCCValues.value.is(v)
 		);
-		return values.some((v) => {
+		return values.every((v) => {
 			const lastUpdated = valueDB.getTimestamp(v);
 			return (
 				lastUpdated == undefined


### PR DESCRIPTION
In #5560, we added support for automatically refreshing the values of certain CCs when they haven't been updated recently. In this first iteration, Z-Wave JS would poll all values of that CC, if at least one was possibly stale.
It is however recommended to disable unnecessary reports, especially for Meter CC and Multilevel Sensor CC, so this was almost always the case.

This PR changes the heuristic to only poll when none of the values have been updated by the device.

fixes: https://github.com/zwave-js/node-zwave-js/issues/6360