### PR TITLE
fix: make route resolution and explorer frames opt-in for pinging

### DIFF
--- a/docs/api/node.md
+++ b/docs/api/node.md
@@ -538,10 +538,12 @@ Aborts an active firmware update process.
 ### `ping`
 
 ```ts
-ping(): Promise<boolean>
+ping(tryReallyHard?: boolean): Promise<boolean>
 ```
 
 Pings the node and returns whether it responded or not.
+
+The optional `tryReallyHard` parameter can be set to `true` to have the controller resort to route resolution and explorer frames if the communication fails. This should only be done when really necessary, because it can block the communication with other nodes for several seconds.
 
 ### `testPowerlevel`
 

--- a/packages/cc/src/cc/NoOperationCC.ts
+++ b/packages/cc/src/cc/NoOperationCC.ts
@@ -1,4 +1,8 @@
-import { CommandClasses, MessagePriority } from "@zwave-js/core";
+import {
+	CommandClasses,
+	MessagePriority,
+	TransmitOptions,
+} from "@zwave-js/core";
 import { PhysicalCCAPI } from "../lib/API.js";
 import { CommandClass } from "../lib/CommandClass.js";
 import {
@@ -19,6 +23,10 @@ export class NoOperationCCAPI extends PhysicalCCAPI {
 				endpointIndex: this.endpoint.index,
 			}),
 			{
+				// Unless instructed otherwise, don't try too hard to
+				// reach the node. Pings are supposed to be short commands
+				// and not block the send queue for multiple seconds.
+				transmitOptions: TransmitOptions.ACK,
 				...this.commandOptions,
 				// Don't retry sending ping packets
 				maxSendAttempts: 1,

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -4925,7 +4925,7 @@ export class ZWaveController
 			|| (node.status === NodeStatus.Asleep
 				&& node.interviewStage === InterviewStage.ProtocolInfo)
 		) {
-			if (!(await node.ping())) {
+			if (!(await node.ping(true))) {
 				this.driver.controllerLog.logNode(
 					nodeId,
 					`Cannot rebuild routes because the node is not responding.`,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -1113,8 +1113,13 @@ protocol version:      ${this.protocolVersion}`;
 		this.setInterviewStage(InterviewStage.ProtocolInfo);
 	}
 
-	/** Node interview: pings the node to see if it responds */
-	public async ping(): Promise<boolean> {
+	/**
+	 * Pings the node to see if it responds
+	 * @param tryReallyHard Whether the controller should resort to route resolution
+	 * and explorer frames if the communication fails. Setting this option to `true`
+	 * can result in multi-second delays.
+	 */
+	public async ping(tryReallyHard: boolean = false): Promise<boolean> {
 		if (this.isControllerNode) {
 			this.driver.controllerLog.logNode(
 				this.id,
@@ -1130,7 +1135,14 @@ protocol version:      ${this.protocolVersion}`;
 		});
 
 		try {
-			await this.commandClasses["No Operation"].send();
+			let api = this.commandClasses["No Operation"];
+			// Enable route resolution and explorer frames if desired
+			if (tryReallyHard) {
+				api = api.withOptions({
+					transmitOptions: TransmitOptions.DEFAULT,
+				});
+			}
+			await api.send();
 			this.driver.controllerLog.logNode(this.id, {
 				message: "ping successful",
 				direction: "inbound",


### PR DESCRIPTION
With this change, calls to `.ping()` no longer use route resolution and explorer frames, unless explicitly enabled with the new `tryReallyHard` parameter.

This avoids these situations where a quick ping was expected but in reality the send queue was blocked for more than 10 seconds:
```
transmit status:        NoAck, took 10990 ms
routing attempts:       23
routing scheme:         Explorer Frame
```

fixes: https://github.com/zwave-js/zwave-js/issues/7901