### PR TITLE
feat(config): add Namron 4512774 Remote Controller

### DIFF
--- a/packages/config/config/devices/0x0438/4512774.json
+++ b/packages/config/config/devices/0x0438/4512774.json
@@ -1,0 +1,16 @@
+{
+	"manufacturer": "Namron",
+	"manufacturerId": "0x0438",
+	"label": "Namron 4512774",
+	"description": "Wall Mounted Remote Control",
+	"devices": [
+		{
+			"productType": "0x0200",
+			"productId": "0xd309"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	}
+}


### PR DESCRIPTION
Introduces a new device configuration file for the Namron 4512774 Wall Mounted Remote Control, including manufacturer details and supported firmware versions. Closes #8114

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

