### PR TITLE
feat(config): add productId 0x0083 to Shelly Wave Shutter

### DIFF
--- a/packages/config/config/devices/0x0460/qnsh-001P10.json
+++ b/packages/config/config/devices/0x0460/qnsh-001P10.json
@@ -10,6 +10,10 @@
 		},
 		{
 			"productType": "0x0003",
+			"productId": "0x0083"
+		},
+		{
+			"productType": "0x0003",
 			"productId": "0x0085"
 		}
 	],


### PR DESCRIPTION
After beta update https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/commit/ceff5ca86e17f1d651bb7c2a1e793d733612aa1e the productId switches to 83


