### PR TITLE
fix(config): add fingerprint `0x0811:0x23a9` to "Kwikset HC620"

### DIFF
--- a/packages/config/config/devices/0x0090/hc620.json
+++ b/packages/config/config/devices/0x0090/hc620.json
@@ -21,6 +21,11 @@
 		},
 		{
 			"productType": "0x0811",
+			"productId": "0x23a9",
+			"zwaveAllianceId": 4184
+		},
+		{
+			"productType": "0x0811",
 			"productId": "0x00a9",
 			"zwaveAllianceId": 5046
 		}

--- a/packages/config/config/devices/0x0090/hc620.json
+++ b/packages/config/config/devices/0x0090/hc620.json
@@ -21,8 +21,7 @@
 		},
 		{
 			"productType": "0x0811",
-			"productId": "0x23a9",
-			"zwaveAllianceId": 4184
+			"productId": "0x23a9"
 		},
 		{
 			"productType": "0x0811",


### PR DESCRIPTION
Add missing fingerprint for HC620 lock. I updated my config locally in Z-Wave JS UI and the locks now display accurate manufacturer-related data as expected.
