### PR TITLE
refactor: tests to use timed `expectXYZ` pattern instead of wait+assert

### DIFF
--- a/packages/shared/src/TimedExpectation.ts
+++ b/packages/shared/src/TimedExpectation.ts
@@ -10,12 +10,16 @@ export class TimedExpectation<TResult = void, TPredicate = never>
 {
 	public constructor(
 		timeoutMs: number,
-		public readonly predicate?: (input: TPredicate) => boolean,
-		private readonly timeoutErrorMessage: string =
+		predicate?: (input: TPredicate) => boolean,
+		timeoutErrorMessage: string =
 			"Expectation was not fulfilled within the timeout",
+		preventDefault: boolean = false,
 	) {
 		this.promise = createDeferredPromise<TResult>();
 		this.timeout = setTimer(() => this.reject(), timeoutMs);
+		this.timeoutErrorMessage = timeoutErrorMessage;
+		this.predicate = predicate;
+		this.preventDefault = preventDefault;
 
 		// We need create the stack on a temporary object or the Error
 		// class will try to print the message
@@ -27,6 +31,9 @@ export class TimedExpectation<TResult = void, TPredicate = never>
 	private promise: DeferredPromise<TResult>;
 	private timeout?: Timer;
 	private _done: boolean = false;
+	private readonly timeoutErrorMessage: string;
+	public readonly predicate?: (input: TPredicate) => boolean;
+	public readonly preventDefault: boolean;
 
 	/** The stack trace where the timed expectation was created */
 	public readonly stack: string;

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -419,7 +419,7 @@ export class MockController {
 	 * @param predicate A predicate function to test incoming CCs
 	 * @param options Optional configuration
 	 * @param options.timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected. Default: 5000ms
-	 * @param options.preventDefault If true, the default behavior will not be executed after the expectation is fulfilled. Default: true
+	 * @param options.preventDefault If true, the default behavior will not be executed after the expectation is fulfilled. Default: false
 	 */
 	public async expectNodeCC<T extends CCId = CCId>(
 		node: MockNode,

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -282,16 +282,23 @@ export class MockController {
 		}
 
 		// Handle message buffer. Check for pending expectations first.
-		const handler = this.expectedHostMessages.find(
+		const handlers = this.expectedHostMessages.filter(
 			(e) => !e.predicate || e.predicate(msg),
 		);
-		if (handler) {
+
+		// Resolve all matching expectations
+		for (const handler of handlers) {
 			handler.resolve(msg);
-		} else {
-			for (const behavior of this.behaviors) {
-				if (await behavior.onHostMessage?.(this, msg)) {
-					return;
-				}
+		}
+
+		// If any handler has preventDefault set, skip default behaviors
+		if (handlers.some((h) => h.preventDefault)) {
+			return;
+		}
+
+		for (const behavior of this.behaviors) {
+			if (await behavior.onHostMessage?.(this, msg)) {
+				return;
 			}
 		}
 	}
@@ -319,16 +326,24 @@ export class MockController {
 	/**
 	 * Waits until the host sends a message matching the given predicate or a timeout has elapsed.
 	 *
-	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
+	 * @param predicate A predicate function to test incoming messages
+	 * @param options Optional configuration
+	 * @param options.timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected. Default: 5000ms
+	 * @param options.preventDefault If true, the default behavior will not be executed after the expectation is fulfilled. Default: false
 	 */
 	public async expectHostMessage(
-		timeout: number,
 		predicate: (msg: Message) => boolean,
+		options?: {
+			timeout?: number;
+			preventDefault?: boolean;
+		},
 	): Promise<Message> {
+		const { timeout = 5000, preventDefault = false } = options ?? {};
 		const expectation = new TimedExpectation<Message, Message>(
 			timeout,
 			predicate,
 			"Host did not send the expected message within the provided timeout!",
+			preventDefault,
 		);
 		try {
 			this.expectedHostMessages.push(expectation);
@@ -342,13 +357,21 @@ export class MockController {
 	/**
 	 * Waits until the node sends a message matching the given predicate or a timeout has elapsed.
 	 *
-	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
+	 * @param node The node to expect a frame from
+	 * @param predicate A predicate function to test incoming frames
+	 * @param options Optional configuration
+	 * @param options.timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected. Default: 5000ms
+	 * @param options.preventDefault If true, the default behavior will not be executed after the expectation is fulfilled. Default: false
 	 */
 	public async expectNodeFrame<T extends MockZWaveFrame = MockZWaveFrame>(
 		node: MockNode,
-		timeout: number,
 		predicate: (msg: MockZWaveFrame) => msg is T,
+		options?: {
+			timeout?: number;
+			preventDefault?: boolean;
+		},
 	): Promise<T> {
+		const { timeout = 5000, preventDefault = false } = options ?? {};
 		const expectation = new TimedExpectation<
 			MockZWaveFrame,
 			MockZWaveFrame
@@ -356,6 +379,7 @@ export class MockController {
 			timeout,
 			predicate,
 			`Node ${node.id} did not send the expected frame within the provided timeout!`,
+			preventDefault,
 		);
 		try {
 			if (!this.expectedNodeFrames.has(node.id)) {
@@ -375,19 +399,26 @@ export class MockController {
 	/**
 	 * Waits until the node sends a message matching the given predicate or a timeout has elapsed.
 	 *
-	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
+	 * @param node The node to expect a CC from
+	 * @param predicate A predicate function to test incoming CCs
+	 * @param options Optional configuration
+	 * @param options.timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected. Default: 5000ms
+	 * @param options.preventDefault If true, the default behavior will not be executed after the expectation is fulfilled. Default: true
 	 */
 	public async expectNodeCC<T extends CCId = CCId>(
 		node: MockNode,
-		timeout: number,
 		predicate: (cc: CCId) => cc is T,
+		options?: {
+			timeout?: number;
+			preventDefault?: boolean;
+		},
 	): Promise<T> {
 		const ret = await this.expectNodeFrame(
 			node,
-			timeout,
 			(msg): msg is MockZWaveRequestFrame & { payload: T } =>
 				msg.type === MockZWaveFrameType.Request
 				&& predicate(msg.payload),
+			options,
 		);
 		return ret.payload;
 	}
@@ -403,9 +434,9 @@ export class MockController {
 	): Promise<MockZWaveAckFrame> {
 		return this.expectNodeFrame(
 			node,
-			timeout,
 			(msg): msg is MockZWaveAckFrame =>
 				msg.type === MockZWaveFrameType.ACK,
+			{ timeout },
 		);
 	}
 
@@ -470,19 +501,23 @@ export class MockController {
 		}
 
 		// Handle message buffer. Check for pending expectations first.
-		const handler = this.expectedNodeFrames
+		const handlers = this.expectedNodeFrames
 			.get(node.id)
-			?.find((e) => !e.predicate || e.predicate(frame));
-		if (handler) {
+			?.filter((e) => !e.predicate || e.predicate(frame)) ?? [];
+
+		// Resolve all matching expectations
+		for (const handler of handlers) {
 			handler.resolve(frame);
-		} else {
-			// Then apply generic predefined behavior
-			for (const behavior of this.behaviors) {
-				if (
-					await behavior.onNodeFrame?.(this, node, frame)
-				) {
-					return;
-				}
+		}
+
+		// If any handler has preventDefault set, skip default behaviors
+		if (handlers.some((h) => h.preventDefault)) {
+			return;
+		}
+
+		for (const behavior of this.behaviors) {
+			if (await behavior.onNodeFrame?.(this, node, frame)) {
+				return;
 			}
 		}
 	}

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -308,11 +308,15 @@ export class MockController {
 	 *
 	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
 	 */
-	public async expectHostACK(timeout: number): Promise<void> {
+	public async expectHostACK(
+		timeout: number,
+		errorMessage?: string,
+	): Promise<void> {
 		const ack = new TimedExpectation(
 			timeout,
 			undefined,
-			"Host did not respond with an ACK within the provided timeout!",
+			errorMessage
+				?? "Host did not respond with an ACK within the provided timeout!",
 		);
 		try {
 			this.expectedHostACKs.push(ack);
@@ -336,13 +340,19 @@ export class MockController {
 		options?: {
 			timeout?: number;
 			preventDefault?: boolean;
+			errorMessage?: string;
 		},
 	): Promise<Message> {
-		const { timeout = 5000, preventDefault = false } = options ?? {};
+		const {
+			timeout = 5000,
+			preventDefault = false,
+			errorMessage =
+				"Host did not send the expected message within the provided timeout!",
+		} = options ?? {};
 		const expectation = new TimedExpectation<Message, Message>(
 			timeout,
 			predicate,
-			"Host did not send the expected message within the provided timeout!",
+			errorMessage,
 			preventDefault,
 		);
 		try {
@@ -369,16 +379,22 @@ export class MockController {
 		options?: {
 			timeout?: number;
 			preventDefault?: boolean;
+			errorMessage?: string;
 		},
 	): Promise<T> {
-		const { timeout = 5000, preventDefault = false } = options ?? {};
+		const {
+			timeout = 5000,
+			preventDefault = false,
+			errorMessage =
+				`Node ${node.id} did not send the expected frame within the provided timeout!`,
+		} = options ?? {};
 		const expectation = new TimedExpectation<
 			MockZWaveFrame,
 			MockZWaveFrame
 		>(
 			timeout,
 			predicate,
-			`Node ${node.id} did not send the expected frame within the provided timeout!`,
+			errorMessage,
 			preventDefault,
 		);
 		try {
@@ -411,6 +427,7 @@ export class MockController {
 		options?: {
 			timeout?: number;
 			preventDefault?: boolean;
+			errorMessage?: string;
 		},
 	): Promise<T> {
 		const ret = await this.expectNodeFrame(
@@ -431,12 +448,13 @@ export class MockController {
 	public expectNodeACK(
 		node: MockNode,
 		timeout: number,
+		errorMessage?: string,
 	): Promise<MockZWaveAckFrame> {
 		return this.expectNodeFrame(
 			node,
 			(msg): msg is MockZWaveAckFrame =>
 				msg.type === MockZWaveFrameType.ACK,
-			{ timeout },
+			{ timeout, errorMessage },
 		);
 	}
 

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -253,16 +253,22 @@ export class MockNode {
 		options?: {
 			timeout?: number;
 			preventDefault?: boolean;
+			errorMessage?: string;
 		},
 	): Promise<T> {
-		const { timeout = 5000, preventDefault = false } = options ?? {};
+		const {
+			timeout = 5000,
+			preventDefault = false,
+			errorMessage =
+				"The controller did not send the expected frame within the provided timeout!",
+		} = options ?? {};
 		const expectation = new TimedExpectation<
 			MockZWaveFrame,
 			MockZWaveFrame
 		>(
 			timeout,
 			predicate,
-			"The controller did not send the expected frame within the provided timeout!",
+			errorMessage,
 			preventDefault,
 		);
 		try {
@@ -281,11 +287,14 @@ export class MockNode {
 	 *
 	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
 	 */
-	public expectControllerACK(timeout: number): Promise<MockZWaveAckFrame> {
+	public expectControllerACK(
+		timeout: number,
+		errorMessage?: string,
+	): Promise<MockZWaveAckFrame> {
 		return this.expectControllerFrame(
 			(msg): msg is MockZWaveAckFrame =>
 				msg.type === MockZWaveFrameType.ACK,
-			{ timeout },
+			{ timeout, errorMessage },
 		);
 	}
 

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -241,14 +241,21 @@ export class MockNode {
 	/**
 	 * Waits until the controller sends a frame matching the given predicate or a timeout has elapsed.
 	 *
-	 * @param timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected
+	 * @param predicate A predicate function to test incoming frames
+	 * @param options Optional configuration
+	 * @param options.timeout The number of milliseconds to wait. If the timeout elapses, the returned promise will be rejected. Default: 5000ms
+	 * @param options.preventDefault If true, the default behavior will not be executed after the expectation is fulfilled. Default: false
 	 */
 	public async expectControllerFrame<
 		T extends MockZWaveFrame = MockZWaveFrame,
 	>(
-		timeout: number,
 		predicate: (msg: MockZWaveFrame) => msg is T,
+		options?: {
+			timeout?: number;
+			preventDefault?: boolean;
+		},
 	): Promise<T> {
+		const { timeout = 5000, preventDefault = false } = options ?? {};
 		const expectation = new TimedExpectation<
 			MockZWaveFrame,
 			MockZWaveFrame
@@ -256,6 +263,7 @@ export class MockNode {
 			timeout,
 			predicate,
 			"The controller did not send the expected frame within the provided timeout!",
+			preventDefault,
 		);
 		try {
 			this.expectedControllerFrames.push(expectation);
@@ -275,9 +283,9 @@ export class MockNode {
 	 */
 	public expectControllerACK(timeout: number): Promise<MockZWaveAckFrame> {
 		return this.expectControllerFrame(
-			timeout,
 			(msg): msg is MockZWaveAckFrame =>
 				msg.type === MockZWaveFrameType.ACK,
+			{ timeout },
 		);
 	}
 
@@ -289,7 +297,9 @@ export class MockNode {
 	): Promise<MockZWaveAckFrame | undefined> {
 		this.controller["air"].add({
 			source: this.id,
-			onTransmit: (frame) => this.sentControllerFrames.push(frame),
+			onTransmit: (frame) => {
+				this.sentControllerFrames.push(frame);
+			},
 			...frame,
 		});
 
@@ -311,12 +321,21 @@ export class MockNode {
 		}
 
 		// Handle message buffer. Check for pending expectations first.
-		const handler = this.expectedControllerFrames.find(
+		const handlers = this.expectedControllerFrames.filter(
 			(e) => !e.predicate || e.predicate(frame),
 		);
-		if (handler) {
+
+		// Resolve all matching expectations
+		for (const handler of handlers) {
 			handler.resolve(frame);
-		} else if (frame.type === MockZWaveFrameType.Request) {
+		}
+
+		// If any handler has preventDefault set, skip default behaviors
+		if (handlers.some((h) => h.preventDefault)) {
+			return;
+		}
+
+		if (frame.type === MockZWaveFrameType.Request) {
 			let cc = frame.payload;
 			let response: MockNodeResponse | undefined;
 

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -685,8 +685,8 @@ const handleRequestNodeInfo: MockControllerBehavior = {
 			void controller.sendToNode(node, frame);
 			const nodeInfoPromise = controller.expectNodeCC(
 				node,
-				MOCK_FRAME_ACK_TIMEOUT,
 				(cc) => cc instanceof ZWaveProtocolCCNodeInformationFrame,
+				{ timeout: MOCK_FRAME_ACK_TIMEOUT },
 			);
 
 			// Notify the host that the message was sent

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -283,6 +283,7 @@ const handleSendData: MockControllerBehavior = {
 				state != undefined
 				&& state !== MockControllerCommunicationState.Idle
 			) {
+				debugger;
 				throw new Error("Received SendDataRequest while not idle");
 			}
 
@@ -374,6 +375,7 @@ const handleSendDataMulticast: MockControllerBehavior = {
 				state != undefined
 				&& state !== MockControllerCommunicationState.Idle
 			) {
+				debugger;
 				throw new Error(
 					"Received SendDataMulticastRequest while not idle",
 				);
@@ -472,6 +474,7 @@ const handleSendDataBridge: MockControllerBehavior = {
 				state != undefined
 				&& state !== MockControllerCommunicationState.Idle
 			) {
+				debugger;
 				throw new Error(
 					"Received SendDataBridgeRequest while not idle",
 				);
@@ -565,6 +568,7 @@ const handleSendDataMulticastBridge: MockControllerBehavior = {
 				state != undefined
 				&& state !== MockControllerCommunicationState.Idle
 			) {
+				debugger;
 				throw new Error(
 					"Received SendDataMulticastBridgeRequest while not idle",
 				);
@@ -663,6 +667,7 @@ const handleRequestNodeInfo: MockControllerBehavior = {
 				state != undefined
 				&& state !== MockControllerCommunicationState.Idle
 			) {
+				debugger;
 				throw new Error(
 					"Received RequestNodeInfoRequest while not idle",
 				);
@@ -686,7 +691,12 @@ const handleRequestNodeInfo: MockControllerBehavior = {
 			const nodeInfoPromise = controller.expectNodeCC(
 				node,
 				(cc) => cc instanceof ZWaveProtocolCCNodeInformationFrame,
-				{ timeout: MOCK_FRAME_ACK_TIMEOUT },
+				{
+					timeout: MOCK_FRAME_ACK_TIMEOUT,
+					// Prevent forwarding the NIF to the host. Otherwise it will mess with
+					// the state tracking in the MockController.
+					preventDefault: true,
+				},
 			);
 
 			// Notify the host that the message was sent
@@ -784,6 +794,7 @@ const handleDeleteSUCReturnRoute: MockControllerBehavior = {
 				state != undefined
 				&& state !== MockControllerCommunicationState.Idle
 			) {
+				debugger;
 				throw new Error(
 					"Received DeleteSUCReturnRouteRequest while not idle",
 				);
@@ -845,6 +856,7 @@ const handleAssignSUCReturnRoute: MockControllerBehavior = {
 				state != undefined
 				&& state !== MockControllerCommunicationState.Idle
 			) {
+				debugger;
 				throw new Error(
 					"Received AssignSUCReturnRouteRequest while not idle",
 				);

--- a/packages/zwave-js/src/lib/test/compliance/decodeLowerS2Keys.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/decodeLowerS2Keys.test.ts
@@ -190,8 +190,6 @@ integrationTest(
 			mockNode.clearReceivedControllerFrames();
 			await node.commandClasses.Basic.set(0xff);
 
-			await wait(200);
-
 			// The controller MUST have sent a NonceGet
 			mockNode.assertReceivedControllerFrame(
 				(f) =>

--- a/packages/zwave-js/src/lib/test/compliance/encapsulationAnswerAsAsked.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/encapsulationAnswerAsAsked.test.ts
@@ -48,8 +48,8 @@ integrationTest(
 			await mockNode.sendToController(createMockZWaveRequestFrame(cc));
 
 			const { payload: response } = await mockNode.expectControllerFrame(
-				1000,
 				(msg) => msg.type === MockZWaveFrameType.Request,
+				{ timeout: 1000 },
 			);
 
 			t.expect(response instanceof CRC16CCCommandEncapsulation).toBe(
@@ -101,9 +101,9 @@ integrationTest(
 			const { payload: response } = await mockNode.expectControllerFrame<
 				MockZWaveRequestFrame
 			>(
-				1000,
 				(msg): msg is MockZWaveRequestFrame =>
 					msg.type === MockZWaveFrameType.Request,
+				{ timeout: 1000 },
 			);
 
 			t.expect(response instanceof MultiChannelCCCommandEncapsulation)
@@ -155,9 +155,9 @@ integrationTest(
 			const { payload: response } = await mockNode.expectControllerFrame<
 				MockZWaveRequestFrame
 			>(
-				1000,
 				(msg): msg is MockZWaveRequestFrame =>
 					msg.type === MockZWaveFrameType.Request,
+				{ timeout: 1000 },
 			);
 
 			t.expect(response instanceof SupervisionCCReport).toBe(true);
@@ -211,9 +211,9 @@ integrationTest(
 			const { payload: response } = await mockNode.expectControllerFrame<
 				MockZWaveRequestFrame
 			>(
-				1000,
 				(msg): msg is MockZWaveRequestFrame =>
 					msg.type === MockZWaveFrameType.Request,
+				{ timeout: 1000 },
 			);
 
 			t.expect(response instanceof MultiChannelCCCommandEncapsulation)

--- a/packages/zwave-js/src/lib/test/compliance/handleMultiCommandPayload.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/handleMultiCommandPayload.test.ts
@@ -46,10 +46,10 @@ integrationTest("All CCs contained in a Multi Command CC are handled", {
 		await mockNode.sendToController(createMockZWaveRequestFrame(cc));
 
 		const expectResponse = mockNode.expectControllerFrame(
-			1000,
 			(msg): msg is any =>
 				msg.type === MockZWaveFrameType.Request
 				&& msg.payload instanceof ZWavePlusCCReport,
+			{ timeout: 1000 },
 		);
 
 		const scaValue = SceneActivationCCValues.sceneId;

--- a/packages/zwave-js/src/lib/test/compliance/zwavePlusInfoResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/compliance/zwavePlusInfoResponse.test.ts
@@ -35,13 +35,13 @@ integrationTest("Response to Z-Wave Plus Info Get", {
 		);
 
 		const { payload: response } = await mockNode.expectControllerFrame(
-			1000,
 			(
 				msg,
 			): msg is MockZWaveRequestFrame & {
 				payload: ZWavePlusCCReport;
 			} => msg.type === MockZWaveFrameType.Request
 				&& msg.payload instanceof ZWavePlusCCReport,
+			{ timeout: 1000 },
 		);
 
 		// Z-Wave+ v2 specifications, section 3.1

--- a/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
@@ -213,7 +213,6 @@ function setupS0NodeBehaviorsForNewlyIncludedNode(
 				);
 
 				const nonceReport = await self.expectControllerFrame(
-					1000,
 					(
 						resp,
 					): resp is MockZWaveFrame & {
@@ -221,6 +220,7 @@ function setupS0NodeBehaviorsForNewlyIncludedNode(
 						payload: SecurityCCNonceReport;
 					} => resp.type === MockZWaveFrameType.Request
 						&& resp.payload instanceof SecurityCCNonceReport,
+					{ timeout: 1000 },
 				);
 				const receiverNonce = nonceReport.payload.nonce;
 

--- a/packages/zwave-js/src/lib/test/driver/features.disableCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/features.disableCCs.test.ts
@@ -5,9 +5,9 @@ import {
 import { CommandClasses } from "@zwave-js/core";
 import {
 	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
 	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
-import { wait } from "alcalzone-shared/async";
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest(
@@ -32,15 +32,14 @@ integrationTest(
 				ackRequested: false,
 			}));
 
-			await wait(100);
-
-			mockNode.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof VersionCCCommandClassReport
 					&& frame.payload.requestedCC
 						=== CommandClasses["Binary Switch"]
 					&& frame.payload.ccVersion === 0,
+				{ timeout: 100 },
 			);
 		},
 	},

--- a/packages/zwave-js/src/lib/test/driver/ignoreCCVersion0ForKnownSupportedCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/ignoreCCVersion0ForKnownSupportedCCs.test.ts
@@ -240,7 +240,6 @@ integrationTest(
 						);
 
 						const nonceReport = await self.expectControllerFrame(
-							1000,
 							(
 								resp,
 							): resp is MockZWaveFrame & {
@@ -249,6 +248,7 @@ integrationTest(
 							} => resp.type === MockZWaveFrameType.Request
 								&& resp.payload
 									instanceof SecurityCCNonceReport,
+							{ timeout: 1000 },
 						);
 						const receiverNonce = nonceReport.payload.nonce;
 
@@ -301,7 +301,6 @@ integrationTest(
 						);
 
 						const nonceReport = await self.expectControllerFrame(
-							1000,
 							(
 								resp,
 							): resp is MockZWaveFrame & {
@@ -310,6 +309,7 @@ integrationTest(
 							} => resp.type === MockZWaveFrameType.Request
 								&& resp.payload
 									instanceof SecurityCCNonceReport,
+							{ timeout: 1000 },
 						);
 						const receiverNonce = nonceReport.payload.nonce;
 

--- a/packages/zwave-js/src/lib/test/driver/multiChannelUnknownVersions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/multiChannelUnknownVersions.test.ts
@@ -27,6 +27,8 @@ integrationTest(
 						instanceof MultiChannelCCCommandEncapsulation
 					&& frame.payload.encapsulated instanceof BinarySwitchCCSet,
 			);
+
+			await driver.waitForIdle();
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
@@ -8,6 +8,7 @@ import {
 	MOCK_FRAME_ACK_TIMEOUT,
 	type MockNodeBehavior,
 	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
 	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
@@ -94,12 +95,12 @@ integrationTest(
 			);
 
 			// The driver should send a Nonce Report command
-			await wait(200);
-			mockNode.assertReceivedControllerFrame(
-				(f) =>
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
 					f.type === MockZWaveFrameType.Request
 					&& f.payload instanceof SecurityCCNonceReport,
 				{
+					timeout: 200,
 					errorMessage: "Expected a Nonce Report to be sent",
 				},
 			);
@@ -131,12 +132,12 @@ integrationTest(
 				}),
 			);
 
-			await wait(200);
-			mockNode.assertReceivedControllerFrame(
-				(f) =>
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
 					f.type === MockZWaveFrameType.Request
 					&& f.payload instanceof SecurityCCNonceReport,
 				{
+					timeout: 200,
 					errorMessage: "Expected a Nonce Report to be sent",
 				},
 			);

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -9,6 +9,7 @@ import { FunctionType } from "@zwave-js/serial";
 import {
 	type MockNodeBehavior,
 	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
 	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
@@ -61,12 +62,12 @@ integrationTest(
 			const pingPromise17 = node17.ping();
 
 			// Ping for 10 should be sent
-			await wait(50);
-			mockNode10.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode10.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof NoOperationCC,
 				{
+					timeout: 50,
 					errorMessage: "Node 10 did not receive the ping",
 				},
 			);
@@ -87,12 +88,12 @@ integrationTest(
 			t.expect(pingResult10).toBe(false);
 
 			// Now the ping for 17 should go out
-			await wait(500);
-			mockNode17.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode17.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof NoOperationCC,
 				{
+					timeout: 500,
 					errorMessage: "Node 17 did not receive the ping",
 				},
 			);

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepMessageOrder.test.ts
@@ -73,13 +73,10 @@ integrationTest(
 
 			// Mark the node as asleep. This should abort the ongoing transaction.
 			node10.markAsAsleep();
-			await wait(50);
 
-			mockController.assertReceivedHostMessage(
+			await mockController.expectHostMessage(
 				(msg) => msg.functionType === FunctionType.SendDataAbort,
-				{
-					errorMessage: "The SendData was not aborted",
-				},
+				{ timeout: 500 },
 			);
 
 			// Now ack the ping so the SendData command will be finished

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepNoReject.test.ts
@@ -1,7 +1,11 @@
 import { BasicCCGet, BasicCCSet } from "@zwave-js/cc";
 import { MessagePriority, NodeStatus } from "@zwave-js/core";
 import type { SendDataRequest } from "@zwave-js/serial/serialapi";
-import { MOCK_FRAME_ACK_TIMEOUT, MockZWaveFrameType } from "@zwave-js/testing";
+import {
+	MOCK_FRAME_ACK_TIMEOUT,
+	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
+} from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import path from "node:path";
 import { integrationTest } from "../integrationTestSuite.js";
@@ -39,13 +43,13 @@ integrationTest(
 			});
 
 			// The node should have received the first command
-			await wait(50);
-			mockNode.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof BasicCCSet
 					&& frame.payload.targetValue === 99,
 				{
+					timeout: 50,
 					errorMessage: "The first command was not received",
 				},
 			);

--- a/packages/zwave-js/src/lib/test/driver/nodeDeadReject.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeDeadReject.test.ts
@@ -1,7 +1,9 @@
 import { BasicCCGet, BasicCCSet } from "@zwave-js/cc";
 import { NodeStatus, ZWaveErrorCodes, assertZWaveError } from "@zwave-js/core";
-import { MockZWaveFrameType } from "@zwave-js/testing";
-import { wait } from "alcalzone-shared/async";
+import {
+	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
+} from "@zwave-js/testing";
 import path from "node:path";
 import { integrationTest } from "../integrationTestSuite.js";
 
@@ -46,13 +48,13 @@ integrationTest(
 			}); // Don't throw here, do it below
 
 			// The node should have received the first command
-			await wait(50);
-			mockNode.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof BasicCCSet
 					&& frame.payload.targetValue === 99,
 				{
+					timeout: 50,
 					errorMessage: "The first command was not received",
 				},
 			);
@@ -114,13 +116,13 @@ integrationTest(
 			});
 
 			// The node should have received the first command
-			await wait(50);
-			mockNode.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof BasicCCSet
 					&& frame.payload.targetValue === 99,
 				{
+					timeout: 50,
 					errorMessage: "The first command was not received",
 				},
 			);
@@ -170,13 +172,13 @@ integrationTest(
 			});
 
 			// The node should have received the first command
-			await wait(50);
-			mockNode.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof BasicCCSet
 					&& frame.payload.targetValue === 99,
 				{
+					timeout: 50,
 					errorMessage: "The first command was not received",
 				},
 			);
@@ -218,13 +220,13 @@ integrationTest(
 			});
 
 			// The node should have received the first command
-			await wait(50);
-			mockNode.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof BasicCCSet
 					&& frame.payload.targetValue === 99,
 				{
+					timeout: 50,
 					errorMessage: "The first command was not received",
 				},
 			);
@@ -243,12 +245,12 @@ integrationTest(
 			});
 
 			// The node should have received the second command
-			await wait(50);
-			mockNode.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof BasicCCGet,
 				{
+					timeout: 50,
 					errorMessage: "The second command was not received",
 				},
 			);

--- a/packages/zwave-js/src/lib/test/driver/s0AndS2Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0AndS2Encapsulation.test.ts
@@ -20,7 +20,6 @@ import {
 	ZWaveErrorCodes,
 } from "@zwave-js/core";
 import { type MockNodeBehavior, MockZWaveFrameType } from "@zwave-js/testing";
-import { wait } from "alcalzone-shared/async";
 import path from "node:path";
 import { integrationTest } from "../integrationTestSuite.js";
 
@@ -196,7 +195,6 @@ integrationTest("S0 commands are S0-encapsulated, even when S2 is supported", {
 	testBody: async (t, driver, node, mockController, mockNode) => {
 		await node.commandClasses.Security.getSupportedCommands();
 
-		await wait(100);
 		mockNode.assertReceivedControllerFrame(
 			(f) =>
 				f.type === MockZWaveFrameType.Request

--- a/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
@@ -77,7 +77,6 @@ integrationTest("Communication via Security S0 works", {
 					);
 
 					const nonceReport = await self.expectControllerFrame(
-						1000,
 						(
 							resp,
 						): resp is MockZWaveFrame & {
@@ -85,6 +84,7 @@ integrationTest("Communication via Security S0 works", {
 							payload: SecurityCCNonceReport;
 						} => resp.type === MockZWaveFrameType.Request
 							&& resp.payload instanceof SecurityCCNonceReport,
+						{ timeout: 1000 },
 					);
 					const receiverNonce = nonceReport.payload.nonce;
 
@@ -131,7 +131,6 @@ integrationTest("Communication via Security S0 works", {
 					);
 
 					const nonceReport = await self.expectControllerFrame(
-						1000,
 						(
 							resp,
 						): resp is MockZWaveFrame & {
@@ -139,6 +138,7 @@ integrationTest("Communication via Security S0 works", {
 							payload: SecurityCCNonceReport;
 						} => resp.type === MockZWaveFrameType.Request
 							&& resp.payload instanceof SecurityCCNonceReport,
+						{ timeout: 1000 },
 					);
 					const receiverNonce = nonceReport.payload.nonce;
 

--- a/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
@@ -99,7 +99,6 @@ integrationTest(
 
 							const nonceReport = await self
 								.expectControllerFrame(
-									1000,
 									(
 										resp,
 									): resp is MockZWaveFrame & {
@@ -109,6 +108,7 @@ integrationTest(
 											=== MockZWaveFrameType.Request
 										&& resp.payload
 											instanceof SecurityCCNonceReport,
+									{ timeout: 1000 },
 								);
 							const receiverNonce = nonceReport.payload.nonce;
 
@@ -164,7 +164,6 @@ integrationTest(
 
 							const nonceReport = await self
 								.expectControllerFrame(
-									1000,
 									(
 										resp,
 									): resp is MockZWaveFrame & {
@@ -174,6 +173,7 @@ integrationTest(
 											=== MockZWaveFrameType.Request
 										&& resp.payload
 											instanceof SecurityCCNonceReport,
+									{ timeout: 1000 },
 								);
 							const receiverNonce = nonceReport.payload.nonce;
 
@@ -246,7 +246,6 @@ integrationTest(
 
 			await mockNode3
 				.expectControllerFrame(
-					250,
 					(
 						resp,
 					): resp is MockZWaveFrame & {
@@ -254,6 +253,7 @@ integrationTest(
 						payload: SecurityCCNonceReport;
 					} => resp.type === MockZWaveFrameType.Request
 						&& resp.payload instanceof SecurityCCNonceReport,
+					{ timeout: 250 },
 				)
 				.catch(() => {
 					throw new Error(

--- a/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
@@ -491,13 +491,13 @@ integrationTest(
 				}),
 			);
 			const reportConfirmation = mockNode.expectControllerFrame(
-				500,
 				(f): f is MockZWaveRequestFrame =>
 					f.type === MockZWaveFrameType.Request
 					&& f.payload instanceof Security2CCMessageEncapsulation
 					&& f.payload.encapsulated instanceof SupervisionCCReport
 					&& f.payload.encapsulated.status
 						=== SupervisionStatus.Success,
+				{ timeout: 500 },
 			);
 
 			// We want both transactions to be completed successfully

--- a/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponse.test.ts
@@ -10,7 +10,6 @@ import type {
 	MockControllerBehavior,
 	MockNodeBehavior,
 } from "@zwave-js/testing";
-import { wait } from "alcalzone-shared/async";
 import path from "node:path";
 import {
 	MockControllerCommunicationState,
@@ -79,14 +78,12 @@ integrationTest(
 			const result = await node.commandClasses.Basic.get();
 			t.expect(result?.currentValue).toBe(42);
 
-			// Wait a bit to allow any pending operations to complete
-			await wait(50);
-
 			// Assert that the controller received a SendDataAbort
 			// This proves that the ongoing transaction was aborted when the
 			// premature response arrived
-			mockController.assertReceivedHostMessage(
+			await mockController.expectHostMessage(
 				(msg) => msg.functionType === FunctionType.SendDataAbort,
+				{ timeout: 500 },
 			);
 		},
 	},

--- a/packages/zwave-js/src/lib/test/driver/sendDataMissingCallbackAbort.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataMissingCallbackAbort.test.ts
@@ -132,17 +132,18 @@ integrationTest(
 
 			const pingPromise = node.ping();
 
-			await wait(2000);
-
 			// The abort should have been issued
-			mockController.assertReceivedHostMessage(
-				(msg) => msg.functionType === FunctionType.SendDataAbort,
-			);
-
-			// And the stick should have been soft-reset
-			mockController.assertReceivedHostMessage(
-				(msg) => msg.functionType === FunctionType.SoftReset,
-			);
+			await Promise.all([
+				mockController.expectHostMessage(
+					(msg) => msg.functionType === FunctionType.SendDataAbort,
+					{ timeout: 2000 },
+				),
+				// And the stick should have been soft-reset
+				mockController.expectHostMessage(
+					(msg) => msg.functionType === FunctionType.SoftReset,
+					{ timeout: 2000 },
+				),
+			]);
 
 			// And the ping should eventually succeed
 			t.expect(await pingPromise).toBe(true);
@@ -225,17 +226,18 @@ integrationTest(
 
 			const pingPromise = node.ping();
 
-			await wait(2000);
-
 			// The abort should have been issued
-			mockController.assertReceivedHostMessage(
-				(msg) => msg.functionType === FunctionType.SendDataAbort,
-			);
-
-			// And the stick should have been soft-reset
-			mockController.assertReceivedHostMessage(
-				(msg) => msg.functionType === FunctionType.SoftReset,
-			);
+			await Promise.all([
+				mockController.expectHostMessage(
+					(msg) => msg.functionType === FunctionType.SendDataAbort,
+					{ timeout: 2000 },
+				),
+				// And the stick should have been soft-reset
+				mockController.expectHostMessage(
+					(msg) => msg.functionType === FunctionType.SoftReset,
+					{ timeout: 2000 },
+				),
+			]);
 
 			// The ping should eventually fail and the node be marked dead
 			t.expect(await pingPromise).toBe(false);
@@ -336,17 +338,18 @@ integrationTest(
 			const firstCommand = node.commandClasses.Basic.set(99);
 			const followupCommand = node.commandClasses.Basic.set(0);
 
-			await wait(2000);
-
 			// The abort should have been issued
-			mockController.assertReceivedHostMessage(
-				(msg) => msg.functionType === FunctionType.SendDataAbort,
-			);
-
-			// And the stick should have been soft-reset
-			mockController.assertReceivedHostMessage(
-				(msg) => msg.functionType === FunctionType.SoftReset,
-			);
+			await Promise.all([
+				mockController.expectHostMessage(
+					(msg) => msg.functionType === FunctionType.SendDataAbort,
+					{ timeout: 2000 },
+				),
+				// And the stick should have been soft-reset
+				mockController.expectHostMessage(
+					(msg) => msg.functionType === FunctionType.SoftReset,
+					{ timeout: 2000 },
+				),
+			]);
 
 			// The ping and the followup command should eventually succeed
 			await firstCommand;
@@ -484,12 +487,12 @@ integrationTest(
 			);
 			const followupCommand = node.commandClasses.Basic.set(0);
 
-			await wait(2500);
-
 			// Transmission should have been aborted
-			mockController.assertReceivedHostMessage(
+			await mockController.expectHostMessage(
 				(msg) => msg.functionType === FunctionType.SendDataAbort,
+				{ timeout: 2500 },
 			);
+
 			// but the stick should NOT have been soft-reset
 			t.expect(() =>
 				mockController.assertReceivedHostMessage(
@@ -713,16 +716,18 @@ integrationTestMulti(
 				priority: MessagePriority.Immediate,
 			}).set(0).catch((e) => e.code);
 
-			await wait(2500);
+			// Transmission should have been aborted and the stick should have been soft-reset
+			await Promise.all([
+				mockController.expectHostMessage(
+					(msg) => msg.functionType === FunctionType.SendDataAbort,
+					{ timeout: 2500 },
+				),
+				mockController.expectHostMessage(
+					(msg) => msg.functionType === FunctionType.SoftReset,
+					{ timeout: 2500 },
+				),
+			]);
 
-			// Transmission should have been aborted
-			mockController.assertReceivedHostMessage(
-				(msg) => msg.functionType === FunctionType.SendDataAbort,
-			);
-			// And the stick should have been soft-reset
-			mockController.assertReceivedHostMessage(
-				(msg) => msg.functionType === FunctionType.SoftReset,
-			);
 			mockController.clearReceivedHostMessages();
 
 			const followupCommand = node3.commandClasses.Basic.set(0).catch((

--- a/packages/zwave-js/src/lib/test/driver/sendDataMissingResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataMissingResponse.test.ts
@@ -109,10 +109,9 @@ integrationTest(
 			const basicSetPromise = node.commandClasses.Basic.set(99)
 				.catch((e) => e);
 
-			await wait(2000);
-
-			mockController.assertReceivedHostMessage(
+			await mockController.expectHostMessage(
 				(msg) => msg.functionType === FunctionType.SendDataAbort,
+				{ timeout: 2000 },
 			);
 			mockController.clearReceivedHostMessages();
 
@@ -135,10 +134,10 @@ integrationTest(
 	},
 );
 
-integrationTest(
+integrationTest.only(
 	"Recover controller if callback times out after timed out SendData response",
 	{
-		// debug: true,
+		debug: true,
 
 		controllerCapabilities: controllerCapabilitiesNoBridge,
 
@@ -192,17 +191,18 @@ integrationTest(
 
 			const basicSetPromise = node.commandClasses.Basic.set(99);
 
-			await wait(2000);
-
-			mockController.assertReceivedHostMessage(
+			// The transmission should be aborted after the response timeout elapses
+			// We leave 500ms of leeway for tests.
+			await mockController.expectHostMessage(
 				(msg) => msg.functionType === FunctionType.SendDataAbort,
+				{ timeout: 1000 },
 			);
-			mockController.clearReceivedHostMessages();
 
-			// The stick should have been soft-reset
-			await wait(1000);
-			mockController.assertReceivedHostMessage(
+			// Soft reset should be done after roughly 2 seconds. Again, leave
+			// a bit of leeway for the tests
+			await mockController.expectHostMessage(
 				(msg) => msg.functionType === FunctionType.SoftReset,
+				{ timeout: 2500 },
 			);
 
 			// And the command should eventually succeed

--- a/packages/zwave-js/src/lib/test/driver/sendDataMissingResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataMissingResponse.test.ts
@@ -134,10 +134,10 @@ integrationTest(
 	},
 );
 
-integrationTest.only(
+integrationTest(
 	"Recover controller if callback times out after timed out SendData response",
 	{
-		debug: true,
+		// debug: true,
 
 		controllerCapabilities: controllerCapabilitiesNoBridge,
 

--- a/packages/zwave-js/src/lib/test/driver/setValueSupervision255Get.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueSupervision255Get.test.ts
@@ -10,9 +10,9 @@ import { CommandClasses, SupervisionStatus } from "@zwave-js/core";
 import {
 	type MockNodeBehavior,
 	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
 	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
-import { wait } from "alcalzone-shared/async";
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest(
@@ -141,8 +141,6 @@ integrationTest(
 				transitionDuration: "1s",
 			});
 
-			await wait(500);
-
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
 					frame.type === MockZWaveFrameType.Request
@@ -155,13 +153,12 @@ integrationTest(
 				},
 			);
 
-			await wait(1000);
-
-			mockNode.assertReceivedControllerFrame(
-				(frame) =>
+			await mockNode.expectControllerFrame(
+				(frame): frame is MockZWaveRequestFrame =>
 					frame.type === MockZWaveFrameType.Request
 					&& frame.payload instanceof MultilevelSwitchCCGet,
 				{
+					timeout: 1500,
 					errorMessage:
 						"Node should have received a MultilevelSwitchCCGet",
 				},

--- a/packages/zwave-js/src/lib/test/driver/transportService.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/transportService.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@zwave-js/cc";
 import {
 	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
 	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
@@ -63,12 +64,14 @@ integrationTest("Receiving Transport Service commands works (happy path)", {
 		await wait(30);
 		await mockNode.sendToController(createMockZWaveRequestFrame(frame3));
 
-		await wait(100);
-
 		// The node should have received the confirmation
-		mockNode.assertReceivedControllerFrame((f) =>
-			f.type === MockZWaveFrameType.Request
-			&& f.payload instanceof TransportServiceCCSegmentComplete
+		await mockNode.expectControllerFrame(
+			(f): f is MockZWaveRequestFrame =>
+				f.type === MockZWaveFrameType.Request
+				&& f.payload instanceof TransportServiceCCSegmentComplete,
+			{
+				timeout: 100,
+			},
 		);
 
 		// And the ConfigurationCCInfoReport should have been assembled correctly
@@ -124,12 +127,14 @@ integrationTest(
 				createMockZWaveRequestFrame(frame2),
 			);
 
-			await wait(50);
-
-			mockNode.assertReceivedControllerFrame((f) =>
-				f.type === MockZWaveFrameType.Request
-				&& f.payload instanceof TransportServiceCCSegmentWait
-				&& f.payload.pendingSegments === 0
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request
+					&& f.payload instanceof TransportServiceCCSegmentWait
+					&& f.payload.pendingSegments === 0,
+				{
+					timeout: 50,
+				},
 			);
 
 			mockNode.assertReceivedControllerFrame(
@@ -200,25 +205,29 @@ integrationTest(
 				createMockZWaveRequestFrame(frame3),
 			);
 
-			await wait(50);
-
 			// The node should have received a request for the missing frame
-			mockNode.assertReceivedControllerFrame((f) =>
-				f.type === MockZWaveFrameType.Request
-				&& f.payload instanceof TransportServiceCCSegmentRequest
-				&& f.payload.datagramOffset === part1.length
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request
+					&& f.payload instanceof TransportServiceCCSegmentRequest
+					&& f.payload.datagramOffset === part1.length,
+				{
+					timeout: 50,
+				},
 			);
 
 			// Send the requested frame
 			await mockNode.sendToController(
 				createMockZWaveRequestFrame(frame2),
 			);
-			await wait(50);
-
 			// Now, the node should have received the confirmation
-			mockNode.assertReceivedControllerFrame((f) =>
-				f.type === MockZWaveFrameType.Request
-				&& f.payload instanceof TransportServiceCCSegmentComplete
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request
+					&& f.payload instanceof TransportServiceCCSegmentComplete,
+				{
+					timeout: 50,
+				},
 			);
 
 			// And the ConfigurationCCInfoReport should have been assembled correctly
@@ -284,26 +293,31 @@ integrationTest(
 			await mockNode.sendToController(
 				createMockZWaveRequestFrame(frame2),
 			);
-			await wait(1000);
 			// Last segment is missing
 
 			// The node should have received a request for the missing frame
-			mockNode.assertReceivedControllerFrame((f) =>
-				f.type === MockZWaveFrameType.Request
-				&& f.payload instanceof TransportServiceCCSegmentRequest
-				&& f.payload.datagramOffset === frame3.datagramOffset
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request
+					&& f.payload instanceof TransportServiceCCSegmentRequest
+					&& f.payload.datagramOffset === frame3.datagramOffset,
+				{
+					timeout: 1000,
+				},
 			);
 
 			// Send the requested frame
 			await mockNode.sendToController(
 				createMockZWaveRequestFrame(frame3),
 			);
-			await wait(50);
-
 			// Now, the node should have received the confirmation
-			mockNode.assertReceivedControllerFrame((f) =>
-				f.type === MockZWaveFrameType.Request
-				&& f.payload instanceof TransportServiceCCSegmentComplete
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request
+					&& f.payload instanceof TransportServiceCCSegmentComplete,
+				{
+					timeout: 50,
+				},
 			);
 
 			// And the ConfigurationCCInfoReport should have been assembled correctly
@@ -374,12 +388,14 @@ integrationTest(
 				createMockZWaveRequestFrame(frame3),
 			);
 
-			await wait(100);
-
 			// The node should have received the confirmation
-			mockNode.assertReceivedControllerFrame((f) =>
-				f.type === MockZWaveFrameType.Request
-				&& f.payload instanceof TransportServiceCCSegmentComplete
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request
+					&& f.payload instanceof TransportServiceCCSegmentComplete,
+				{
+					timeout: 100,
+				},
 			);
 			mockNode.clearReceivedControllerFrames();
 
@@ -396,12 +412,14 @@ integrationTest(
 				createMockZWaveRequestFrame(frame3),
 			);
 
-			await wait(100);
-
 			// The node should have received the confirmation again
-			mockNode.assertReceivedControllerFrame((f) =>
-				f.type === MockZWaveFrameType.Request
-				&& f.payload instanceof TransportServiceCCSegmentComplete
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request
+					&& f.payload instanceof TransportServiceCCSegmentComplete,
+				{
+					timeout: 100,
+				},
 			);
 			mockNode.clearReceivedControllerFrames();
 		},
@@ -460,13 +478,15 @@ integrationTest(
 			// We must not send the last frame here, or the issue won't happen
 
 			// The controller should request the missing frame after a while
-			await wait(1100);
-
 			// The controller should request the missing frame
-			mockNode.assertReceivedControllerFrame((f) =>
-				f.type === MockZWaveFrameType.Request
-				&& f.payload instanceof TransportServiceCCSegmentRequest
-				&& f.payload.datagramOffset === part1.length
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
+					f.type === MockZWaveFrameType.Request
+					&& f.payload instanceof TransportServiceCCSegmentRequest
+					&& f.payload.datagramOffset === part1.length,
+				{
+					timeout: 1100,
+				},
 			);
 
 			// Send it

--- a/packages/zwave-js/src/lib/test/node/legacyRefreshActuatorSensorCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/node/legacyRefreshActuatorSensorCCs.test.ts
@@ -5,8 +5,11 @@ import {
 } from "@zwave-js/cc";
 import { CommandClasses } from "@zwave-js/core";
 import { ApplicationUpdateRequestNodeInfoReceived } from "@zwave-js/serial/serialapi";
-import { type MockNodeBehavior, MockZWaveFrameType } from "@zwave-js/testing";
-import { wait } from "alcalzone-shared/async";
+import {
+	type MockNodeBehavior,
+	MockZWaveFrameType,
+	type MockZWaveRequestFrame,
+} from "@zwave-js/testing";
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest(
@@ -77,12 +80,11 @@ integrationTest(
 			});
 			await mockController.sendMessageToHost(nif);
 
-			await wait(100);
-
-			mockNode.assertReceivedControllerFrame(
-				(f) =>
+			await mockNode.expectControllerFrame(
+				(f): f is MockZWaveRequestFrame =>
 					f.type === MockZWaveFrameType.Request
 					&& f.payload instanceof MultilevelSwitchCCGet,
+				{ timeout: 100 },
 			);
 		},
 	},


### PR DESCRIPTION
This should speed up some of the longer running tests where we wait for several hundred ms and then assert the reception of a frame. Instead, we now resolve the assertion immediately when it is fulfilled.