### PR TITLE
chore: fix "author config file" copilot prompt

### DIFF
--- a/.github/prompts/author-config-from-web.prompt.md
+++ b/.github/prompts/author-config-from-web.prompt.md
@@ -1,7 +1,7 @@
 ---
 mode: 'agent'
-model: Claude Sonnet 4
-tools: ['createFile', 'createDirectory', 'editFiles', 'search', 'runTasks', 'usages', 'think', 'problems', 'changes', 'fetch', 'todos', 'zwave-dev']
+model: Claude Sonnet 4.5 (copilot)
+tools: ['edit/createFile', 'edit/createDirectory', 'edit/editFiles', 'search', 'runTasks', 'usages', 'think', 'problems', 'changes', 'fetch', 'todos', 'zwave-dev/*']
 description: 'Author Z-Wave JS configuration files based on scraped manufacturer website information'
 ---
 

--- a/packages/mcp-server-dev/package.json
+++ b/packages/mcp-server-dev/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "build": "tsc -b",
+    "bootstrap": "yarn build",
     "clean": "del-cli build/ *.tsbuildinfo",
     "lint:ts": "eslint --cache --cache-location .eslintcache/ -c ../../eslint.config.mjs src/**/*.ts",
     "lint:ts:fix": "yarn run lint:ts --fix"


### PR DESCRIPTION
The tool name definitions in VSCode were updated. This PR fixes that, uses a newer model and makes sure the MCP server is built during repo `bootstrap`.