### PR TITLE
feat(config): update parameters for Shelly Wave 1PM firmware 13.02 adn Wave 2PM firmware 16.02

### DIFF
--- a/packages/config/config/devices/0x0460/qnsw-001P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001P16.json
@@ -43,7 +43,7 @@
 		},
 		{
 			"#": "17",
-			"$import": "templates/wave_template.json#detached_mode",
+			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
 			"label": "O1: State After Power Failure"
 		},
 		{

--- a/packages/config/config/devices/0x0460/qnsw-001P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001P16.json
@@ -36,6 +36,12 @@
 			"label": "SW1 Switch Type"
 		},
 		{
+			"#": "7",
+			"$if": "firmwareVersion > 13.0",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Detach O1 Output"
+		},
+		{
 			"#": "17",
 			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
 			"label": "O1: State After Power Failure"
@@ -72,21 +78,25 @@
 		},
 		{
 			"#": "91",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Water"
 		},
 		{
 			"#": "92",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Smoke"
 		},
 		{
 			"#": "93",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: CO"
 		},
 		{
 			"#": "94",
+			"$if": "firmwareVersion < 13.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Heat"
 		},

--- a/packages/config/config/devices/0x0460/qnsw-001P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001P16.json
@@ -43,7 +43,7 @@
 		},
 		{
 			"#": "17",
-			"$import": "~/templates/master_template.json#state_after_power_failure_prev_off",
+			"$import": "templates/wave_template.json#detached_mode",
 			"label": "O1: State After Power Failure"
 		},
 		{

--- a/packages/config/config/devices/0x0460/qnsw-001P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-001P16.json
@@ -38,7 +38,7 @@
 		{
 			"#": "7",
 			"$if": "firmwareVersion > 13.0",
-			"$import": "~/templates/master_template.json#base_enable_disable",
+			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O1 Output"
 		},
 		{

--- a/packages/config/config/devices/0x0460/qnsw-002P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-002P16.json
@@ -76,7 +76,7 @@
 		},
 		{
 			"#": "6",
-			"$import": "templates/wave_template.json#swap_inputs"
+			"$import": "templates/wave_template.json#swap_inputs",
 			"label": "Inputs SW1 & SW2 Swap"
 		},
 		{
@@ -93,7 +93,7 @@
 		},
 		{
 			"#": "16",
-			"$import": "templates/wave_template.json#swap_outputs"
+			"$import": "templates/wave_template.json#swap_outputs",
 			"label": "Outputs O1 & O2 Swap"
 		},
 		{

--- a/packages/config/config/devices/0x0460/qnsw-002P16.json
+++ b/packages/config/config/devices/0x0460/qnsw-002P16.json
@@ -77,10 +77,24 @@
 		{
 			"#": "6",
 			"$import": "templates/wave_template.json#swap_inputs"
+			"label": "Inputs SW1 & SW2 Swap"
+		},
+		{
+			"#": "7",
+			"$if": "firmwareVersion > 12.0",
+			"$import": "templates/wave_template.json#detached_mode",
+			"label": "Detach O1 Output"
+		},
+		{
+			"#": "8",
+			"$if": "firmwareVersion > 12.0",
+			"$import": "templates/wave_template.json#detached_mode",
+			"label": "Detach O2 Output"
 		},
 		{
 			"#": "16",
 			"$import": "templates/wave_template.json#swap_outputs"
+			"label": "Outputs O1 & O2 Swap"
 		},
 		{
 			"#": "17",
@@ -154,23 +168,33 @@
 		},
 		{
 			"#": "91",
+			"$if": "firmwareVersion < 15.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Water"
 		},
 		{
 			"#": "92",
+			"$if": "firmwareVersion < 15.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Smoke"
 		},
 		{
 			"#": "93",
+			"$if": "firmwareVersion < 15.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: CO"
 		},
 		{
 			"#": "94",
+			"$if": "firmwareVersion < 15.0",
 			"$import": "templates/wave_template.json#alarm_configuration",
 			"label": "Alarm Configuration: Heat"
+		},
+		{
+			"#": "117",
+			"$if": "firmwareVersion > 16.0",
+			"$import": "templates/wave_template.json#remote_reboot",
+			"label": "Remote Reboot"
 		},
 		{
 			"#": "120",

--- a/packages/config/config/devices/0x0460/qpdm-0A1P01.json
+++ b/packages/config/config/devices/0x0460/qpdm-0A1P01.json
@@ -33,12 +33,12 @@
 		},
 		{
 			"#": "7",
-			"$import": "~/templates/master_template.json#base_enable_disable",
+			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O1 Output"
 		},
 		{
 			"#": "8",
-			"$import": "~/templates/master_template.json#base_enable_disable",
+			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O2 Output"
 		},
 		{

--- a/packages/config/config/devices/0x0460/qpdm-0A2P01.json
+++ b/packages/config/config/devices/0x0460/qpdm-0A2P01.json
@@ -52,22 +52,22 @@
 		},
 		{
 			"#": "7",
-			"$import": "~/templates/master_template.json#base_enable_disable",
+			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O1 Output"
 		},
 		{
 			"#": "8",
-			"$import": "~/templates/master_template.json#base_enable_disable",
+			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O2 Output"
 		},
 		{
 			"#": "9",
-			"$import": "~/templates/master_template.json#base_enable_disable",
+			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O3 Output"
 		},
 		{
 			"#": "10",
-			"$import": "~/templates/master_template.json#base_enable_disable",
+			"$import": "templates/wave_template.json#detached_mode",
 			"label": "Detach O4 Output"
 		},
 		{


### PR DESCRIPTION
With firmware 13.02 the Shelly Wave 1PM has the new parameter 7 (Detached Mode) and they removed parameters 91, 92, 93 and 94. In the proposed template the changes are implemented conditionally so it will work with older firmware versions correctly.

Details from Shelly can be found at https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/tree/main/Wave_1PM.

With firmware 15.0 the Shelly Wave 2PM has the new parameter 7 and 8 (Detached Mode) and they removed parameters 91, 92, 93 and 94. With firmware 16.02 parameter 117 is added.  In the proposed template the changes are implemented conditionally so it will work with older firmware versions correctly. Added missing labels for parameters 6 and 16.

Details from Shelly can be found at https://github.com/QubinoHelp/Shelly_Wave_FW_OTA/tree/main/Wave_2PM.

For Shelly Wave PRO Dimmer 1PM and Shelly Wave PRO Dimmer 2PM the import for Detached mode now uses the more accurate description from Shelly's template/wave_template.json