### PR TITLE
feat: support checking for all firmware updates at once

### DIFF
--- a/docs/api/controller.md
+++ b/docs/api/controller.md
@@ -1109,16 +1109,16 @@ Writes a buffer to the external NVM at the given offset. If `endOfFile` is `true
 > [!NOTE]
 > This section describes updating the firmware of a node using the **Z-Wave JS firmware update service**. If you want to update the firmware of a node using a file, see [`ZWaveNode.updateFirmware`](api/node.md#updatefirmware).
 
-#### `getAvailableFirmwareUpdates`
-
 ```ts
 getAvailableFirmwareUpdates(nodeId: number, options?: GetFirmwareUpdatesOptions): Promise<FirmwareUpdateInfo[]>
+getAllAvailableFirmwareUpdates(options?: GetFirmwareUpdatesOptions): Promise<Map<number, FirmwareUpdateInfo[]>>
 ```
 
-Retrieves the available firmware updates for the given node from the [Z-Wave JS firmware update service](https://github.com/zwave-js/firmware-updates/). The following options are available to control the behavior:
+Retrieves the available firmware updates for the given node or all nodes at once from the [Z-Wave JS firmware update service](https://github.com/zwave-js/firmware-updates/).
 
-<!-- TODO: Figure out why this cannot be imported automatically:
-#import GetFirmwareUpdatesOptions from "zwave-js" -->
+The following options are available to control the behavior:
+
+<!-- #import GetFirmwareUpdatesOptions from "zwave-js" -->
 
 ```ts
 interface GetFirmwareUpdatesOptions {
@@ -1128,10 +1128,30 @@ interface GetFirmwareUpdatesOptions {
 	additionalUserAgentComponents?: Record<string, string>;
 	/** Whether the returned firmware upgrades should include prereleases from the `"beta"` channel. Default: `false`. */
 	includePrereleases?: boolean;
+	/**
+	 * Can be used to specify the RF region if the Z-Wave controller
+	 * does not support querying this information.
+	 *
+	 * **WARNING:** Specifying the wrong region may result in bricking the device!
+	 *
+	 * For this reason, the specified value is only used as a fallback
+	 * if the RF region of the controller is not already known.
+	 */
+	rfRegion?: RFRegion;
 }
 ```
 
-This method returns an array with all available firmware updates for the given node. The entries of the array have the following form:
+`getAvailableFirmwareUpdates` returns an array of available updates for the given node ID, or an empty array if no updates are available.
+
+`getAllAvailableFirmwareUpdates` returns a `Map` where the keys are the node IDs and the values are arrays of available updates for the respective node. Devices that are not known to the firmware update service are omitted from the map.
+
+> [!ATTENTION] For backwards compatibility reasons, you cannot distinguish between devices that have no updates and devices that are not known to the firmware update service when using `getAvailableFirmwareUpdates`.
+>
+> It is strongly recommended to use `getAllAvailableFirmwareUpdates` instead, which omits unknown devices from the result.
+>
+> Under the hood, both methods perform a bulk request to the firmware update service including the information for all nodes that have been identified so far. Results are cached, so repeated calls to either method will not result in additional HTTP requests.
+
+The entries of the array have the following form:
 
 ```ts
 type FirmwareUpdateInfo = {
@@ -1177,8 +1197,6 @@ In addition, the `channel` property indicates which release channel an upgrade i
 - `"beta"`: Beta or pre-release firmwares. This channel is supposed to contain firmwares that are stable enough for a wide audience to test, but may still contain bugs.
 
 Many Z-Wave devices only have a single upgradeable firmware target (chip), so the `files` array will usually contain a single entry. If there are more, the entries must be applied in the order they are defined.
-
-> [!WARNING] This method **does not** rely on cached data to identify a node, so sleeping nodes need to be woken up for this to work. If a sleeping node is not woken up within a minute after calling this, the method will throw. You can schedule the check when a node wakes up using the [`waitForWakeup`](api/node#waitForWakeup) method.
 
 > [!NOTE] Calling this will result in an HTTP request to the firmware update service at https://firmware.zwave-js.io
 

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -281,6 +281,7 @@ import {
 import {
 	Bytes,
 	Mixin,
+	ObjectKeyMap,
 	type ReadonlyObjectKeyMap,
 	type ReadonlyThrowingMap,
 	type ThrowingMap,
@@ -321,7 +322,7 @@ import {
 import { ZWaveFeature, minFeatureVersions } from "./Features.js";
 import {
 	downloadFirmwareUpdate,
-	getAvailableFirmwareUpdates,
+	getAvailableFirmwareUpdatesBulk,
 } from "./FirmwareUpdateService.js";
 import {
 	type ExclusionOptions,
@@ -8919,10 +8920,7 @@ export class ZWaveController
 	/**
 	 * Retrieves the available firmware updates for the given node from the Z-Wave JS firmware update service.
 	 *
-	 * **Note:** Sleeping nodes need to be woken up for this to work. This method will throw when called for a sleeping node
-	 * which did not wake up within a minute.
-	 *
-	 * **Note:** This requires an API key to be set in the driver options, or passed .
+	 * **Note:** This requires an API key to be set in the driver options, or passed using the `options` parameter.
 	 */
 	public async getAvailableFirmwareUpdates(
 		nodeId: number,
@@ -8945,33 +8943,122 @@ export class ZWaveController
 			);
 		}
 
-		// Now invoke the service
+		// Use the bulk method and extract the result for this specific node
 		try {
-			return await getAvailableFirmwareUpdates(
-				{
-					manufacturerId,
-					productType,
-					productId,
-					firmwareVersion,
-					// Prefer the actual region...
-					rfRegion: this.rfRegion
-						// ...over the specified one,
-						?? options?.rfRegion
-						// ... and fall back to the configured region on 500 series controllers as a last resort.
-						?? this.driver.options.rf?.region,
-				},
+			const allUpdates = await this.getAllAvailableFirmwareUpdates(
+				options,
+			);
+			return allUpdates.get(nodeId) || [];
+		} catch (e: any) {
+			let message =
+				`Cannot check for firmware updates for node ${nodeId}: `;
+			if (e.response) {
+				if (isObject(e.response.data)) {
+					if (typeof e.response.data.error === "string") {
+						message += `${e.response.data.error} `;
+					} else if (typeof e.response.data.message === "string") {
+						message += `${e.response.data.message} `;
+					}
+				}
+				message += `[${e.response.status} ${e.response.statusText}]`;
+			} else if (typeof e.message === "string") {
+				message += e.message;
+			} else {
+				message += `Failed to download update information!`;
+			}
+
+			throw new ZWaveError(
+				message,
+				ZWaveErrorCodes.FWUpdateService_RequestError,
+			);
+		}
+	}
+
+	/**
+	 * Retrieves the available firmware updates for all ready nodes from the Z-Wave JS firmware update service.
+	 *
+	 * **Note:** This requires an API key to be set in the driver options, or passed using the `options` parameter.
+	 *
+	 * @returns A map where the keys are node IDs and the values are available firmware updates
+	 */
+	public async getAllAvailableFirmwareUpdates(
+		options?: GetFirmwareUpdatesOptions,
+	): Promise<Map<number, FirmwareUpdateInfo[]>> {
+		// Collect device fingerprints for all ready nodes
+		const deviceIds: FirmwareUpdateDeviceID[] = [];
+		const nodeIdMap = new ObjectKeyMap<FirmwareUpdateDeviceID, number[]>();
+
+		for (const node of this.nodes.values()) {
+			const { manufacturerId, productType, productId, firmwareVersion } =
+				node;
+
+			// Skip nodes without complete fingerprint information
+			if (
+				typeof manufacturerId !== "number"
+				|| typeof productType !== "number"
+				|| typeof productId !== "number"
+				|| typeof firmwareVersion !== "string"
+			) {
+				continue;
+			}
+
+			const deviceId: FirmwareUpdateDeviceID = {
+				manufacturerId,
+				productType,
+				productId,
+				firmwareVersion,
+			};
+
+			deviceIds.push(deviceId);
+
+			// Create a cache key to map back to node ID
+			if (!nodeIdMap.has(deviceId)) {
+				nodeIdMap.set(deviceId, []);
+			}
+			nodeIdMap.get(deviceId)!.push(node.id);
+		}
+
+		if (deviceIds.length === 0) {
+			return new Map();
+		}
+
+		const rfRegion = // Prefer the actual region...
+			this.rfRegion
+				// ...over the specified one,
+				?? options?.rfRegion
+				// ... and fall back to the configured region on 500 series controllers as a last resort.
+				?? this.driver.options.rf?.region;
+
+		// Perform bulk request
+		try {
+			const bulkResult = await getAvailableFirmwareUpdatesBulk(
+				deviceIds,
 				{
 					userAgent: this.driver.getUserAgentStringWithComponents(
 						options?.additionalUserAgentComponents,
 					),
 					apiKey: options?.apiKey
 						?? this.driver.options.apiKeys?.firmwareUpdateService,
-					includePrereleases: options?.includePrereleases,
+					rfRegion,
 				},
 			);
+
+			// Map results back to node IDs
+			const result = new Map<number, FirmwareUpdateInfo[]>();
+			for (const [deviceKey, updates] of bulkResult) {
+				const nodeIds = nodeIdMap.get(deviceKey) ?? [];
+				// Filter out prerelease updates if desired
+				const filteredUpdates = options?.includePrereleases
+					? updates
+					: updates.filter((u) => u.channel === "stable");
+				// Apply the updates to all nodes that match this fingerprint
+				for (const nodeId of nodeIds) {
+					result.set(nodeId, filteredUpdates);
+				}
+			}
+			return result;
 		} catch (e: any) {
-			let message =
-				`Cannot check for firmware updates for node ${nodeId}: `;
+			let message = `Cannot check for firmware updates: `;
 			if (e.response) {
 				if (isObject(e.response.data)) {
 					if (typeof e.response.data.error === "string") {

--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -8979,7 +8979,7 @@ export class ZWaveController
 	 *
 	 * **Note:** This requires an API key to be set in the driver options, or passed using the `options` parameter.
 	 *
-	 * @returns A map where the keys are node IDs and the values are available firmware updates
+	 * @returns A map where the keys are node IDs and the values are available firmware updates. Devices missing from the map are unknown to the firmware update service.
 	 */
 	public async getAllAvailableFirmwareUpdates(
 		options?: GetFirmwareUpdatesOptions,

--- a/packages/zwave-js/src/lib/controller/_Types.ts
+++ b/packages/zwave-js/src/lib/controller/_Types.ts
@@ -36,6 +36,16 @@ export interface FirmwareUpdateServiceResponse {
 	files: FirmwareUpdateFileInfo[];
 	downgrade: boolean;
 	normalizedVersion: string;
+	region?: string;
+}
+
+/** Response from API v4 bulk request */
+export interface FirmwareUpdateBulkInfo {
+	manufacturerId: string;
+	productType: string;
+	productId: string;
+	firmwareVersion: string;
+	updates: FirmwareUpdateServiceResponse[];
 }
 
 export type FirmwareUpdateInfo = Expand<


### PR DESCRIPTION
This PR adds a new method `getAllAvailableFirmwareUpdates` to the `Controller` class, which checks for firmware updates for all identified devices in a single request. This also adds the possibility to detect which devices are not known to the firmware update service, since they will be omitted from the returned `Map`.

fixes: https://github.com/zwave-js/firmware-updates/issues/82