### PR TITLE
fix(config): add version conditionals and correct parameters for Enbrighten 55258

### DIFF
--- a/packages/config/config/devices/0x0063/55258_zw4002.json
+++ b/packages/config/config/devices/0x0063/55258_zw4002.json
@@ -33,6 +33,7 @@
 	"paramInformation": [
 		{
 			"#": "3",
+			"$if": "firmwareVersion >= 5.51",
 			"$import": "~/templates/master_template.json#led_indicator_four_options"
 		},
 		{
@@ -41,6 +42,7 @@
 		},
 		{
 			"#": "40",
+			"$if": "firmwareVersion >= 5.51",
 			"label": "Fan Speed Control",
 			"valueSize": 1,
 			"defaultValue": 0,
@@ -58,6 +60,7 @@
 		},
 		{
 			"#": "84",
+			"$if": "firmwareVersion >= 5.51",
 			"$import": "templates/jasco_template.json#factory_default"
 		}
 	],
@@ -68,6 +71,6 @@
 		"inclusion": "Press and release the top or bottom rocker.",
 		"exclusion": "Press and release the top or bottom rocker.",
 		"reset": "1. Quickly press the top button three times, then immediately press the bottom button three times. 2. The LED will flash on/off five times when completed successfully.",
-		"manual": "https://products.z-wavealliance.org/ProductManual/File?folder=&filename=product_documents/3928/55258%20QSG%20v1%20(5).pdf"
+		"manual": "https://products.z-wavealliance.org/wp-content/uploads/products/52589/55258%20QSG%20v1%20(5).pdf"
 	}
 }

--- a/packages/config/config/devices/0x0063/55258_zw4002.json
+++ b/packages/config/config/devices/0x0063/55258_zw4002.json
@@ -34,7 +34,8 @@
 		{
 			"#": "3",
 			"$if": "firmwareVersion >= 5.51",
-			"$import": "~/templates/master_template.json#led_indicator_four_options"
+			"$import": "~/templates/master_template.json#led_indicator_three_options_inverted",
+			"defaultValue": 1
 		},
 		{
 			"#": "4",

--- a/packages/config/config/devices/0x0063/55258_zw4002.json
+++ b/packages/config/config/devices/0x0063/55258_zw4002.json
@@ -42,6 +42,10 @@
 			"$import": "~/templates/master_template.json#orientation"
 		},
 		{
+			"#": "19",
+			"$import": "templates/jasco_template.json#alternate_exclusion_menu"
+		},
+		{
 			"#": "40",
 			"$if": "firmwareVersion >= 5.51",
 			"label": "Fan Speed Control",


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

1. Corrects #8357 to add conditionals on firmware version (@jascoproducts please correct me if I'm wrong here)
2. Fixes broken link to manual
3. I also believe the LED indicator template is incorrect, so I'll hold this as draft until that is confirmed
