### PR TITLE
fix: only expose currentValue on devices that use Basic CC for reporting

### DIFF
--- a/maintenance/schemas/deviceClasses.json
+++ b/maintenance/schemas/deviceClasses.json
@@ -28,6 +28,9 @@
 						"controlledCCs": {
 							"$ref": "#/definitions/CCs"
 						},
+						"maySupportBasicCC": {
+							"const": false
+						},
 						"specific": {
 							"type": "object",
 							"patternProperties": {
@@ -45,6 +48,9 @@
 										},
 										"controlledCCs": {
 											"$ref": "#/definitions/CCs"
+										},
+										"maySupportBasicCC": {
+											"const": false
 										}
 									},
 									"required": ["label"],

--- a/packages/cc/src/cc/BasicCC.ts
+++ b/packages/cc/src/cc/BasicCC.ts
@@ -327,12 +327,15 @@ remaining duration: ${basicResponse.duration?.toString() ?? "undefined"}`;
 			ret.push(...super.getDefinedValueIDs(applHost));
 		}
 
-		// Add the compat event value if it should be exposed
 		if (
 			!!applHost.getDeviceConfig?.(endpoint.nodeId)?.compat
 				?.treatBasicSetAsEvent
 		) {
+			// Add the compat event value if it should be exposed
 			ret.push(BasicCCValues.compatEvent.endpoint(endpoint.index));
+		} else if (endpoint.controlsCC(CommandClasses.Basic)) {
+			// Otherwise, only expose currentValue on devices that only control Basic CC
+			ret.push(BasicCCValues.currentValue.endpoint(endpoint.index));
 		}
 
 		return ret;

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -444,6 +444,8 @@ export type {
 	MultilevelSensorCCGetOptions,
 	MultilevelSensorCCGetSupportedScaleOptions,
 	MultilevelSensorCCReportOptions,
+	MultilevelSensorCCSupportedScaleReportOptions,
+	MultilevelSensorCCSupportedSensorReportOptions,
 } from "./MultilevelSensorCC";
 export {
 	MultilevelSensorCC,

--- a/packages/config/config/deviceClasses.json
+++ b/packages/config/config/deviceClasses.json
@@ -12,6 +12,7 @@
 		"0x01": {
 			"label": "Remote Controller",
 			"controlledCCs": ["Basic"],
+			"maySupportBasicCC": false,
 			"specific": {
 				"0x01": {
 					"label": "Portable Remote Controller",
@@ -164,6 +165,7 @@
 				"0x07": {
 					"label": "Gateway",
 					"zwavePlusDeviceType": "Gateway",
+					"maySupportBasicCC": false,
 					"supportedCCs": [
 						"Manufacturer Specific",
 						// "Security", (some devices only support S2)
@@ -252,7 +254,8 @@
 			"specific": {
 				"0x01": {
 					"label": "Notification Sensor",
-					"zwavePlusDeviceType": "Sensor - Notification"
+					"zwavePlusDeviceType": "Sensor - Notification",
+					"maySupportBasicCC": false
 				}
 			}
 		},
@@ -327,11 +330,13 @@
 			"specific": {
 				"0x01": {
 					"label": "Repeater Slave",
-					"zwavePlusDeviceType": "Repeater"
+					"zwavePlusDeviceType": "Repeater",
+					"maySupportBasicCC": false
 				},
 				"0x03": {
 					"label": "IR Repeater",
 					"zwavePlusDeviceType": "IR Repeater",
+					"maySupportBasicCC": false,
 					"supportedCCs": [
 						"Association", // V2+
 						"Association Group Information",
@@ -624,7 +629,8 @@
 			"specific": {
 				"0x01": {
 					"label": "Basic Wall Controller",
-					"zwavePlusDeviceType": "Wall Controller"
+					"zwavePlusDeviceType": "Wall Controller",
+					"maySupportBasicCC": false
 				}
 			}
 		},
@@ -643,7 +649,8 @@
 			"specific": {
 				"0x01": {
 					"label": "Routing Multilevel Sensor",
-					"zwavePlusDeviceType": "Sensor - Multilevel"
+					"zwavePlusDeviceType": "Sensor - Multilevel",
+					"maySupportBasicCC": false
 				}
 			}
 		},
@@ -653,7 +660,7 @@
 		},
 		"0x31": {
 			"label": "Meter",
-			"supportedCCs": ["Basic"],
+			"maySupportBasicCC": false,
 			"specific": {
 				"0x01": {
 					"label": "Simple Meter",
@@ -843,6 +850,7 @@
 					"label": "Secure Keypad",
 					"zwavePlusDeviceType": "Entry Control Keypad",
 					"requiresSecurity": true,
+					"maySupportBasicCC": false,
 					"supportedCCs": [
 						// "Device Reset Locally", (we can't know if the device can be reset)
 						"Entry Control",

--- a/packages/config/src/DeviceClasses.ts
+++ b/packages/config/src/DeviceClasses.ts
@@ -152,6 +152,21 @@ export class GenericDeviceClass {
 			this.controlledCCs = [];
 		}
 
+		if (definition.maySupportBasicCC != undefined) {
+			if (definition.maySupportBasicCC !== false) {
+				throwInvalidConfig(
+					"device classes",
+					`maySupportBasicCC in device class ${this.label} (${
+						num2hex(this.key)
+					}) must be false or omitted (= true)!`,
+				);
+			} else {
+				this.maySupportBasicCC = false;
+			}
+		} else {
+			this.maySupportBasicCC = true;
+		}
+
 		const specific = new Map<number, SpecificDeviceClass>();
 		if (isObject(definition.specific)) {
 			for (
@@ -190,6 +205,7 @@ export class GenericDeviceClass {
 	public readonly requiresSecurity?: boolean;
 	public readonly supportedCCs: readonly CommandClasses[];
 	public readonly controlledCCs: readonly CommandClasses[];
+	public readonly maySupportBasicCC: boolean;
 	public readonly specific: ReadonlyMap<number, SpecificDeviceClass>;
 }
 
@@ -312,6 +328,21 @@ export class SpecificDeviceClass {
 			...generic.controlledCCs,
 			...this.controlledCCs,
 		]);
+
+		if (definition.maySupportBasicCC != undefined) {
+			if (definition.maySupportBasicCC !== false) {
+				throwInvalidConfig(
+					"device classes",
+					`maySupportBasicCC in device class ${generic.label} -> ${this.label} (${
+						num2hex(this.key)
+					}) must be false or omitted (= true)!`,
+				);
+			} else {
+				this.maySupportBasicCC = false;
+			}
+		} else {
+			this.maySupportBasicCC = true;
+		}
 	}
 
 	public readonly key: number;
@@ -320,4 +351,5 @@ export class SpecificDeviceClass {
 	public readonly requiresSecurity?: boolean;
 	public readonly supportedCCs: readonly CommandClasses[];
 	public readonly controlledCCs: readonly CommandClasses[];
+	public readonly maySupportBasicCC: boolean;
 }

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1816,6 +1816,13 @@ export class ZWaveNode extends Endpoint
 			if (this.interviewStage === InterviewStage.NodeInfo) {
 				// Only advance the interview if it was completed, otherwise abort
 				if (await this.interviewCCs()) {
+					// After interviewing the CCs, we may need to clean up the Basic CC values.
+					// Some device types are not allowed to support it, but there are devices that do.
+					// If a device type is forbidden to support Basic CC, remove the "support" portion of it
+					for (const endpoint of this.getAllEndpoints()) {
+						endpoint.removeBasicCCSupportIfForbidden();
+					}
+
 					this.setInterviewStage(InterviewStage.CommandClasses);
 				} else {
 					return false;

--- a/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
@@ -5,7 +5,7 @@ import { integrationTest } from "../integrationTestSuite";
 integrationTest(
 	"On devices that MUST not support Basic CC, but use Basic Set to report status, ONLY currentValue should be exposed",
 	{
-		debug: true,
+		// debug: true,
 
 		nodeCapabilities: {
 			// Routing Multilevel Sensor, MUST not support Basic CC

--- a/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
@@ -1,0 +1,46 @@
+import { BasicCCValues } from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import { integrationTest } from "../integrationTestSuite";
+
+integrationTest(
+	"On devices that MUST not support Basic CC, but use Basic Set to report status, ONLY currentValue should be exposed",
+	{
+		debug: true,
+
+		nodeCapabilities: {
+			// Routing Multilevel Sensor, MUST not support Basic CC
+			genericDeviceClass: 0x21,
+			specificDeviceClass: 0x01,
+			commandClasses: [
+				CommandClasses.Version,
+				// But it reports support if asked
+				CommandClasses.Basic,
+			],
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const valueIDs = node.getDefinedValueIDs();
+			t.true(
+				valueIDs.some((v) => BasicCCValues.currentValue.is(v)),
+				"Did not find Basic CC currentValue although it should be exposed",
+			);
+			t.false(
+				valueIDs.some((v) => BasicCCValues.targetValue.is(v)),
+				"Found Basic CC targetValue although it shouldn't be exposed",
+			);
+			t.false(
+				valueIDs.some((v) => BasicCCValues.duration.is(v)),
+				"Found Basic CC duration although it shouldn't be exposed",
+			);
+			t.false(
+				valueIDs.some((v) => BasicCCValues.restorePrevious.is(v)),
+				"Found Basic CC restorePrevious although it shouldn't be exposed",
+			);
+
+			t.false(
+				valueIDs.some((v) => BasicCCValues.compatEvent.is(v)),
+				"Found Basic CC compatEvent although it shouldn't be exposed",
+			);
+		},
+	},
+);


### PR DESCRIPTION
Since HA now creates a light entity for devices supporting Basic CC, it was noticed that some sensors that cannot be controlled "support" Basic CC. This is now forbidden per the Z-Wave specifications, so we assume that the devices actually **control** Basic CC and do not **support** it. For these devices, Z-Wave JS now only exposes the `currentValue`:

![grafik](https://github.com/zwave-js/node-zwave-js/assets/17641229/2cddfe44-e054-4484-b207-8edbe0da8b51)

fixes: https://github.com/zwave-js/node-zwave-js/issues/6516