### PR TITLE
test: simplify using encrypted communication in mock-based tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
 	"editor.formatOnSave": false, // the default of true interferes with codeActionsOnSave
 	"editor.codeActionsOnSave": [
 		"source.fixAll.eslint",
+		"source.fixAll.oxc",
 		"source.formatDocument"
 	],
 	"eslint.codeActionsOnSave.mode": "problems",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -67,6 +67,8 @@ export default tseslint.config(
 		rules: {
 			// Prevent debug logging in checked in tests
 			"@zwave-js/no-debug-in-tests": "error",
+			// Ensure consistent nodeId usage in MockNodeBehavior
+			"@zwave-js/consistent-mock-node-behaviors": "error",
 		},
 	},
 	{
@@ -92,6 +94,13 @@ export default tseslint.config(
 		files: ["packages/cc/src/**"],
 		rules: {
 			"@zwave-js/consistent-cc-classes": "error",
+		},
+	},
+	// Enable consistent mock node behaviors for mock CC behaviors
+	{
+		files: ["packages/zwave-js/src/lib/node/mockCCBehaviors/**/*.ts"],
+		rules: {
+			"@zwave-js/consistent-mock-node-behaviors": "error",
 		},
 	},
 	// {

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -241,16 +241,19 @@ async function decryptSinglecast(
 		);
 
 		const iv = nonce;
+
+		const ret = await decryptAES128CCM(
+			ciphertext,
+			key,
+			iv,
+			authData,
+			authTag,
+		);
+
 		return {
 			key,
 			iv,
-			...(await decryptAES128CCM(
-				ciphertext,
-				key,
-				iv,
-				authData,
-				authTag,
-			)),
+			...ret,
 		};
 	};
 	const getNonceAndDecrypt = async () => {

--- a/packages/cc/src/cc/Security2CC.ts
+++ b/packages/cc/src/cc/Security2CC.ts
@@ -1814,6 +1814,7 @@ export class Security2CCMessageEncapsulation extends Security2CC {
 		const spanState = securityManager.getSPANState(
 			receiverNodeId,
 		);
+
 		if (
 			spanState.type === SPANState.None
 			|| spanState.type === SPANState.LocalEI

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -4,6 +4,7 @@ import { consistentCCClasses } from "./rules/consistent-cc-classes.js";
 import { consistentConfigStringCase } from "./rules/consistent-config-string-case.js";
 import { consistentDeviceConfigPropertyOrder } from "./rules/consistent-device-config-property-order.js";
 import { consistentImportDeclarations } from "./rules/consistent-import-declarations.js";
+import { consistentMockNodeBehaviors } from "./rules/consistent-mock-node-behaviors.js";
 import { consistentParamUnits } from "./rules/consistent-param-units.js";
 import { noDebugInTests } from "./rules/no-debug-in-tests.js";
 import { noForbiddenImports } from "./rules/no-forbidden-imports.js";
@@ -24,6 +25,7 @@ export default {
 		"consistent-device-config-property-order":
 			consistentDeviceConfigPropertyOrder,
 		"consistent-import-declarations": consistentImportDeclarations,
+		"consistent-mock-node-behaviors": consistentMockNodeBehaviors,
 		"consistent-param-units": consistentParamUnits,
 		"no-debug-in-tests": noDebugInTests,
 		"no-forbidden-imports": noForbiddenImports,

--- a/packages/eslint-plugin/src/rules/consistent-mock-node-behaviors.ts
+++ b/packages/eslint-plugin/src/rules/consistent-mock-node-behaviors.ts
@@ -1,0 +1,353 @@
+import {
+	AST_NODE_TYPES,
+	ESLintUtils,
+	type TSESTree,
+} from "@typescript-eslint/utils";
+
+export const consistentMockNodeBehaviors = ESLintUtils.RuleCreator.withoutDocs({
+	create(context) {
+		const services = ESLintUtils.getParserServices(context);
+		const checker = services.program.getTypeChecker();
+
+		/**
+		 * Check if a type annotation references a specific type name
+		 */
+		function hasTypeName(
+			typeAnnotation: TSESTree.TypeNode | undefined,
+			typeName: string,
+		): boolean {
+			if (!typeAnnotation) return false;
+
+			if (
+				typeAnnotation.type === AST_NODE_TYPES.TSTypeReference
+				&& typeAnnotation.typeName.type === AST_NODE_TYPES.Identifier
+				&& typeAnnotation.typeName.name === typeName
+			) {
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Check if a type annotation references MockNodeBehavior
+		 */
+		function isMockNodeBehaviorType(
+			typeAnnotation: TSESTree.TypeNode | undefined,
+		): boolean {
+			return hasTypeName(typeAnnotation, "MockNodeBehavior");
+		}
+
+		/**
+		 * Check if a return type annotation references MockNodeResponse or Promise<MockNodeResponse>
+		 */
+		function isMockNodeResponseReturnType(
+			returnType: TSESTree.TypeNode | undefined,
+		): boolean {
+			if (!returnType) return false;
+
+			// Direct MockNodeResponse
+			if (hasTypeName(returnType, "MockNodeResponse")) {
+				return true;
+			}
+
+			// Promise<MockNodeResponse>
+			if (
+				returnType.type === AST_NODE_TYPES.TSTypeReference
+				&& returnType.typeName.type === AST_NODE_TYPES.Identifier
+				&& returnType.typeName.name === "Promise"
+				&& returnType.typeArguments?.params.length === 1
+			) {
+				const typeArg = returnType.typeArguments.params[0];
+				if (hasTypeName(typeArg, "MockNodeResponse")) {
+					return true;
+				}
+			}
+
+			// Union types that include MockNodeResponse (e.g., MockNodeResponse | undefined)
+			if (returnType.type === AST_NODE_TYPES.TSUnionType) {
+				return returnType.types.some((t) =>
+					isMockNodeResponseReturnType(t)
+				);
+			}
+
+			return false;
+		}
+
+		/**
+		 * Get the parameter name for a given type in a function
+		 */
+		function getParamNameForType(
+			func:
+				| TSESTree.FunctionExpression
+				| TSESTree.ArrowFunctionExpression,
+			typeName: string,
+		): string | undefined {
+			for (const param of func.params) {
+				if (param.type !== AST_NODE_TYPES.Identifier) continue;
+
+				// Check explicit type annotation first
+				if (
+					param.typeAnnotation
+					&& hasTypeName(
+						param.typeAnnotation.typeAnnotation,
+						typeName,
+					)
+				) {
+					return param.name;
+				}
+
+				// Use TypeScript type checker to get inferred type
+				const tsNode = services.esTreeNodeToTSNodeMap.get(param);
+				const type = checker.getTypeAtLocation(tsNode);
+				const typeStr = checker.typeToString(type);
+
+				// Check if the type string matches the type name we're looking for
+				if (typeStr === typeName || typeStr.includes(typeName)) {
+					return param.name;
+				}
+			}
+			return undefined;
+		}
+
+		/**
+		 * Check if a function is inside a transformResponse method
+		 */
+		function isInTransformResponse(
+			func:
+				| TSESTree.FunctionExpression
+				| TSESTree.ArrowFunctionExpression,
+		): boolean {
+			// Check if function is a property value
+			const parent = func.parent;
+			if (parent?.type === AST_NODE_TYPES.Property) {
+				if (
+					parent.key.type === AST_NODE_TYPES.Identifier
+					&& parent.key.name === "transformResponse"
+				) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/**
+		 * Check if a function is a MockNodeBehavior method or returns MockNodeResponse
+		 */
+		function shouldCheckFunction(
+			node:
+				| TSESTree.FunctionExpression
+				| TSESTree.ArrowFunctionExpression,
+			parent: TSESTree.Node | undefined,
+		): boolean {
+			// Check if function has a return type annotation for MockNodeResponse
+			if (
+				node.returnType
+				&& isMockNodeResponseReturnType(node.returnType.typeAnnotation)
+			) {
+				return true;
+			}
+
+			// Check if function is a property of a MockNodeBehavior object
+			if (
+				parent?.type === AST_NODE_TYPES.Property
+				&& parent.value === node
+			) {
+				const objectParent = parent.parent;
+				if (objectParent?.type === AST_NODE_TYPES.ObjectExpression) {
+					// Check if object has MockNodeBehavior type
+					const objectGrandParent = objectParent.parent;
+					if (
+						objectGrandParent?.type
+							=== AST_NODE_TYPES.VariableDeclarator
+						&& objectGrandParent.id.type
+							=== AST_NODE_TYPES.Identifier
+						&& objectGrandParent.id.typeAnnotation
+						&& isMockNodeBehaviorType(
+							objectGrandParent.id.typeAnnotation.typeAnnotation,
+						)
+					) {
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		/**
+		 * Check if a NewExpression is for a CC class (contains "CC" in the name)
+		 */
+		function isCCConstructor(node: TSESTree.NewExpression): boolean {
+			if (node.callee.type === AST_NODE_TYPES.Identifier) {
+				return node.callee.name.includes("CC");
+			}
+			return false;
+		}
+
+		/**
+		 * Find nodeId property in constructor arguments and check its value
+		 */
+		function checkConstructorNodeId(
+			node: TSESTree.NewExpression,
+			containingFunc:
+				| TSESTree.FunctionExpression
+				| TSESTree.ArrowFunctionExpression,
+		): void {
+			if (node.arguments.length === 0) return;
+
+			const firstArg = node.arguments[0];
+			if (firstArg.type !== AST_NODE_TYPES.ObjectExpression) return;
+
+			const nodeIdProp = firstArg.properties.find(
+				(prop): prop is TSESTree.Property =>
+					prop.type === AST_NODE_TYPES.Property
+					&& prop.key.type === AST_NODE_TYPES.Identifier
+					&& prop.key.name === "nodeId",
+			);
+
+			if (!nodeIdProp) return;
+
+			const { value } = nodeIdProp;
+
+			// Get the actual parameter names from the function
+			const controllerParamName = getParamNameForType(
+				containingFunc,
+				"MockController",
+			);
+			const responseParamName = getParamNameForType(
+				containingFunc,
+				"MockNodeResponse",
+			);
+
+			const inTransformResponse = isInTransformResponse(containingFunc);
+
+			// In transformResponse, the correct pattern is <responseParam>.cc.nodeId
+			if (inTransformResponse) {
+				// Check if the value is <responseParam>.cc.nodeId
+				if (
+					responseParamName
+					&& value.type === AST_NODE_TYPES.MemberExpression
+					&& value.object.type === AST_NODE_TYPES.MemberExpression
+					&& value.object.object.type === AST_NODE_TYPES.Identifier
+					&& value.object.object.name === responseParamName
+					&& value.object.property.type === AST_NODE_TYPES.Identifier
+					&& value.object.property.name === "cc"
+					&& value.property.type === AST_NODE_TYPES.Identifier
+					&& value.property.name === "nodeId"
+				) {
+					// Correct usage in transformResponse
+					return;
+				}
+
+				// Any other value in transformResponse is incorrect
+				const fixValue = responseParamName
+					? `${responseParamName}.cc.nodeId`
+					: "response.cc.nodeId";
+
+				context.report({
+					node: value,
+					messageId: "incorrect-node-id-transform",
+					data: {
+						correctValue: fixValue,
+					},
+					fix(fixer) {
+						return fixer.replaceText(value, fixValue);
+					},
+				});
+				return;
+			}
+
+			// In other functions (handleCC, etc.), the correct pattern is <controllerParam>.ownNodeId
+			if (
+				controllerParamName
+				&& value.type === AST_NODE_TYPES.MemberExpression
+				&& value.object.type === AST_NODE_TYPES.Identifier
+				&& value.object.name === controllerParamName
+				&& value.property.type === AST_NODE_TYPES.Identifier
+				&& value.property.name === "ownNodeId"
+			) {
+				// Correct usage
+				return;
+			}
+
+			// Any other value is incorrect
+			const fixValue = controllerParamName
+				? `${controllerParamName}.ownNodeId`
+				: "controller.ownNodeId";
+
+			context.report({
+				node: value,
+				messageId: "incorrect-node-id",
+				data: {
+					correctValue: fixValue,
+				},
+				fix(fixer) {
+					return fixer.replaceText(value, fixValue);
+				},
+			});
+		}
+
+		// Track which functions we should check
+		const functionsToCheck = new Set<
+			TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression
+		>();
+
+		return {
+			FunctionExpression(node) {
+				if (shouldCheckFunction(node, node.parent)) {
+					functionsToCheck.add(node);
+				}
+			},
+			ArrowFunctionExpression(node) {
+				if (shouldCheckFunction(node, node.parent)) {
+					functionsToCheck.add(node);
+				}
+			},
+			NewExpression(node) {
+				// Check if we're inside a function we should check
+				let parent: TSESTree.Node | undefined = node.parent;
+				let containingFunction:
+					| TSESTree.FunctionExpression
+					| TSESTree.ArrowFunctionExpression
+					| undefined;
+
+				while (parent) {
+					if (
+						(parent.type === AST_NODE_TYPES.FunctionExpression
+							|| parent.type
+								=== AST_NODE_TYPES.ArrowFunctionExpression)
+						&& functionsToCheck.has(parent)
+					) {
+						containingFunction = parent;
+						break;
+					}
+					parent = parent.parent;
+				}
+
+				if (!containingFunction) return;
+
+				// Check if this is a CC constructor
+				if (isCCConstructor(node)) {
+					checkConstructorNodeId(node, containingFunction);
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			description:
+				"Ensures that CC constructors in MockNodeBehavior functions use the correct nodeId value.",
+		},
+		type: "problem",
+		schema: [],
+		fixable: "code",
+		messages: {
+			"incorrect-node-id":
+				"Use `{{correctValue}}` as the target node ID in MockNodeBehavior.handleCC methods.",
+			"incorrect-node-id-transform":
+				"Use `{{correctValue}}` as the target node ID in MockNodeBehavior.transformResponse methods.",
+		},
+	},
+	defaultOptions: [],
+});

--- a/packages/testing/src/MockController.ts
+++ b/packages/testing/src/MockController.ts
@@ -31,7 +31,7 @@ import {
 	type MockControllerCapabilities,
 	getDefaultMockControllerCapabilities,
 } from "./MockControllerCapabilities.js";
-import type { MockNode, MockNodeOptions } from "./MockNode.js";
+import type { MockNode, NodePendingInclusion } from "./MockNode.js";
 import {
 	type LazyMockZWaveFrame,
 	MOCK_FRAME_ACK_TIMEOUT,
@@ -152,7 +152,9 @@ export class MockController {
 			requestStorage,
 		};
 
-		void this.execute();
+		void this.execute().catch((e) => {
+			console.error(e);
+		});
 	}
 
 	private _options: MockControllerOptions;
@@ -268,12 +270,7 @@ export class MockController {
 	public readonly state = new Map<string, unknown>();
 
 	/** Node info for the node that is pending inclusion. Set this before starting inclusion to simulate a node joining. */
-	public nodePendingInclusion:
-		| (Omit<MockNodeOptions, "controller"> & {
-			/** Optional callback that is called when the node is created during inclusion */
-			setup?: (node: MockNode) => void;
-		})
-		| undefined;
+	public nodePendingInclusion: NodePendingInclusion | undefined;
 
 	/** Controls whether the controller automatically ACKs messages from the host before handling them */
 	public autoAckHostMessages: boolean = true;
@@ -350,6 +347,8 @@ export class MockController {
 				this.ackHostMessage();
 			}
 		} catch (e: any) {
+			// oxlint-disable-next-line no-debugger
+			debugger;
 			throw new Error(
 				`Mock controller received an invalid message from the host: ${e.stack}`,
 			);

--- a/packages/testing/src/MockNode.ts
+++ b/packages/testing/src/MockNode.ts
@@ -123,7 +123,8 @@ export class MockNode {
 		) {
 			securityManager = new SecurityManager({
 				ownNodeId: this.id,
-				networkKey: options.controller.securityManagers.securityManager.networkKey,
+				networkKey: options.controller.securityManagers.securityManager
+					.networkKey,
 				// Use a high nonce timeout to allow debugging tests more easily
 				nonceTimeout: 100000,
 			});
@@ -175,7 +176,7 @@ export class MockNode {
 				}),
 			);
 		}
-		
+
 		const self = this;
 		this.encodingContext = {
 			homeId: this.controller.homeId,

--- a/packages/testing/src/MockNodeCapabilities.ts
+++ b/packages/testing/src/MockNodeCapabilities.ts
@@ -4,6 +4,7 @@ import {
 	type CommandClasses,
 	type NodeProtocolInfoAndDeviceClass,
 	NodeType,
+	type SecurityClass,
 } from "@zwave-js/core";
 import type { CCIdToCapabilities } from "./CCSpecificCapabilities.js";
 
@@ -30,6 +31,8 @@ export interface MockNodeCapabilities extends NodeProtocolInfoAndDeviceClass {
 
 	/** How long it takes to send a command to or from the node */
 	txDelay: number;
+
+	securityClasses: Set<SecurityClass>;
 }
 
 export interface MockEndpointCapabilities {
@@ -58,6 +61,9 @@ export function getDefaultMockNodeCapabilities(): MockNodeCapabilities {
 		specificDeviceClass: 0x01, // General Appliance
 
 		txDelay: 10,
+
+		// No security by default
+		securityClasses: new Set(),
 	};
 }
 

--- a/packages/testing/src/MockZWaveFrame.ts
+++ b/packages/testing/src/MockZWaveFrame.ts
@@ -43,9 +43,13 @@ export enum MockZWaveFrameType {
 	ACK,
 }
 
+export type CreateMockZWaveRequestFrameOptions = Partial<
+	Omit<MockZWaveRequestFrame, "direction" | "payload">
+>;
+
 export function createMockZWaveRequestFrame(
 	payload: CommandClass | (() => Promise<CommandClass>),
-	options: Partial<Omit<MockZWaveRequestFrame, "direction" | "payload">> = {},
+	options: CreateMockZWaveRequestFrameOptions = {},
 ): LazyMockZWaveRequestFrame {
 	const { repeaters = [], ackRequested = true } = options;
 	return {

--- a/packages/zwave-js/src/lib/controller/Controller.nodes.getOrThrow.test.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.nodes.getOrThrow.test.ts
@@ -23,8 +23,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				loadConfiguration: false,
 				skipNodeInterview: true,
-				beforeStartup(mockPort, serial) {
-					context.controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					context.controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -969,7 +969,7 @@ const handleAddNode: MockControllerBehavior = {
 				if (controller.nodePendingInclusion) {
 					const { setup: testSpecificSetup, ...nodeOptions } =
 						controller.nodePendingInclusion;
-					const node = new MockNode({
+					const node = await MockNode.create({
 						controller,
 						...nodeOptions,
 					});

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -967,7 +967,7 @@ const handleAddNode: MockControllerBehavior = {
 				// If there's a node pending inclusion, simulate the inclusion sequence
 				// after responding to the add request
 				if (controller.nodePendingInclusion) {
-					const { setup, ...nodeOptions } =
+					const { setup: testSpecificSetup, ...nodeOptions } =
 						controller.nodePendingInclusion;
 					const node = new MockNode({
 						controller,
@@ -976,7 +976,7 @@ const handleAddNode: MockControllerBehavior = {
 					// Apply default behaviors that are required for interacting with the driver correctly
 					node.defineBehavior(...createDefaultMockNodeBehaviors());
 					// Allow the tests to set up additional behavior before inclusion happens
-					setup?.(node);
+					testSpecificSetup?.(node);
 
 					const supportedCCs = [...node.implementedCCs]
 						.filter(([, info]) =>

--- a/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
+++ b/packages/zwave-js/src/lib/controller/MockControllerBehaviors.ts
@@ -310,8 +310,9 @@ const handleSendData: MockControllerBehavior = {
 				node,
 				msg,
 			);
+			const ackRequested = !!(msg.transmitOptions & TransmitOptions.ACK);
 			const lazyFrame = createMockZWaveRequestFrame(lazyPayload, {
-				ackRequested: !!(msg.transmitOptions & TransmitOptions.ACK),
+				ackRequested,
 			});
 			const ackPromise = controller.sendToNode(node, lazyFrame);
 
@@ -322,23 +323,27 @@ const handleSendData: MockControllerBehavior = {
 					MockControllerCommunicationState.WaitingForNode,
 				);
 
-				// Wait for the ACK and notify the host
-				let ack = false;
-				try {
-					const ackResult = await ackPromise;
-					ack = !!ackResult?.ack;
-				} catch (e) {
-					// We want to know when we're using a command in tests that cannot be decoded yet
-					if (
-						isZWaveError(e)
-						&& e.code
-							=== ZWaveErrorCodes.Deserialization_NotImplemented
-					) {
-						console.error(e.message);
-						throw e;
-					}
+				// If an ACK is requested, wait for the ACK and notify the host
+				let ack = true;
+				if (ackRequested) {
+					try {
+						const ackResult = await ackPromise;
+						ack = !!ackResult?.ack;
+					} catch (e) {
+						// We want to know when we're using a command in tests that cannot be decoded yet
+						if (
+							isZWaveError(e)
+							&& e.code
+								=== ZWaveErrorCodes
+									.Deserialization_NotImplemented
+						) {
+							console.error(e.message);
+							throw e;
+						}
 
-					// Treat all other errors as no response
+						// Treat all other errors as no response
+						ack = false;
+					}
 				}
 				controller.state.set(
 					MockControllerStateKeys.CommunicationState,
@@ -398,6 +403,7 @@ const handleSendDataMulticast: MockControllerBehavior = {
 			// so CC knows it came from the controller's node ID.
 			const nodeIds = msg.nodeIds;
 
+			const ackRequested = !!(msg.transmitOptions & TransmitOptions.ACK);
 			const ackPromises = nodeIds.map((nodeId) => {
 				const node = controller.nodes.get(nodeId)!;
 				// Create a lazy frame, so it can be deserialized on the node after a short delay to simulate radio transmission
@@ -407,7 +413,7 @@ const handleSendDataMulticast: MockControllerBehavior = {
 					msg,
 				);
 				const lazyFrame = createMockZWaveRequestFrame(lazyPayload, {
-					ackRequested: !!(msg.transmitOptions & TransmitOptions.ACK),
+					ackRequested,
 				});
 				const ackPromise = controller.sendToNode(node, lazyFrame);
 				return ackPromise;
@@ -420,23 +426,27 @@ const handleSendDataMulticast: MockControllerBehavior = {
 					MockControllerCommunicationState.WaitingForNode,
 				);
 
-				// Wait for the ACKs and notify the host
-				let ack = false;
-				try {
-					const ackResults = await Promise.all(ackPromises);
-					ack = ackResults.every((result) => !!result?.ack);
-				} catch (e) {
-					// We want to know when we're using a command in tests that cannot be decoded yet
-					if (
-						isZWaveError(e)
-						&& e.code
-							=== ZWaveErrorCodes.Deserialization_NotImplemented
-					) {
-						console.error(e.message);
-						throw e;
-					}
+				// If an ACK is requested, wait for the ACKs and notify the host
+				let ack = true;
+				if (ackRequested) {
+					try {
+						const ackResults = await Promise.all(ackPromises);
+						ack = ackResults.every((result) => !!result?.ack);
+					} catch (e) {
+						// We want to know when we're using a command in tests that cannot be decoded yet
+						if (
+							isZWaveError(e)
+							&& e.code
+								=== ZWaveErrorCodes
+									.Deserialization_NotImplemented
+						) {
+							console.error(e.message);
+							throw e;
+						}
 
-					// Treat all other errors as no response
+						// Treat all other errors as no response
+						ack = false;
+					}
 				}
 				controller.state.set(
 					MockControllerStateKeys.CommunicationState,
@@ -501,8 +511,9 @@ const handleSendDataBridge: MockControllerBehavior = {
 				node,
 				msg,
 			);
+			const ackRequested = !!(msg.transmitOptions & TransmitOptions.ACK);
 			const lazyFrame = createMockZWaveRequestFrame(lazyPayload, {
-				ackRequested: !!(msg.transmitOptions & TransmitOptions.ACK),
+				ackRequested,
 			});
 			const ackPromise = controller.sendToNode(node, lazyFrame);
 
@@ -513,23 +524,27 @@ const handleSendDataBridge: MockControllerBehavior = {
 					MockControllerCommunicationState.WaitingForNode,
 				);
 
-				// Wait for the ACK and notify the host
-				let ack = false;
-				try {
-					const ackResult = await ackPromise;
-					ack = !!ackResult?.ack;
-				} catch (e) {
-					// We want to know when we're using a command in tests that cannot be decoded yet
-					if (
-						isZWaveError(e)
-						&& e.code
-							=== ZWaveErrorCodes.Deserialization_NotImplemented
-					) {
-						console.error(e.message);
-						throw e;
-					}
+				// If an ACK is requested, wait for the ACK and notify the host
+				let ack = true;
+				if (ackRequested) {
+					try {
+						const ackResult = await ackPromise;
+						ack = !!ackResult?.ack;
+					} catch (e) {
+						// We want to know when we're using a command in tests that cannot be decoded yet
+						if (
+							isZWaveError(e)
+							&& e.code
+								=== ZWaveErrorCodes
+									.Deserialization_NotImplemented
+						) {
+							console.error(e.message);
+							throw e;
+						}
 
-					// Treat all other errors as no response
+						// Treat all other errors as no response
+						ack = false;
+					}
 				}
 				controller.state.set(
 					MockControllerStateKeys.CommunicationState,
@@ -589,6 +604,7 @@ const handleSendDataMulticastBridge: MockControllerBehavior = {
 			// so CC knows it came from the controller's node ID.
 			const nodeIds = msg.nodeIds;
 
+			const ackRequested = !!(msg.transmitOptions & TransmitOptions.ACK);
 			const ackPromises = nodeIds.map((nodeId) => {
 				const node = controller.nodes.get(nodeId)!;
 				// Create a lazy frame, so it can be deserialized on the node after a short delay to simulate radio transmission
@@ -598,7 +614,7 @@ const handleSendDataMulticastBridge: MockControllerBehavior = {
 					msg,
 				);
 				const lazyFrame = createMockZWaveRequestFrame(lazyPayload, {
-					ackRequested: !!(msg.transmitOptions & TransmitOptions.ACK),
+					ackRequested,
 				});
 				const ackPromise = controller.sendToNode(node, lazyFrame);
 				return ackPromise;
@@ -611,23 +627,27 @@ const handleSendDataMulticastBridge: MockControllerBehavior = {
 					MockControllerCommunicationState.WaitingForNode,
 				);
 
-				// Wait for the ACKs and notify the host
-				let ack = false;
-				try {
-					const ackResults = await Promise.all(ackPromises);
-					ack = ackResults.every((result) => !!result?.ack);
-				} catch (e) {
-					// We want to know when we're using a command in tests that cannot be decoded yet
-					if (
-						isZWaveError(e)
-						&& e.code
-							=== ZWaveErrorCodes.Deserialization_NotImplemented
-					) {
-						console.error(e.message);
-						throw e;
-					}
+				// If an ACK is requested, wait for the ACKs and notify the host
+				let ack = true;
+				if (ackRequested) {
+					try {
+						const ackResults = await Promise.all(ackPromises);
+						ack = ackResults.every((result) => !!result?.ack);
+					} catch (e) {
+						// We want to know when we're using a command in tests that cannot be decoded yet
+						if (
+							isZWaveError(e)
+							&& e.code
+								=== ZWaveErrorCodes
+									.Deserialization_NotImplemented
+						) {
+							console.error(e.message);
+							throw e;
+						}
 
-					// Treat all other errors as no response
+						// Treat all other errors as no response
+						ack = false;
+					}
 				}
 				controller.state.set(
 					MockControllerStateKeys.CommunicationState,

--- a/packages/zwave-js/src/lib/node/Endpoint.test.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.test.ts
@@ -30,8 +30,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -36,6 +36,10 @@ import {
 	SecurityCCBehaviors,
 	SecurityCCHooks,
 } from "./mockCCBehaviors/Security.js";
+import {
+	Security2CCBehaviors,
+	Security2CCHooks,
+} from "./mockCCBehaviors/Security2.js";
 import { SoundSwitchCCBehaviors } from "./mockCCBehaviors/SoundSwitch.js";
 import { ThermostatModeCCBehaviors } from "./mockCCBehaviors/ThermostatMode.js";
 import { ThermostatSetbackCCBehaviors } from "./mockCCBehaviors/ThermostatSetback.js";
@@ -90,7 +94,7 @@ const respondToVersionCCCommandClassGet: MockNodeBehavior = {
 			}
 
 			const cc = new VersionCCCommandClassReport({
-				nodeId: self.id,
+				nodeId: controller.ownNodeId,
 				endpointIndex: "index" in endpoint ? endpoint.index : undefined,
 				requestedCC: receivedCC.requestedCC,
 				ccVersion: version,
@@ -155,6 +159,8 @@ export function createDefaultBehaviors(): MockNodeBehavior[] {
 
 		...SecurityCCHooks,
 		...SecurityCCBehaviors,
+		...Security2CCHooks,
+		...Security2CCBehaviors,
 
 		...MultiChannelCCHooks,
 		...MultiChannelCCBehaviors,

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -120,7 +120,6 @@ const respondToZWavePlusCCGet: MockNodeBehavior = {
 	},
 };
 
-
 const respondToS2ZWavePlusCCGet: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
 		if (

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/ManufacturerSpecific.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/ManufacturerSpecific.ts
@@ -8,7 +8,7 @@ const respondToManufacturerSpecificGet: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
 		if (receivedCC instanceof ManufacturerSpecificCCGet) {
 			const cc = new ManufacturerSpecificCCReport({
-				nodeId: self.id,
+				nodeId: controller.ownNodeId,
 				manufacturerId: self.capabilities.manufacturerId,
 				productType: self.capabilities.productType,
 				productId: self.capabilities.productId,

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/MultiChannel.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/MultiChannel.ts
@@ -141,7 +141,7 @@ const respondToMultiChannelCCV1Get: MockNodeBehavior = {
 			const endpointCount = Math.max(0, ...supportedEndpointIndizes);
 
 			const cc = new MultiChannelCCV1Report({
-				nodeId: self.id,
+				nodeId: controller.ownNodeId,
 				requestedCC,
 				endpointCount,
 			});

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Security.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Security.ts
@@ -105,7 +105,7 @@ const respondToS0CommandsSupportedGet: MockNodeBehavior = {
 	},
 };
 
-// Parse and unwrap Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
+// Parse and unwrap Security CC commands.
 const encapsulateS0CC: MockNodeBehavior = {
 	async transformIncomingCC(controller, self, receivedCC) {
 		// We don't support sequenced commands here

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Security.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Security.ts
@@ -137,7 +137,7 @@ const encapsulateS0CC: MockNodeBehavior = {
 			// encapsulating commands, so we have to do it ourselves here.
 			// This requires a nonce exchange.
 			const nonceGet = new SecurityCCNonceGet({
-				nodeId: controller.ownNodeId,
+				nodeId: response.cc.nodeId,
 			});
 			await self.sendToController(
 				createMockZWaveRequestFrame(nonceGet, {

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Security.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Security.ts
@@ -1,0 +1,184 @@
+import {
+	CommandClass,
+	SecurityCC,
+	SecurityCCCommandEncapsulation,
+	SecurityCCCommandsSupportedGet,
+	SecurityCCCommandsSupportedReport,
+	SecurityCCNetworkKeySet,
+	SecurityCCNetworkKeyVerify,
+	SecurityCCNonceGet,
+	SecurityCCNonceReport,
+	SecurityCCSchemeGet,
+	SecurityCCSchemeReport,
+} from "@zwave-js/cc";
+import {
+	CommandClasses,
+	SecurityManager,
+	isEncapsulationCC,
+} from "@zwave-js/core";
+import {
+	type MockNodeBehavior,
+	type MockZWaveFrame,
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+
+// Respond to Scheme Get with Scheme Report
+const respondToSchemeGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof SecurityCCSchemeGet) {
+			// This essentially means that the device is going to be bootstrapped
+			// with Security S0. We need to set up the security manager accordingly
+			// with the temporary key.
+			const tempKey = new Uint8Array(16).fill(0x00);
+			self.securityManagers.securityManager = new SecurityManager({
+				ownNodeId: self.id,
+				networkKey: tempKey,
+				nonceTimeout: 100000,
+			});
+
+			// Now respond to the Scheme Get
+			const cc = new SecurityCCSchemeReport({
+				nodeId: controller.ownNodeId,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+// Respond to S0 Nonce Get
+const respondToS0NonceGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		const sm0Node = self.securityManagers.securityManager;
+		if (!sm0Node) return;
+
+		if (receivedCC instanceof SecurityCCNonceGet) {
+			const nonce = sm0Node.generateNonce(controller.ownNodeId, 8);
+			const cc = new SecurityCCNonceReport({
+				nodeId: controller.ownNodeId,
+				nonce,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+// Respond to Network Key Set with Network Key Verify
+const respondToNetworkKeySet: MockNodeBehavior = {
+	async handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof SecurityCCNetworkKeySet) {
+			// Update the node's security manager to use the received network key
+			const receivedKey = receivedCC.networkKey;
+			self.securityManagers.securityManager!.networkKey = receivedKey;
+
+			const response = new SecurityCCNetworkKeyVerify({
+				nodeId: controller.ownNodeId,
+			});
+
+			return { action: "sendCC", cc: response };
+		}
+	},
+};
+
+// Respond to S0 Commands Supported Get
+const respondToS0CommandsSupportedGet: MockNodeBehavior = {
+	async handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof SecurityCCCommandsSupportedGet) {
+			// Determine securely supported CCs from the mock node's implementedCCs
+			const supportedCCs = [...self.implementedCCs.entries()]
+				.filter(
+					([cc, info]) =>
+						info.secure === true
+						&& !isEncapsulationCC(cc),
+				)
+				.map(([cc]) => cc);
+
+			const response = new SecurityCCCommandsSupportedReport({
+				nodeId: controller.ownNodeId,
+				supportedCCs,
+				controlledCCs: [],
+				reportsToFollow: 0,
+			});
+
+			return { action: "sendCC", cc: response };
+		}
+	},
+};
+
+// Parse and unwrap Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
+const encapsulateS0CC: MockNodeBehavior = {
+	async transformIncomingCC(controller, self, receivedCC) {
+		// We don't support sequenced commands here
+		if (receivedCC instanceof SecurityCCCommandEncapsulation) {
+			await receivedCC.mergePartialCCs([], {
+				sourceNodeId: controller.ownNodeId,
+				__internalIsMockNode: true,
+				frameType: "singlecast",
+				...self.encodingContext,
+				...self.securityManagers,
+			});
+			// Return the unwrapped command
+			if (receivedCC.encapsulated) {
+				return receivedCC.encapsulated;
+			}
+		}
+		return receivedCC;
+	},
+
+	async transformResponse(controller, self, receivedCC, response) {
+		// Ensure that responses to S0-encapsulated CCs are also S0-encapsulated
+		if (
+			response.action === "sendCC"
+			&& receivedCC instanceof CommandClass
+			&& receivedCC.isEncapsulatedWith(CommandClasses.Security)
+			&& !response.cc.isEncapsulatedWith(CommandClasses.Security)
+		) {
+			// The mock node does not have the magic for automatically
+			// encapsulating commands, so we have to do it ourselves here.
+			// This requires a nonce exchange.
+			const nonceGet = new SecurityCCNonceGet({
+				nodeId: controller.ownNodeId,
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(nonceGet, {
+					ackRequested: false,
+				}),
+			);
+
+			const nonceReport = await self.expectControllerFrame(
+				(
+					resp,
+				): resp is MockZWaveFrame & {
+					type: MockZWaveFrameType.Request;
+					payload: SecurityCCNonceReport;
+				} => resp.type === MockZWaveFrameType.Request
+					&& resp.payload instanceof SecurityCCNonceReport,
+				{ timeout: 1000 },
+			);
+			const receiverNonce = nonceReport.payload.nonce;
+
+			// Encapsulate the response
+			const encapsulated = SecurityCC.encapsulate(
+				self.id,
+				self.securityManagers.securityManager!,
+				response.cc,
+			);
+			encapsulated.nonce = receiverNonce;
+
+			response.cc = encapsulated;
+		}
+
+		return response;
+	},
+};
+
+export const SecurityCCHooks = [
+	encapsulateS0CC,
+];
+
+export const SecurityCCBehaviors = [
+	respondToSchemeGet,
+	respondToS0NonceGet,
+	respondToNetworkKeySet,
+	respondToS0CommandsSupportedGet,
+];

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Security2.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Security2.ts
@@ -1,0 +1,148 @@
+import {
+	CommandClass,
+	InvalidCC,
+	Security2CC,
+	Security2CCCommandsSupportedGet,
+	Security2CCCommandsSupportedReport,
+	Security2CCMessageEncapsulation,
+	Security2CCNonceGet,
+	Security2CCNonceReport,
+	Security2Command,
+} from "@zwave-js/cc";
+import { CommandClasses, EncapsulationFlags, ZWaveErrorCodes } from "@zwave-js/core";
+import { type MockNodeBehavior } from "@zwave-js/testing";
+
+// Respond to S2 Nonce Get
+const respondToS2NonceGet: MockNodeBehavior = {
+	async handleCC(controller, self, receivedCC) {
+		const sm2Node = self.securityManagers.securityManager2;
+		if (!sm2Node) return;
+
+		if (receivedCC instanceof Security2CCNonceGet) {
+			const nonce = await sm2Node.generateNonce(
+				controller.ownNodeId,
+			);
+			const cc = new Security2CCNonceReport({
+				nodeId: controller.ownNodeId,
+				SOS: true,
+				MOS: false,
+				receiverEI: nonce,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+// Handle decode errors
+const handleS2DecodeError: MockNodeBehavior = {
+	async handleCC(controller, self, receivedCC) {
+		const sm2Node = self.securityManagers.securityManager2;
+		if (!sm2Node) return;
+
+		if (receivedCC instanceof InvalidCC) {
+			if (
+				receivedCC.reason
+					=== ZWaveErrorCodes.Security2CC_CannotDecode
+				|| receivedCC.reason
+					=== ZWaveErrorCodes.Security2CC_NoSPAN
+			) {
+				const nonce = await sm2Node.generateNonce(
+					controller.ownNodeId,
+				);
+				const cc = new Security2CCNonceReport({
+					nodeId: controller.ownNodeId,
+					SOS: true,
+					MOS: false,
+					receiverEI: nonce,
+				});
+				return { action: "sendCC", cc };
+			}
+		}
+	},
+};
+
+const respondToS2CommandsSupportedGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (
+			receivedCC
+				instanceof Security2CCCommandsSupportedGet
+		) {
+			const encapCC = receivedCC.getEncapsulatingCC(
+				CommandClasses["Security 2"],
+				Security2Command.MessageEncapsulation,
+			) as Security2CCMessageEncapsulation | undefined;
+			if (!encapCC) return;
+
+			const isHighestGranted = encapCC.securityClass
+				=== self.encodingContext.getHighestSecurityClass(
+					self.id,
+				);
+
+			const cc = Security2CC.encapsulate(
+				new Security2CCCommandsSupportedReport({
+					nodeId: controller.ownNodeId,
+					supportedCCs: isHighestGranted
+						? [...self.implementedCCs.entries()]
+							.filter(
+								([ccId, info]) =>
+									info.secure
+									&& ccId
+										!== CommandClasses[
+											"Security 2"
+										],
+							)
+							.map(([ccId]) => ccId)
+						: [],
+				}),
+				self.id,
+				self.securityManagers,
+			);
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+// Parse and unwrap Security2 CC commands.
+const encapsulateS2CC: MockNodeBehavior = {
+	async transformIncomingCC(controller, self, receivedCC) {
+		if (
+			receivedCC instanceof Security2CCMessageEncapsulation
+			&& receivedCC.encapsulated
+		) {
+			receivedCC.encapsulated?.toggleEncapsulationFlag(EncapsulationFlags.Security, true);
+			return receivedCC.encapsulated;
+		}
+
+		return receivedCC;
+	},
+
+	async transformResponse(controller, self, receivedCC, response) {
+		// Ensure that responses to S2-encapsulated CCs are also S2-encapsulated
+		if (
+			response.action === "sendCC"
+			&& receivedCC instanceof CommandClass
+			&& receivedCC.isEncapsulatedWith(CommandClasses["Security 2"])
+			&& !(response.cc instanceof Security2CCMessageEncapsulation)
+		) {
+			// Encapsulate the response
+			const encapsulated = Security2CC.encapsulate(
+				response.cc,
+				self.id,
+				self.securityManagers,
+			);
+			response.cc = encapsulated;
+		}
+
+		return response;
+	},
+};
+
+export const Security2CCHooks = [
+	encapsulateS2CC,
+];
+
+export const Security2CCBehaviors = [
+	respondToS2NonceGet,
+	handleS2DecodeError,
+	respondToS2CommandsSupportedGet,
+];

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Security2.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Security2.ts
@@ -28,7 +28,7 @@ import {
 	deriveSharedECDHSecret,
 	deriveTempKeys,
 } from "@zwave-js/core";
-import { type BytesView, getEnumMemberName } from "@zwave-js/shared";
+import { type BytesView } from "@zwave-js/shared";
 import {
 	type MockController,
 	type MockNode,
@@ -236,7 +236,7 @@ const handleS2NetworkKeyReport: MockNodeBehavior = {
 				receivedCC.grantedKey,
 				true,
 			);
-			sm2Node.setKey(receivedCC.grantedKey, receivedCC.networkKey);
+			await sm2Node.setKey(receivedCC.grantedKey, receivedCC.networkKey);
 
 			// Verify the key
 			self.state.set(
@@ -406,7 +406,7 @@ const respondToS2NonceGet: MockNodeBehavior = {
 						secClass,
 						true,
 					);
-					sm2Node.setKey(secClass, key);
+					await sm2Node.setKey(secClass, key);
 
 					sm2Node.tempKeys.delete(controller.ownNodeId);
 					sm2Node.deleteNonce(controller.ownNodeId);

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Security2.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Security2.ts
@@ -1,24 +1,420 @@
 import {
 	CommandClass,
+	ECDHProfiles,
 	InvalidCC,
+	KEXSchemes,
 	Security2CC,
 	Security2CCCommandsSupportedGet,
 	Security2CCCommandsSupportedReport,
+	Security2CCKEXGet,
+	Security2CCKEXReport,
+	Security2CCKEXSet,
 	Security2CCMessageEncapsulation,
+	Security2CCNetworkKeyGet,
+	Security2CCNetworkKeyReport,
+	Security2CCNetworkKeyVerify,
 	Security2CCNonceGet,
 	Security2CCNonceReport,
+	Security2CCPublicKeyReport,
+	Security2CCTransferEnd,
 	Security2Command,
 } from "@zwave-js/cc";
-import { CommandClasses, EncapsulationFlags, ZWaveErrorCodes } from "@zwave-js/core";
-import { type MockNodeBehavior } from "@zwave-js/testing";
+import {
+	CommandClasses,
+	EncapsulationFlags,
+	type SecurityClass,
+	ZWaveErrorCodes,
+	computePRK,
+	deriveSharedECDHSecret,
+	deriveTempKeys,
+} from "@zwave-js/core";
+import { type BytesView, getEnumMemberName } from "@zwave-js/shared";
+import {
+	type MockController,
+	type MockNode,
+	type MockNodeBehavior,
+	type MockNodeResponse,
+	type MockZWaveFrame,
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
 
-// Respond to S2 Nonce Get
+enum BootstrapStage {
+	Started,
+	Handshake,
+	RequestingKeys,
+	VerifyingKeys,
+	Finalizing,
+}
+
+type Security2BootstrapState = {
+	stage: BootstrapStage.Started;
+} | {
+	stage: BootstrapStage.Handshake;
+	grantedKeys: SecurityClass[];
+} | {
+	stage: BootstrapStage.RequestingKeys | BootstrapStage.Finalizing;
+	grantedKeys: SecurityClass[];
+	keys: Map<SecurityClass, BytesView>;
+} | {
+	stage: BootstrapStage.VerifyingKeys;
+	grantedKeys: SecurityClass[];
+	keys: Map<SecurityClass, BytesView>;
+	currentKey: SecurityClass;
+};
+
+const STATE_KEY_PREFIX = "Security2_";
+const StateKeys = {
+	bootstrapState: `${STATE_KEY_PREFIX}bootstrapState`,
+} as const;
+
+const respondToS2KEXGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		const sm2Node = self.securityManagers.securityManager2;
+		if (!sm2Node) return;
+
+		if (receivedCC instanceof Security2CCKEXGet) {
+			// Reset the bootstrap state
+			self.state.set(
+				StateKeys.bootstrapState,
+				{ stage: BootstrapStage.Started },
+			);
+
+			const cc = new Security2CCKEXReport({
+				nodeId: controller.ownNodeId,
+				echo: false,
+				supportedKEXSchemes: [KEXSchemes.KEXScheme1],
+				supportedECDHProfiles: [ECDHProfiles.Curve25519],
+				requestCSA: false,
+				requestedKeys: [...self.capabilities.securityClasses],
+			});
+
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToS2KEXSet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		const sm2Node = self.securityManagers.securityManager2;
+		if (!sm2Node) return;
+
+		if (receivedCC instanceof Security2CCKEXSet && !receivedCC.echo) {
+			// Remember the granted keys
+			self.state.set(
+				StateKeys.bootstrapState,
+				{
+					stage: BootstrapStage.Handshake,
+					grantedKeys: receivedCC.grantedKeys,
+				} as Security2BootstrapState,
+			);
+
+			// We're supposed to respond with our public key now
+			const cc = new Security2CCPublicKeyReport({
+				nodeId: controller.ownNodeId,
+				includingNode: false,
+				publicKey: self.ecdhKeyPair.publicKey,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToS2KEXReport: MockNodeBehavior = {
+	async handleCC(controller, self, receivedCC) {
+		const sm2Node = self.securityManagers.securityManager2;
+		if (!sm2Node) return;
+
+		if (
+			receivedCC instanceof Security2CCKEXReport
+			&& receivedCC.echo
+			&& receivedCC.isEncapsulatedWith(CommandClasses["Security 2"])
+		) {
+			// This should happen after the "handshake"
+			const currentState = self.state.get(
+				StateKeys.bootstrapState,
+			) as Security2BootstrapState | undefined;
+			if (currentState?.stage !== BootstrapStage.Handshake) return;
+
+			// We are now ready to request the network keys
+			self.state.set(
+				StateKeys.bootstrapState,
+				{
+					stage: BootstrapStage.RequestingKeys,
+					grantedKeys: currentState.grantedKeys,
+					keys: new Map(),
+				} as Security2BootstrapState,
+			);
+
+			// Kick off the key request process using the first key
+			const firstKey = currentState.grantedKeys[0];
+			return requestKey(self, firstKey);
+		}
+		return undefined;
+	},
+};
+
+const handleS2PublicKeyReport: MockNodeBehavior = {
+	async handleCC(controller, self, receivedCC) {
+		const sm2Node = self.securityManagers.securityManager2;
+		if (!sm2Node) return;
+
+		if (
+			receivedCC instanceof Security2CCPublicKeyReport
+			&& receivedCC.includingNode
+		) {
+			// Derive the shared secret and temp keys
+			const sharedSecret = await deriveSharedECDHSecret({
+				publicKey: receivedCC.publicKey,
+				privateKey: self.ecdhKeyPair.privateKey,
+			});
+
+			const tempKeys = await deriveTempKeys(
+				await computePRK(
+					sharedSecret,
+					receivedCC.publicKey,
+					self.ecdhKeyPair.publicKey,
+				),
+			);
+
+			sm2Node.deleteNonce(controller.ownNodeId);
+			sm2Node.tempKeys.set(controller.ownNodeId, {
+				keyCCM: tempKeys.tempKeyCCM,
+				personalizationString: tempKeys.tempPersonalizationString,
+			});
+
+			// The mock node does not have the magic for automatically
+			// initializing the SPAN state, so we have to do it ourselves here.
+			// This requires a nonce exchange.
+			await requestNonce(controller, self);
+
+			// Send the KEX Set echo to finalize creation of the secure channel
+			let cc: CommandClass = new Security2CCKEXSet({
+				nodeId: controller.ownNodeId,
+				echo: true,
+				// TODO: We should copy these from the received KEX Set instead
+				selectedKEXScheme: KEXSchemes.KEXScheme1,
+				selectedECDHProfile: ECDHProfiles.Curve25519,
+				permitCSA: false,
+				grantedKeys: [...self.capabilities.securityClasses],
+			});
+			cc = Security2CC.encapsulate(
+				cc,
+				self.id,
+				self.securityManagers,
+			);
+
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const handleS2NetworkKeyReport: MockNodeBehavior = {
+	async handleCC(controller, self, receivedCC) {
+		const sm2Node = self.securityManagers.securityManager2;
+		if (!sm2Node) return;
+
+		if (
+			receivedCC instanceof Security2CCNetworkKeyReport
+			&& receivedCC.isEncapsulatedWith(CommandClasses["Security 2"])
+		) {
+			// Ensure we are in the "requesting keys" stage
+			const currentState = self.state.get(
+				StateKeys.bootstrapState,
+			) as Security2BootstrapState | undefined;
+			if (currentState?.stage !== BootstrapStage.RequestingKeys) return;
+
+			// Remember the key
+			currentState.keys.set(
+				receivedCC.grantedKey,
+				receivedCC.networkKey,
+			);
+
+			// And temporarily use it for verification
+			self.encodingContext.setSecurityClass(
+				controller.ownNodeId,
+				receivedCC.grantedKey,
+				true,
+			);
+			sm2Node.setKey(receivedCC.grantedKey, receivedCC.networkKey);
+
+			// Verify the key
+			self.state.set(
+				StateKeys.bootstrapState,
+				{
+					...currentState,
+					stage: BootstrapStage.VerifyingKeys,
+					currentKey: receivedCC.grantedKey,
+				},
+			);
+			await requestNonce(controller, self);
+			return verifyKey(self, receivedCC.grantedKey);
+		}
+	},
+};
+
+async function requestNonce(
+	controller: MockController,
+	self: MockNode,
+): Promise<BytesView> {
+	const nonceGet = new Security2CCNonceGet({
+		nodeId: controller.ownNodeId,
+	});
+	await self.sendToController(
+		createMockZWaveRequestFrame(nonceGet, {
+			ackRequested: false,
+		}),
+	);
+
+	const nonceReport = await self.expectControllerFrame(
+		(
+			resp,
+		): resp is MockZWaveFrame & {
+			type: MockZWaveFrameType.Request;
+			payload: Security2CCNonceReport;
+		} => resp.type === MockZWaveFrameType.Request
+			&& resp.payload instanceof Security2CCNonceReport
+			&& resp.payload.SOS,
+		{ timeout: 1000 },
+	);
+
+	return nonceReport.payload.receiverEI!;
+}
+
+// Returns the mock node action for requesting a network key
+function requestKey(self: MockNode, secClass: SecurityClass): MockNodeResponse {
+	let networkKeyGet: CommandClass = new Security2CCNetworkKeyGet({
+		nodeId: self.controller.ownNodeId,
+		requestedKey: secClass,
+	});
+	networkKeyGet = Security2CC.encapsulate(
+		networkKeyGet,
+		self.id,
+		self.securityManagers,
+	);
+
+	return { action: "sendCC", cc: networkKeyGet };
+}
+
+// Returns the mock node action for verifying a network key
+function verifyKey(self: MockNode, secClass: SecurityClass): MockNodeResponse {
+	let networkKeyVerify: CommandClass = new Security2CCNetworkKeyVerify({
+		nodeId: self.controller.ownNodeId,
+	});
+	networkKeyVerify = Security2CC.encapsulate(
+		networkKeyVerify,
+		self.id,
+		self.securityManagers,
+		{ securityClass: secClass },
+	);
+	return { action: "sendCC", cc: networkKeyVerify };
+}
+
+const handleS2TransferEnd: MockNodeBehavior = {
+	async handleCC(controller, self, receivedCC) {
+		const sm2Node = self.securityManagers.securityManager2;
+		if (!sm2Node) return;
+
+		if (
+			receivedCC instanceof Security2CCTransferEnd
+			&& receivedCC.keyVerified
+			&& !receivedCC.keyRequestComplete
+			&& receivedCC.isEncapsulatedWith(CommandClasses["Security 2"])
+		) {
+			// Ensure we are in the "requesting keys" stage
+			const currentState = self.state.get(
+				StateKeys.bootstrapState,
+			) as Security2BootstrapState | undefined;
+			if (currentState?.stage !== BootstrapStage.RequestingKeys) return;
+
+			const nextKey = currentState.grantedKeys[
+				currentState.keys.size
+			];
+
+			if (nextKey) {
+				// Request the next key
+				return requestKey(self, nextKey);
+			}
+
+			// We're done. The next command still needs to use the temporary
+			// key though, so we cannot restore the security manager etc.
+			// just yet.
+			currentState.stage = BootstrapStage.Finalizing;
+
+			let transferEnd: CommandClass = new Security2CCTransferEnd({
+				nodeId: controller.ownNodeId,
+				keyVerified: false,
+				keyRequestComplete: true,
+			});
+			transferEnd = Security2CC.encapsulate(
+				transferEnd,
+				self.id,
+				self.securityManagers,
+			);
+			return { action: "sendCC", cc: transferEnd };
+
+			// The next communication attempt from the controller will
+			// need a NonceGet, at which point we'll restore the security
+			// manager etc.
+		}
+	},
+};
+
+// Create a new nonce when asked for
 const respondToS2NonceGet: MockNodeBehavior = {
 	async handleCC(controller, self, receivedCC) {
 		const sm2Node = self.securityManagers.securityManager2;
 		if (!sm2Node) return;
 
 		if (receivedCC instanceof Security2CCNonceGet) {
+			const bootstrapState = self.state.get(
+				StateKeys.bootstrapState,
+			) as Security2BootstrapState | undefined;
+
+			if (bootstrapState?.stage === BootstrapStage.VerifyingKeys) {
+				// This is the NonceGet after sending the NetworkKeyVerify.
+				// The next command will use the temporary key again,
+				// so we need to reset the security manager for that.
+				self.encodingContext.setSecurityClass(
+					controller.ownNodeId,
+					bootstrapState.currentKey,
+					false,
+				);
+				sm2Node.deleteNonce(controller.ownNodeId);
+
+				// Reset the state back to requesting keys
+				self.state.set(
+					StateKeys.bootstrapState,
+					{
+						stage: BootstrapStage.RequestingKeys,
+						grantedKeys: bootstrapState.grantedKeys,
+						keys: bootstrapState.keys,
+					} as Security2BootstrapState,
+				);
+			} else if (bootstrapState?.stage === BootstrapStage.Finalizing) {
+				// Bootstrapping is now actually done. Restore all keys
+				// and security manager settings, so the communication uses
+				// the correct security classes from now on.
+				for (const [secClass, key] of bootstrapState.keys) {
+					self.encodingContext.setSecurityClass(
+						controller.ownNodeId,
+						secClass,
+						true,
+					);
+					self.encodingContext.setSecurityClass(
+						self.id,
+						secClass,
+						true,
+					);
+					sm2Node.setKey(secClass, key);
+
+					sm2Node.tempKeys.delete(controller.ownNodeId);
+					sm2Node.deleteNonce(controller.ownNodeId);
+				}
+
+				self.state.delete(StateKeys.bootstrapState);
+			}
+
 			const nonce = await sm2Node.generateNonce(
 				controller.ownNodeId,
 			);
@@ -109,7 +505,10 @@ const encapsulateS2CC: MockNodeBehavior = {
 			receivedCC instanceof Security2CCMessageEncapsulation
 			&& receivedCC.encapsulated
 		) {
-			receivedCC.encapsulated?.toggleEncapsulationFlag(EncapsulationFlags.Security, true);
+			receivedCC.encapsulated?.toggleEncapsulationFlag(
+				EncapsulationFlags.Security,
+				true,
+			);
 			return receivedCC.encapsulated;
 		}
 
@@ -142,6 +541,14 @@ export const Security2CCHooks = [
 ];
 
 export const Security2CCBehaviors = [
+	// Key exchange
+	respondToS2KEXGet,
+	respondToS2KEXSet,
+	handleS2PublicKeyReport,
+	respondToS2KEXReport,
+	handleS2NetworkKeyReport,
+	handleS2TransferEnd,
+	// Normal operation
 	respondToS2NonceGet,
 	handleS2DecodeError,
 	respondToS2CommandsSupportedGet,

--- a/packages/zwave-js/src/lib/test/cc/API.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/API.test.ts
@@ -28,8 +28,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/cc/CommandClass.persistValues.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/CommandClass.persistValues.test.ts
@@ -28,8 +28,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/cc/ManufacturerProprietary.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ManufacturerProprietary.test.ts
@@ -26,7 +26,7 @@ integrationTest(
 						const received =
 							receivedCC as ManufacturerProprietaryCC;
 						const response = new ManufacturerProprietaryCC({
-							nodeId: self.id,
+							nodeId: controller.ownNodeId,
 							manufacturerId: received.manufacturerId!,
 							payload: received.payload,
 						});

--- a/packages/zwave-js/src/lib/test/driver/assemblePartialCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/assemblePartialCCs.test.ts
@@ -30,15 +30,15 @@ const test = baseTest.extend<LocalTestContext>({
 				securityKeys: {
 					S0_Legacy: new Uint8Array(16).fill(0xff),
 				},
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});
 					controller.defineBehavior(
 						...createDefaultMockControllerBehaviors(),
 					);
-					const node2 = new MockNode({
+					const node2 = await MockNode.create({
 						id: 2,
 						controller,
 					});

--- a/packages/zwave-js/src/lib/test/driver/computeNetCCPayloadSize.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/computeNetCCPayloadSize.test.ts
@@ -28,8 +28,8 @@ const test = baseTest.extend<LocalTestContext>({
 				securityKeys: {
 					S0_Legacy: new Uint8Array(16).fill(0xff),
 				},
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
@@ -89,160 +89,6 @@ integrationTest(
 	},
 );
 
-function setupS0NodeBehaviorsForNewlyIncludedNode(
-	mockNode: MockNode,
-): void {
-	// Create a security manager for the node with temporary key (all zeros)
-	// The real network key will be set after receiving SecurityCCNetworkKeySet
-	const temporaryKey = new Uint8Array(16).fill(0x00);
-	const sm0Node = new SecurityManager({
-		ownNodeId: mockNode.id,
-		networkKey: temporaryKey,
-		nonceTimeout: 100000,
-	});
-	mockNode.securityManagers.securityManager = sm0Node;
-
-	// Respond to Scheme Get with Scheme Report
-	const respondToSchemeGet: MockNodeBehavior = {
-		handleCC(controller, self, receivedCC) {
-			if (receivedCC instanceof SecurityCCSchemeGet) {
-				const cc = new SecurityCCSchemeReport({
-					nodeId: controller.ownNodeId,
-				});
-				return { action: "sendCC", cc };
-			}
-		},
-	};
-	mockNode.defineBehavior(respondToSchemeGet);
-
-	// Respond to S0 Nonce Get
-	const respondToS0NonceGet: MockNodeBehavior = {
-		handleCC(controller, self, receivedCC) {
-			if (receivedCC instanceof SecurityCCNonceGet) {
-				const nonce = sm0Node.generateNonce(controller.ownNodeId, 8);
-				const cc = new SecurityCCNonceReport({
-					nodeId: controller.ownNodeId,
-					nonce,
-				});
-				return { action: "sendCC", cc };
-			}
-		},
-	};
-	mockNode.defineBehavior(respondToS0NonceGet);
-
-	// Respond to Network Key Set with Network Key Verify
-	const respondToNetworkKeySet: MockNodeBehavior = {
-		async handleCC(controller, self, receivedCC) {
-			if (receivedCC instanceof SecurityCCNetworkKeySet) {
-				// Update the node's security manager to use the received network key
-				const receivedKey = receivedCC.networkKey;
-				self.securityManagers.securityManager!.networkKey = receivedKey;
-
-				const response = new SecurityCCNetworkKeyVerify({
-					nodeId: controller.ownNodeId,
-				});
-
-				return { action: "sendCC", cc: response };
-			}
-		},
-	};
-	mockNode.defineBehavior(respondToNetworkKeySet);
-
-	// Respond to S0 Commands Supported Get
-	const respondToS0CommandsSupportedGet: MockNodeBehavior = {
-		async handleCC(controller, self, receivedCC) {
-			if (receivedCC instanceof SecurityCCCommandsSupportedGet) {
-				// Determine securely supported CCs from the mock node's implementedCCs
-				const supportedCCs = [...mockNode.implementedCCs.entries()]
-					.filter(
-						([cc, info]) =>
-							info.secure === true
-							&& !isEncapsulationCC(cc),
-					)
-					.map(([cc]) => cc);
-
-				const response = new SecurityCCCommandsSupportedReport({
-					nodeId: controller.ownNodeId,
-					supportedCCs,
-					controlledCCs: [],
-					reportsToFollow: 0,
-				});
-
-				return { action: "sendCC", cc: response };
-			}
-		},
-	};
-	mockNode.defineBehavior(respondToS0CommandsSupportedGet);
-
-	// Parse and unwrap Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
-	const parseS0CC: MockNodeBehavior = {
-		async transformIncomingCC(controller, self, receivedCC) {
-			// We don't support sequenced commands here
-			if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-				await receivedCC.mergePartialCCs([], {
-					sourceNodeId: controller.ownNodeId,
-					__internalIsMockNode: true,
-					frameType: "singlecast",
-					...self.encodingContext,
-					...self.securityManagers,
-				});
-				// Return the unwrapped command
-				if (receivedCC.encapsulated) {
-					return receivedCC.encapsulated;
-				}
-			}
-			return receivedCC;
-		},
-
-		async transformResponse(controller, self, receivedCC, response) {
-			// Ensure that responses to S0-encapsulated CCs are also S0-encapsulated
-			if (
-				response.action === "sendCC"
-				&& receivedCC instanceof CommandClass
-				&& receivedCC.isEncapsulatedWith(CommandClasses.Security)
-				&& !response.cc.isEncapsulatedWith(CommandClasses.Security)
-			) {
-				// The mock node does not have the magic for automatically
-				// encapsulating commands, so we have to do it ourselves here.
-				// This requires a nonce exchange.
-				const nonceGet = new SecurityCCNonceGet({
-					nodeId: controller.ownNodeId,
-				});
-				await self.sendToController(
-					createMockZWaveRequestFrame(nonceGet, {
-						ackRequested: false,
-					}),
-				);
-
-				const nonceReport = await self.expectControllerFrame(
-					(
-						resp,
-					): resp is MockZWaveFrame & {
-						type: MockZWaveFrameType.Request;
-						payload: SecurityCCNonceReport;
-					} => resp.type === MockZWaveFrameType.Request
-						&& resp.payload instanceof SecurityCCNonceReport,
-					{ timeout: 1000 },
-				);
-				const receiverNonce = nonceReport.payload.nonce;
-
-				// Encapsulate the response
-				const encapsulated = SecurityCC.encapsulate(
-					self.id,
-					self.securityManagers.securityManager!,
-					response.cc,
-				);
-				encapsulated.nonce = receiverNonce;
-
-				response.cc = encapsulated;
-			}
-
-			return response;
-		},
-	};
-	mockNode.defineBehavior(parseS0CC);
-}
-
 integrationTestMulti(
 	"Inclusion with S0 should work",
 	{
@@ -289,7 +135,6 @@ integrationTestMulti(
 						}),
 					],
 				},
-				setup: setupS0NodeBehaviorsForNewlyIncludedNode,
 			};
 
 			// Start the inclusion process with S0
@@ -367,7 +212,6 @@ integrationTestMulti(
 						CommandClasses.Version,
 					],
 				},
-				setup: setupS0NodeBehaviorsForNewlyIncludedNode,
 			};
 
 			// Start the inclusion process

--- a/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
@@ -15,6 +15,7 @@ import {
 import {
 	BasicDeviceClass,
 	CommandClasses,
+	SecurityClass,
 	SecurityManager,
 	isEncapsulationCC,
 } from "@zwave-js/core";
@@ -85,6 +86,99 @@ integrationTest(
 				});
 			});
 			await interviewCompletePromise;
+		},
+	},
+);
+
+integrationTestMulti(
+	"Inclusion with S2 should work",
+	{
+		debug: true,
+
+		testBody: async (t, driver, nodes, mockController, mockNodes) => {
+			// Set up a promise to wait for the "node added" event
+			let includedNode: ZWaveNode | undefined;
+			const nodeAddedPromise = new Promise<void>((resolve) => {
+				driver.controller.once("node added", (node) => {
+					includedNode = node;
+					resolve();
+				});
+			});
+
+			// Set up the node that will be included
+			let inclusionPIN: string | undefined;
+			mockController.nodePendingInclusion = {
+				id: 3,
+				capabilities: {
+					basicDeviceClass: 0x04,
+					genericDeviceClass: 0x10,
+					specificDeviceClass: 0x01,
+					commandClasses: [
+						CommandClasses["Z-Wave Plus Info"],
+						CommandClasses["Manufacturer Specific"],
+						CommandClasses["Device Reset Locally"],
+						CommandClasses["Security 2"],
+						CommandClasses.Powerlevel,
+						CommandClasses["Firmware Update Meta Data"],
+						ccCaps({
+							ccId: CommandClasses["Binary Switch"],
+							secure: true,
+							defaultValue: false,
+						}),
+					],
+					securityClasses: new Set([
+						SecurityClass.S2_Unauthenticated,
+					]),
+				},
+				setup(node) {
+					inclusionPIN = node.s2Pin;
+				},
+			};
+
+			// Start the inclusion process with S2
+			await driver.controller.beginInclusion({
+				strategy: InclusionStrategy.Security_S2,
+				userCallbacks: {
+					async grantSecurityClasses(requested) {
+						// Simply grant all requested classes for this test
+						return requested;
+					},
+					async validateDSKAndEnterPIN(dsk) {
+						return inclusionPIN!;
+					},
+					abort() {
+					},
+				},
+			});
+
+			// Wait for the "node added" event
+			await nodeAddedPromise;
+
+			// Wait for the interview to complete
+			const interviewCompletePromise = new Promise<void>((resolve) => {
+				includedNode!.once("interview completed", () => {
+					resolve();
+				});
+			});
+			await interviewCompletePromise;
+
+			// Verify that the node was added to the controller's nodes map
+			t.expect(includedNode).toBeDefined();
+			t.expect(includedNode!.id).toBe(3);
+			t.expect(includedNode!.isSecure).toBe(true);
+			t.expect(includedNode!.supportsCC(CommandClasses["Security 2"]))
+				.toBe(
+					true,
+				);
+
+			// That Binary Switch CC is only supported securely
+			t.expect(includedNode?.isCCSecure(CommandClasses["Binary Switch"]))
+				.toBe(true);
+
+			// And that we received a response when querying its value during the interview
+			t.expect(
+				includedNode?.getValue(BinarySwitchCCValues.currentValue.id),
+			).toBe(false);
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
@@ -33,15 +33,9 @@ import { integrationTest } from "../integrationTestSuite.js";
 import { integrationTest as integrationTestMulti } from "../integrationTestSuiteMulti.js";
 
 integrationTest(
-	"Device inclusion process should emit 'node added' event",
+	"Device inclusion process should emit 'node added' event and interview the device",
 	{
 		// debug: true,
-
-		additionalDriverOptions: {
-			testingHooks: {
-				skipNodeInterview: true,
-			},
-		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// Set up a promise to wait for the "node added" event
@@ -83,6 +77,14 @@ integrationTest(
 			const addedNode = driver.controller.nodes.get(3);
 			t.expect(addedNode).toBeDefined();
 			t.expect(addedNode?.id).toBe(3);
+
+			// Now wait for the interview to complete
+			const interviewCompletePromise = new Promise<void>((resolve) => {
+				addedNode!.once("interview completed", () => {
+					resolve();
+				});
+			});
+			await interviewCompletePromise;
 		},
 	},
 );

--- a/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/deviceInclusion.test.ts
@@ -1,33 +1,12 @@
-import {
-	BinarySwitchCCValues,
-	CommandClass,
-	SecurityCC,
-	SecurityCCCommandEncapsulation,
-	SecurityCCCommandsSupportedGet,
-	SecurityCCCommandsSupportedReport,
-	SecurityCCNetworkKeySet,
-	SecurityCCNetworkKeyVerify,
-	SecurityCCNonceGet,
-	SecurityCCNonceReport,
-	SecurityCCSchemeGet,
-	SecurityCCSchemeReport,
-} from "@zwave-js/cc";
+import { BinarySwitchCCValues } from "@zwave-js/cc";
 import {
 	BasicDeviceClass,
 	CommandClasses,
 	SecurityClass,
 	SecurityManager,
-	isEncapsulationCC,
 } from "@zwave-js/core";
 
-import {
-	type MockNode,
-	type MockNodeBehavior,
-	type MockZWaveFrame,
-	MockZWaveFrameType,
-	ccCaps,
-	createMockZWaveRequestFrame,
-} from "@zwave-js/testing";
+import { ccCaps } from "@zwave-js/testing";
 import { InclusionStrategy } from "../../controller/Inclusion.js";
 import type { ZWaveNode } from "../../node/Node.js";
 import { integrationTest } from "../integrationTestSuite.js";
@@ -93,7 +72,7 @@ integrationTest(
 integrationTestMulti(
 	"Inclusion with S2 should work",
 	{
-		debug: true,
+		// debug: true,
 
 		testBody: async (t, driver, nodes, mockController, mockNodes) => {
 			// Set up a promise to wait for the "node added" event

--- a/packages/zwave-js/src/lib/test/driver/hasPendingMessages.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/hasPendingMessages.test.ts
@@ -23,8 +23,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				loadConfiguration: false,
 				skipNodeInterview: true,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/driver/ignoreCCVersion0ForKnownSupportedCCs.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/ignoreCCVersion0ForKnownSupportedCCs.test.ts
@@ -44,125 +44,22 @@ integrationTest(
 				CommandClasses.Version,
 				CommandClasses["Security 2"],
 			],
+			securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
 		},
 
 		customSetup: async (driver, controller, mockNode) => {
-			// Create a security manager for the node
-			const smNode = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smNode.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			mockNode.securityManagers.securityManager2 = smNode;
-			mockNode.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Create a security manager for the controller
-			const smCtrlr = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smCtrlr.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Respond to Nonce Get
-			const respondToNonceGet: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof Security2CCNonceGet) {
-						const nonce = await smNode.generateNonce(
-							controller.ownNodeId,
-						);
-						const cc = new Security2CCNonceReport({
-							nodeId: controller.ownNodeId,
-							SOS: true,
-							MOS: false,
-							receiverEI: nonce,
-						});
-						return { action: "sendCC", cc };
-					}
-				},
-			};
-			mockNode.defineBehavior(respondToNonceGet);
-
-			// Handle decode errors
-			const handleInvalidCC: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof InvalidCC) {
-						if (
-							receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_CannotDecode
-							|| receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_NoSPAN
-						) {
-							const nonce = await smNode.generateNonce(
-								controller.ownNodeId,
-							);
-							const cc = new Security2CCNonceReport({
-								nodeId: controller.ownNodeId,
-								SOS: true,
-								MOS: false,
-								receiverEI: nonce,
-							});
-							return { action: "sendCC", cc };
-						}
-					}
-				},
-			};
-			mockNode.defineBehavior(handleInvalidCC);
-
-			const reportSecurelySupportedCCs: MockNodeBehavior = {
-				handleCC(controller, self, receivedCC) {
-					if (
-						receivedCC
-							instanceof Security2CCMessageEncapsulation
-						&& receivedCC.securityClass
-							=== SecurityClass.S2_Unauthenticated
-						&& receivedCC.encapsulated
-							instanceof Security2CCCommandsSupportedGet
-					) {
-						let cc: CommandClass =
-							new Security2CCCommandsSupportedReport({
-								nodeId: controller.ownNodeId,
-								supportedCCs: [
-									// The node supports Version CC securely
-									CommandClasses.Version,
-								],
-							});
-						cc = Security2CC.encapsulate(
-							cc,
-							self.id,
-							self.securityManagers,
-						);
-						return { action: "sendCC", cc };
-					}
-				},
-			};
-			mockNode.defineBehavior(reportSecurelySupportedCCs);
-
 			const respondWithInvalidVersionReport: MockNodeBehavior = {
 				handleCC(controller, self, receivedCC) {
 					if (
-						receivedCC
-							instanceof Security2CCMessageEncapsulation
-						&& receivedCC.encapsulated
-							instanceof VersionCCCommandClassGet
-						&& receivedCC.encapsulated.requestedCC
+						receivedCC instanceof VersionCCCommandClassGet
+						&& receivedCC.requestedCC
 							=== CommandClasses["Security 2"]
 					) {
 						let cc: CommandClass = new VersionCCCommandClassReport({
 							nodeId: controller.ownNodeId,
-							requestedCC: receivedCC.encapsulated.requestedCC,
+							requestedCC: receivedCC.requestedCC,
 							ccVersion: 0,
 						});
-						cc = Security2CC.encapsulate(
-							cc,
-							self.id,
-							self.securityManagers,
-						);
 						return { action: "sendCC", cc };
 					}
 				},

--- a/packages/zwave-js/src/lib/test/driver/noInterleavedAddRemoveNode.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/noInterleavedAddRemoveNode.test.ts
@@ -17,7 +17,7 @@ integrationTest(
 			// These two commands should not be interleaved
 			const expectation = mockController.expectHostMessage(
 				(msg) => msg instanceof RemoveFailedNodeRequest,
-				{timeout:500},
+				{ timeout: 500 },
 			).then(() => "FAIL").catch(() => "PASS");
 
 			void driver.controller["beginInclusionSmartStart"]({

--- a/packages/zwave-js/src/lib/test/driver/noInterleavedAddRemoveNode.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/noInterleavedAddRemoveNode.test.ts
@@ -16,8 +16,8 @@ integrationTest(
 
 			// These two commands should not be interleaved
 			const expectation = mockController.expectHostMessage(
-				500,
 				(msg) => msg instanceof RemoveFailedNodeRequest,
+				{timeout:500},
 			).then(() => "FAIL").catch(() => "PASS");
 
 			void driver.controller["beginInclusionSmartStart"]({

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
@@ -1,7 +1,4 @@
-import {
-	SecurityCCNonceGet,
-	SecurityCCNonceReport,
-} from "@zwave-js/cc";
+import { SecurityCCNonceGet, SecurityCCNonceReport } from "@zwave-js/cc";
 import { CommandClasses, SecurityClass } from "@zwave-js/core";
 import {
 	MOCK_FRAME_ACK_TIMEOUT,
@@ -31,7 +28,6 @@ integrationTest(
 			],
 			securityClasses: new Set([SecurityClass.S0_Legacy]),
 		},
-
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// The node requests a nonce while asleep, but the ACK gets lost

--- a/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeAsleepBlockNonceReport.test.ts
@@ -1,12 +1,10 @@
 import {
-	SecurityCCCommandEncapsulation,
 	SecurityCCNonceGet,
 	SecurityCCNonceReport,
 } from "@zwave-js/cc";
-import { SecurityManager } from "@zwave-js/core";
+import { CommandClasses, SecurityClass } from "@zwave-js/core";
 import {
 	MOCK_FRAME_ACK_TIMEOUT,
-	type MockNodeBehavior,
 	MockZWaveFrameType,
 	type MockZWaveRequestFrame,
 	createMockZWaveRequestFrame,
@@ -25,60 +23,15 @@ integrationTest(
 			"fixtures/nodeAsleepBlockNonceReport",
 		),
 
-		customSetup: async (driver, controller, mockNode) => {
-			// Create a security manager for the node
-			const sm0Node = new SecurityManager({
-				ownNodeId: mockNode.id,
-				networkKey: driver.options.securityKeys!.S0_Legacy!,
-				nonceTimeout: 100000,
-			});
-			mockNode.securityManagers.securityManager = sm0Node;
-
-			// Create a security manager for the controller
-			const sm0Ctrlr = new SecurityManager({
-				ownNodeId: controller.ownNodeId,
-				networkKey: driver.options.securityKeys!.S0_Legacy!,
-				nonceTimeout: 100000,
-			});
-			controller.securityManagers.securityManager = sm0Ctrlr;
-
-			// Respond to S0 Nonce Get
-			const respondToS0NonceGet: MockNodeBehavior = {
-				handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof SecurityCCNonceGet) {
-						const nonce = sm0Node.generateNonce(
-							controller.ownNodeId,
-							8,
-						);
-						const cc = new SecurityCCNonceReport({
-							nodeId: controller.ownNodeId,
-							nonce,
-						});
-						return { action: "sendCC", cc };
-					}
-				},
-			};
-			mockNode.defineBehavior(respondToS0NonceGet);
-
-			// Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
-			const parseS0CC: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					// We don't support sequenced commands here
-					if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-						await receivedCC.mergePartialCCs([], {
-							sourceNodeId: controller.ownNodeId,
-							__internalIsMockNode: true,
-							frameType: "singlecast",
-							...self.encodingContext,
-							...self.securityManagers,
-						});
-					}
-					// This just decodes - we need to call further handlers
-					return undefined;
-				},
-			};
-			mockNode.defineBehavior(parseS0CC);
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Basic,
+				CommandClasses["Wake Up"],
+				CommandClasses.Security,
+			],
+			securityClasses: new Set([SecurityClass.S0_Legacy]),
 		},
+
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// The node requests a nonce while asleep, but the ACK gets lost

--- a/packages/zwave-js/src/lib/test/driver/nodeUpdateBeforeCallback.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/nodeUpdateBeforeCallback.test.ts
@@ -31,7 +31,7 @@ integrationTest(
 				async handleCC(controller, self, receivedCC) {
 					if (receivedCC instanceof BasicCCGet) {
 						const cc = new BasicCCReport({
-							nodeId: self.id,
+							nodeId: controller.ownNodeId,
 							currentValue: 55,
 						});
 						await self.sendToController(

--- a/packages/zwave-js/src/lib/test/driver/receiveMessages.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/receiveMessages.test.ts
@@ -26,8 +26,8 @@ const test = baseTest.extend<LocalTestContext>({
 				// We don't need a real interview for this
 				skipControllerIdentification: true,
 				skipNodeInterview: true,
-				beforeStartup(mockPort, serial) {
-					context.controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					context.controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/driver/s0AndS2Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0AndS2Encapsulation.test.ts
@@ -7,17 +7,16 @@ import {
 	Security2CCNonceReport,
 	SecurityCCCommandEncapsulation,
 	SecurityCCCommandsSupportedGet,
-	SecurityCCNonceGet,
-	SecurityCCNonceReport,
 	SupervisionCCGet,
 	SupervisionCCReport,
 } from "@zwave-js/cc";
 import {
+	CommandClasses,
 	SecurityClass,
-	SecurityManager,
 	SecurityManager2,
 	SupervisionStatus,
 	ZWaveErrorCodes,
+	securityClassOrder as allSecurityClasses,
 } from "@zwave-js/core";
 import { type MockNodeBehavior, MockZWaveFrameType } from "@zwave-js/testing";
 import path from "node:path";
@@ -31,6 +30,16 @@ integrationTest("S0 commands are S0-encapsulated, even when S2 is supported", {
 		__dirname,
 		"fixtures/s0AndS2Encapsulation",
 	),
+
+	nodeCapabilities: {
+		commandClasses: [
+			{ ccId: CommandClasses.Basic, secure: true },
+			CommandClasses.Version,
+			CommandClasses.Security,
+			CommandClasses["Security 2"],
+		],
+		securityClasses: new Set(allSecurityClasses),
+	},
 
 	customSetup: async (driver, controller, mockNode) => {
 		// Create a security manager for the node
@@ -52,13 +61,6 @@ integrationTest("S0 commands are S0-encapsulated, even when S2 is supported", {
 		mockNode.encodingContext.getHighestSecurityClass = () =>
 			SecurityClass.S2_Unauthenticated;
 
-		const sm0Node = new SecurityManager({
-			ownNodeId: mockNode.id,
-			networkKey: driver.options.securityKeys!.S0_Legacy!,
-			nonceTimeout: 100000,
-		});
-		mockNode.securityManagers.securityManager = sm0Node;
-
 		// Create a security manager for the controller
 		const smCtrlr = await SecurityManager2.create();
 		// Copy keys from the driver
@@ -77,50 +79,6 @@ integrationTest("S0 commands are S0-encapsulated, even when S2 is supported", {
 		controller.securityManagers.securityManager2 = smCtrlr;
 		controller.encodingContext.getHighestSecurityClass = () =>
 			SecurityClass.S2_Unauthenticated;
-
-		const sm0Ctrlr = new SecurityManager({
-			ownNodeId: controller.ownNodeId,
-			networkKey: driver.options.securityKeys!.S0_Legacy!,
-			nonceTimeout: 100000,
-		});
-		controller.securityManagers.securityManager = sm0Ctrlr;
-
-		// Respond to S0 Nonce Get
-		const respondToS0NonceGet: MockNodeBehavior = {
-			handleCC(controller, self, receivedCC) {
-				if (receivedCC instanceof SecurityCCNonceGet) {
-					const nonce = sm0Node.generateNonce(
-						controller.ownNodeId,
-						8,
-					);
-					const cc = new SecurityCCNonceReport({
-						nodeId: controller.ownNodeId,
-						nonce,
-					});
-					return { action: "sendCC", cc };
-				}
-			},
-		};
-		mockNode.defineBehavior(respondToS0NonceGet);
-
-		// Parse Security CC commands
-		const parseS0CC: MockNodeBehavior = {
-			async handleCC(controller, self, receivedCC) {
-				// We don't support sequenced commands here
-				if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-					await receivedCC.mergePartialCCs([], {
-						sourceNodeId: controller.ownNodeId,
-						__internalIsMockNode: true,
-						frameType: "singlecast",
-						...self.encodingContext,
-						...self.securityManagers,
-					});
-				}
-				// This just decodes - we need to call further handlers
-				return undefined;
-			},
-		};
-		mockNode.defineBehavior(parseS0CC);
 
 		// Respond to S2 Nonce Get
 		const respondToS2NonceGet: MockNodeBehavior = {

--- a/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
@@ -18,7 +18,7 @@ import {
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest("Communication via Security S0 works", {
-	debug: true,
+	// debug: true,
 
 	nodeCapabilities: {
 		commandClasses: [
@@ -33,146 +33,6 @@ integrationTest("Communication via Security S0 works", {
 	},
 
 	customSetup: async (driver, controller, mockNode) => {
-		// // Create a security manager for the node
-		// const sm0Node = new SecurityManager({
-		// 	ownNodeId: mockNode.id,
-		// 	networkKey: driver.options.securityKeys!.S0_Legacy!,
-		// 	nonceTimeout: 100000,
-		// });
-		// mockNode.securityManagers.securityManager = sm0Node;
-
-		// // Create a security manager for the controller
-		// const sm0Ctrlr = new SecurityManager({
-		// 	ownNodeId: controller.ownNodeId,
-		// 	networkKey: driver.options.securityKeys!.S0_Legacy!,
-		// 	nonceTimeout: 100000,
-		// });
-		// controller.securityManagers.securityManager = sm0Ctrlr;
-
-		// // Respond to S0 Nonce Get
-		// const respondToS0NonceGet: MockNodeBehavior = {
-		// 	handleCC(controller, self, receivedCC) {
-		// 		if (receivedCC instanceof SecurityCCNonceGet) {
-		// 			const nonce = sm0Node.generateNonce(
-		// 				controller.ownNodeId,
-		// 				8,
-		// 			);
-		// 			const cc = new SecurityCCNonceReport({
-		// 				nodeId: controller.ownNodeId,
-		// 				nonce,
-		// 			});
-		// 			return { action: "sendCC", cc };
-		// 		}
-		// 	},
-		// };
-		// mockNode.defineBehavior(respondToS0NonceGet);
-
-		// // Respond to S0 Commands Supported Get
-		// const respondToS0CommandsSupportedGet: MockNodeBehavior = {
-		// 	async handleCC(controller, self, receivedCC) {
-		// 		if (
-		// 			receivedCC instanceof SecurityCCCommandEncapsulation
-		// 			&& receivedCC.encapsulated
-		// 				instanceof SecurityCCCommandsSupportedGet
-		// 		) {
-		// 			const nonceGet = new SecurityCCNonceGet({
-		// 				nodeId: controller.ownNodeId,
-		// 			});
-		// 			await self.sendToController(
-		// 				createMockZWaveRequestFrame(nonceGet, {
-		// 					ackRequested: false,
-		// 				}),
-		// 			);
-
-		// 			const nonceReport = await self.expectControllerFrame(
-		// 				(
-		// 					resp,
-		// 				): resp is MockZWaveFrame & {
-		// 					type: MockZWaveFrameType.Request;
-		// 					payload: SecurityCCNonceReport;
-		// 				} => resp.type === MockZWaveFrameType.Request
-		// 					&& resp.payload instanceof SecurityCCNonceReport,
-		// 				{ timeout: 1000 },
-		// 			);
-		// 			const receiverNonce = nonceReport.payload.nonce;
-
-		// 			const response = new SecurityCCCommandsSupportedReport({
-		// 				nodeId: controller.ownNodeId,
-		// 				supportedCCs: [CommandClasses.Basic],
-		// 				controlledCCs: [],
-		// 				reportsToFollow: 0,
-		// 			});
-		// 			const cc = SecurityCC.encapsulate(
-		// 				self.id,
-		// 				self.securityManagers.securityManager!,
-		// 				response,
-		// 			);
-		// 			cc.nonce = receiverNonce;
-
-		// 			await self.sendToController(
-		// 				createMockZWaveRequestFrame(cc, {
-		// 					ackRequested: false,
-		// 				}),
-		// 			);
-
-		// 			return { action: "stop" };
-		// 		}
-		// 	},
-		// };
-		// mockNode.defineBehavior(respondToS0CommandsSupportedGet);
-
-		// // Respond to S0-encapsulated Basic Get with a level that increases with each request
-		// let queryCount = 0;
-		// const respondToS0BasicGet: MockNodeBehavior = {
-		// 	async handleCC(controller, self, receivedCC) {
-		// 		if (
-		// 			receivedCC instanceof SecurityCCCommandEncapsulation
-		// 			&& receivedCC.encapsulated instanceof BasicCCGet
-		// 		) {
-		// 			const nonceGet = new SecurityCCNonceGet({
-		// 				nodeId: controller.ownNodeId,
-		// 			});
-		// 			await self.sendToController(
-		// 				createMockZWaveRequestFrame(nonceGet, {
-		// 					ackRequested: false,
-		// 				}),
-		// 			);
-
-		// 			const nonceReport = await self.expectControllerFrame(
-		// 				(
-		// 					resp,
-		// 				): resp is MockZWaveFrame & {
-		// 					type: MockZWaveFrameType.Request;
-		// 					payload: SecurityCCNonceReport;
-		// 				} => resp.type === MockZWaveFrameType.Request
-		// 					&& resp.payload instanceof SecurityCCNonceReport,
-		// 				{ timeout: 1000 },
-		// 			);
-		// 			const receiverNonce = nonceReport.payload.nonce;
-
-		// 			const response = new BasicCCReport({
-		// 				nodeId: controller.ownNodeId,
-		// 				currentValue: ++queryCount,
-		// 			});
-		// 			const cc = SecurityCC.encapsulate(
-		// 				self.id,
-		// 				self.securityManagers.securityManager!,
-		// 				response,
-		// 			);
-		// 			cc.nonce = receiverNonce;
-
-		// 			await self.sendToController(
-		// 				createMockZWaveRequestFrame(cc, {
-		// 					ackRequested: false,
-		// 				}),
-		// 			);
-
-		// 			return { action: "stop" };
-		// 		}
-		// 	},
-		// };
-		// mockNode.defineBehavior(respondToS0BasicGet);
-
 		// Respond to Basic Get with a level that increases with each request
 		let queryCount = 0;
 		const respondToBasicGet: MockNodeBehavior = {
@@ -190,25 +50,6 @@ integrationTest("Communication via Security S0 works", {
 			},
 		};
 		mockNode.defineBehavior(respondToBasicGet);
-
-		// // Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
-		// const parseS0CC: MockNodeBehavior = {
-		// 	async handleCC(controller, self, receivedCC) {
-		// 		// We don't support sequenced commands here
-		// 		if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-		// 			await receivedCC.mergePartialCCs([], {
-		// 				sourceNodeId: controller.ownNodeId,
-		// 				__internalIsMockNode: true,
-		// 				frameType: "singlecast",
-		// 				...self.encodingContext,
-		// 				...self.securityManagers,
-		// 			});
-		// 		}
-		// 		// This just decodes - we need to call further handlers
-		// 		return undefined;
-		// 	},
-		// };
-		// mockNode.defineBehavior(parseS0CC);
 	},
 
 	testBody: async (t, driver, node, mockController, mockNode) => {

--- a/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
@@ -1,20 +1,6 @@
-import {
-	BasicCCGet,
-	BasicCCReport,
-	SecurityCC,
-	SecurityCCCommandEncapsulation,
-	SecurityCCCommandsSupportedGet,
-	SecurityCCCommandsSupportedReport,
-	SecurityCCNonceGet,
-	SecurityCCNonceReport,
-} from "@zwave-js/cc";
-import { CommandClasses, SecurityClass, SecurityManager } from "@zwave-js/core";
-import {
-	type MockNodeBehavior,
-	type MockZWaveFrame,
-	MockZWaveFrameType,
-	createMockZWaveRequestFrame,
-} from "@zwave-js/testing";
+import { BasicCCGet, BasicCCReport } from "@zwave-js/cc";
+import { CommandClasses, SecurityClass } from "@zwave-js/core";
+import { type MockNodeBehavior } from "@zwave-js/testing";
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest("Communication via Security S0 works", {

--- a/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0Encapsulation.test.ts
@@ -8,7 +8,7 @@ import {
 	SecurityCCNonceGet,
 	SecurityCCNonceReport,
 } from "@zwave-js/cc";
-import { CommandClasses, SecurityManager } from "@zwave-js/core";
+import { CommandClasses, SecurityClass, SecurityManager } from "@zwave-js/core";
 import {
 	type MockNodeBehavior,
 	type MockZWaveFrame,
@@ -18,171 +18,197 @@ import {
 import { integrationTest } from "../integrationTestSuite.js";
 
 integrationTest("Communication via Security S0 works", {
-	// debug: true,
+	debug: true,
 
 	nodeCapabilities: {
-		commandClasses: [CommandClasses.Basic, CommandClasses.Security],
+		commandClasses: [
+			CommandClasses.Version,
+			CommandClasses.Security,
+			{
+				ccId: CommandClasses.Basic,
+				secure: true,
+			},
+		],
+		securityClasses: new Set([SecurityClass.S0_Legacy]),
 	},
 
 	customSetup: async (driver, controller, mockNode) => {
-		// Create a security manager for the node
-		const sm0Node = new SecurityManager({
-			ownNodeId: mockNode.id,
-			networkKey: driver.options.securityKeys!.S0_Legacy!,
-			nonceTimeout: 100000,
-		});
-		mockNode.securityManagers.securityManager = sm0Node;
+		// // Create a security manager for the node
+		// const sm0Node = new SecurityManager({
+		// 	ownNodeId: mockNode.id,
+		// 	networkKey: driver.options.securityKeys!.S0_Legacy!,
+		// 	nonceTimeout: 100000,
+		// });
+		// mockNode.securityManagers.securityManager = sm0Node;
 
-		// Create a security manager for the controller
-		const sm0Ctrlr = new SecurityManager({
-			ownNodeId: controller.ownNodeId,
-			networkKey: driver.options.securityKeys!.S0_Legacy!,
-			nonceTimeout: 100000,
-		});
-		controller.securityManagers.securityManager = sm0Ctrlr;
+		// // Create a security manager for the controller
+		// const sm0Ctrlr = new SecurityManager({
+		// 	ownNodeId: controller.ownNodeId,
+		// 	networkKey: driver.options.securityKeys!.S0_Legacy!,
+		// 	nonceTimeout: 100000,
+		// });
+		// controller.securityManagers.securityManager = sm0Ctrlr;
 
-		// Respond to S0 Nonce Get
-		const respondToS0NonceGet: MockNodeBehavior = {
-			handleCC(controller, self, receivedCC) {
-				if (receivedCC instanceof SecurityCCNonceGet) {
-					const nonce = sm0Node.generateNonce(
-						controller.ownNodeId,
-						8,
-					);
-					const cc = new SecurityCCNonceReport({
-						nodeId: controller.ownNodeId,
-						nonce,
-					});
-					return { action: "sendCC", cc };
-				}
-			},
-		};
-		mockNode.defineBehavior(respondToS0NonceGet);
+		// // Respond to S0 Nonce Get
+		// const respondToS0NonceGet: MockNodeBehavior = {
+		// 	handleCC(controller, self, receivedCC) {
+		// 		if (receivedCC instanceof SecurityCCNonceGet) {
+		// 			const nonce = sm0Node.generateNonce(
+		// 				controller.ownNodeId,
+		// 				8,
+		// 			);
+		// 			const cc = new SecurityCCNonceReport({
+		// 				nodeId: controller.ownNodeId,
+		// 				nonce,
+		// 			});
+		// 			return { action: "sendCC", cc };
+		// 		}
+		// 	},
+		// };
+		// mockNode.defineBehavior(respondToS0NonceGet);
 
-		// Respond to S0 Commands Supported Get
-		const respondToS0CommandsSupportedGet: MockNodeBehavior = {
-			async handleCC(controller, self, receivedCC) {
-				if (
-					receivedCC instanceof SecurityCCCommandEncapsulation
-					&& receivedCC.encapsulated
-						instanceof SecurityCCCommandsSupportedGet
-				) {
-					const nonceGet = new SecurityCCNonceGet({
-						nodeId: controller.ownNodeId,
-					});
-					await self.sendToController(
-						createMockZWaveRequestFrame(nonceGet, {
-							ackRequested: false,
-						}),
-					);
+		// // Respond to S0 Commands Supported Get
+		// const respondToS0CommandsSupportedGet: MockNodeBehavior = {
+		// 	async handleCC(controller, self, receivedCC) {
+		// 		if (
+		// 			receivedCC instanceof SecurityCCCommandEncapsulation
+		// 			&& receivedCC.encapsulated
+		// 				instanceof SecurityCCCommandsSupportedGet
+		// 		) {
+		// 			const nonceGet = new SecurityCCNonceGet({
+		// 				nodeId: controller.ownNodeId,
+		// 			});
+		// 			await self.sendToController(
+		// 				createMockZWaveRequestFrame(nonceGet, {
+		// 					ackRequested: false,
+		// 				}),
+		// 			);
 
-					const nonceReport = await self.expectControllerFrame(
-						(
-							resp,
-						): resp is MockZWaveFrame & {
-							type: MockZWaveFrameType.Request;
-							payload: SecurityCCNonceReport;
-						} => resp.type === MockZWaveFrameType.Request
-							&& resp.payload instanceof SecurityCCNonceReport,
-						{ timeout: 1000 },
-					);
-					const receiverNonce = nonceReport.payload.nonce;
+		// 			const nonceReport = await self.expectControllerFrame(
+		// 				(
+		// 					resp,
+		// 				): resp is MockZWaveFrame & {
+		// 					type: MockZWaveFrameType.Request;
+		// 					payload: SecurityCCNonceReport;
+		// 				} => resp.type === MockZWaveFrameType.Request
+		// 					&& resp.payload instanceof SecurityCCNonceReport,
+		// 				{ timeout: 1000 },
+		// 			);
+		// 			const receiverNonce = nonceReport.payload.nonce;
 
-					const response = new SecurityCCCommandsSupportedReport({
-						nodeId: controller.ownNodeId,
-						supportedCCs: [CommandClasses.Basic],
-						controlledCCs: [],
-						reportsToFollow: 0,
-					});
-					const cc = SecurityCC.encapsulate(
-						self.id,
-						self.securityManagers.securityManager!,
-						response,
-					);
-					cc.nonce = receiverNonce;
+		// 			const response = new SecurityCCCommandsSupportedReport({
+		// 				nodeId: controller.ownNodeId,
+		// 				supportedCCs: [CommandClasses.Basic],
+		// 				controlledCCs: [],
+		// 				reportsToFollow: 0,
+		// 			});
+		// 			const cc = SecurityCC.encapsulate(
+		// 				self.id,
+		// 				self.securityManagers.securityManager!,
+		// 				response,
+		// 			);
+		// 			cc.nonce = receiverNonce;
 
-					await self.sendToController(
-						createMockZWaveRequestFrame(cc, {
-							ackRequested: false,
-						}),
-					);
+		// 			await self.sendToController(
+		// 				createMockZWaveRequestFrame(cc, {
+		// 					ackRequested: false,
+		// 				}),
+		// 			);
 
-					return { action: "stop" };
-				}
-			},
-		};
-		mockNode.defineBehavior(respondToS0CommandsSupportedGet);
+		// 			return { action: "stop" };
+		// 		}
+		// 	},
+		// };
+		// mockNode.defineBehavior(respondToS0CommandsSupportedGet);
 
-		// Respond to S0-encapsulated Basic Get with a level that increases with each request
+		// // Respond to S0-encapsulated Basic Get with a level that increases with each request
+		// let queryCount = 0;
+		// const respondToS0BasicGet: MockNodeBehavior = {
+		// 	async handleCC(controller, self, receivedCC) {
+		// 		if (
+		// 			receivedCC instanceof SecurityCCCommandEncapsulation
+		// 			&& receivedCC.encapsulated instanceof BasicCCGet
+		// 		) {
+		// 			const nonceGet = new SecurityCCNonceGet({
+		// 				nodeId: controller.ownNodeId,
+		// 			});
+		// 			await self.sendToController(
+		// 				createMockZWaveRequestFrame(nonceGet, {
+		// 					ackRequested: false,
+		// 				}),
+		// 			);
+
+		// 			const nonceReport = await self.expectControllerFrame(
+		// 				(
+		// 					resp,
+		// 				): resp is MockZWaveFrame & {
+		// 					type: MockZWaveFrameType.Request;
+		// 					payload: SecurityCCNonceReport;
+		// 				} => resp.type === MockZWaveFrameType.Request
+		// 					&& resp.payload instanceof SecurityCCNonceReport,
+		// 				{ timeout: 1000 },
+		// 			);
+		// 			const receiverNonce = nonceReport.payload.nonce;
+
+		// 			const response = new BasicCCReport({
+		// 				nodeId: controller.ownNodeId,
+		// 				currentValue: ++queryCount,
+		// 			});
+		// 			const cc = SecurityCC.encapsulate(
+		// 				self.id,
+		// 				self.securityManagers.securityManager!,
+		// 				response,
+		// 			);
+		// 			cc.nonce = receiverNonce;
+
+		// 			await self.sendToController(
+		// 				createMockZWaveRequestFrame(cc, {
+		// 					ackRequested: false,
+		// 				}),
+		// 			);
+
+		// 			return { action: "stop" };
+		// 		}
+		// 	},
+		// };
+		// mockNode.defineBehavior(respondToS0BasicGet);
+
+		// Respond to Basic Get with a level that increases with each request
 		let queryCount = 0;
-		const respondToS0BasicGet: MockNodeBehavior = {
+		const respondToBasicGet: MockNodeBehavior = {
 			async handleCC(controller, self, receivedCC) {
 				if (
-					receivedCC instanceof SecurityCCCommandEncapsulation
-					&& receivedCC.encapsulated instanceof BasicCCGet
+					receivedCC instanceof BasicCCGet
 				) {
-					const nonceGet = new SecurityCCNonceGet({
-						nodeId: controller.ownNodeId,
-					});
-					await self.sendToController(
-						createMockZWaveRequestFrame(nonceGet, {
-							ackRequested: false,
-						}),
-					);
-
-					const nonceReport = await self.expectControllerFrame(
-						(
-							resp,
-						): resp is MockZWaveFrame & {
-							type: MockZWaveFrameType.Request;
-							payload: SecurityCCNonceReport;
-						} => resp.type === MockZWaveFrameType.Request
-							&& resp.payload instanceof SecurityCCNonceReport,
-						{ timeout: 1000 },
-					);
-					const receiverNonce = nonceReport.payload.nonce;
-
 					const response = new BasicCCReport({
 						nodeId: controller.ownNodeId,
 						currentValue: ++queryCount,
 					});
-					const cc = SecurityCC.encapsulate(
-						self.id,
-						self.securityManagers.securityManager!,
-						response,
-					);
-					cc.nonce = receiverNonce;
 
-					await self.sendToController(
-						createMockZWaveRequestFrame(cc, {
-							ackRequested: false,
-						}),
-					);
-
-					return { action: "stop" };
+					return { action: "sendCC", cc: response };
 				}
 			},
 		};
-		mockNode.defineBehavior(respondToS0BasicGet);
+		mockNode.defineBehavior(respondToBasicGet);
 
-		// Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
-		const parseS0CC: MockNodeBehavior = {
-			async handleCC(controller, self, receivedCC) {
-				// We don't support sequenced commands here
-				if (receivedCC instanceof SecurityCCCommandEncapsulation) {
-					await receivedCC.mergePartialCCs([], {
-						sourceNodeId: controller.ownNodeId,
-						__internalIsMockNode: true,
-						frameType: "singlecast",
-						...self.encodingContext,
-						...self.securityManagers,
-					});
-				}
-				// This just decodes - we need to call further handlers
-				return undefined;
-			},
-		};
-		mockNode.defineBehavior(parseS0CC);
+		// // Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
+		// const parseS0CC: MockNodeBehavior = {
+		// 	async handleCC(controller, self, receivedCC) {
+		// 		// We don't support sequenced commands here
+		// 		if (receivedCC instanceof SecurityCCCommandEncapsulation) {
+		// 			await receivedCC.mergePartialCCs([], {
+		// 				sourceNodeId: controller.ownNodeId,
+		// 				__internalIsMockNode: true,
+		// 				frameType: "singlecast",
+		// 				...self.encodingContext,
+		// 				...self.securityManagers,
+		// 			});
+		// 		}
+		// 		// This just decodes - we need to call further handlers
+		// 		return undefined;
+		// 	},
+		// };
+		// mockNode.defineBehavior(parseS0CC);
 	},
 
 	testBody: async (t, driver, node, mockController, mockNode) => {

--- a/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
@@ -1,14 +1,10 @@
 import {
 	BasicCCGet,
 	BasicCCReport,
-	SecurityCC,
-	SecurityCCCommandEncapsulation,
-	SecurityCCCommandsSupportedGet,
-	SecurityCCCommandsSupportedReport,
 	SecurityCCNonceGet,
 	SecurityCCNonceReport,
 } from "@zwave-js/cc";
-import { CommandClasses, SecurityClass, SecurityManager } from "@zwave-js/core";
+import { CommandClasses, SecurityClass } from "@zwave-js/core";
 import {
 	type MockNodeBehavior,
 	type MockZWaveFrame,

--- a/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s0EncapsulationTwoNodes.test.ts
@@ -8,7 +8,7 @@ import {
 	SecurityCCNonceGet,
 	SecurityCCNonceReport,
 } from "@zwave-js/cc";
-import { CommandClasses, SecurityManager } from "@zwave-js/core";
+import { CommandClasses, SecurityClass, SecurityManager } from "@zwave-js/core";
 import {
 	type MockNodeBehavior,
 	type MockZWaveFrame,
@@ -28,124 +28,39 @@ integrationTest(
 				id: 2,
 				capabilities: {
 					commandClasses: [
-						CommandClasses.Basic,
+						CommandClasses.Version,
 						CommandClasses.Security,
+						{
+							ccId: CommandClasses.Basic,
+							secure: true,
+						},
 					],
+					securityClasses: new Set([SecurityClass.S0_Legacy]),
 				},
 			},
 			{
 				id: 3,
 				capabilities: {
 					commandClasses: [
-						CommandClasses.Basic,
+						CommandClasses.Version,
 						CommandClasses.Security,
+						{
+							ccId: CommandClasses.Basic,
+							secure: true,
+						},
 					],
+					securityClasses: new Set([SecurityClass.S0_Legacy]),
 				},
 			},
 		],
 
 		customSetup: async (driver, controller, mockNodes) => {
 			for (const mockNode of mockNodes) {
-				// Create a security manager for the node
-				const sm0Node = new SecurityManager({
-					ownNodeId: mockNode.id,
-					networkKey: driver.options.securityKeys!.S0_Legacy!,
-					nonceTimeout: 100000,
-				});
-				mockNode.securityManagers.securityManager = sm0Node;
-
-				// Create a security manager for the controller
-				const sm0Ctrlr = new SecurityManager({
-					ownNodeId: controller.ownNodeId,
-					networkKey: driver.options.securityKeys!.S0_Legacy!,
-					nonceTimeout: 100000,
-				});
-				controller.securityManagers.securityManager = sm0Ctrlr;
-
-				// Respond to S0 Nonce Get
-				const respondToS0NonceGet: MockNodeBehavior = {
-					handleCC(controller, self, receivedCC) {
-						if (receivedCC instanceof SecurityCCNonceGet) {
-							const nonce = sm0Node.generateNonce(
-								controller.ownNodeId,
-								8,
-							);
-							const cc = new SecurityCCNonceReport({
-								nodeId: controller.ownNodeId,
-								nonce,
-							});
-							return { action: "sendCC", cc };
-						}
-					},
-				};
-				mockNode.defineBehavior(respondToS0NonceGet);
-
-				// Respond to S0 Commands Supported Get
-				const respondToS0CommandsSupportedGet: MockNodeBehavior = {
-					async handleCC(controller, self, receivedCC) {
-						if (
-							receivedCC instanceof SecurityCCCommandEncapsulation
-							&& receivedCC.encapsulated
-								instanceof SecurityCCCommandsSupportedGet
-						) {
-							const nonceGet = new SecurityCCNonceGet({
-								nodeId: controller.ownNodeId,
-							});
-							await self.sendToController(
-								createMockZWaveRequestFrame(nonceGet, {
-									ackRequested: false,
-								}),
-							);
-
-							const nonceReport = await self
-								.expectControllerFrame(
-									(
-										resp,
-									): resp is MockZWaveFrame & {
-										type: MockZWaveFrameType.Request;
-										payload: SecurityCCNonceReport;
-									} => resp.type
-											=== MockZWaveFrameType.Request
-										&& resp.payload
-											instanceof SecurityCCNonceReport,
-									{ timeout: 1000 },
-								);
-							const receiverNonce = nonceReport.payload.nonce;
-
-							const response =
-								new SecurityCCCommandsSupportedReport({
-									nodeId: controller.ownNodeId,
-									supportedCCs: [CommandClasses.Basic],
-									controlledCCs: [],
-									reportsToFollow: 0,
-								});
-							const cc = SecurityCC.encapsulate(
-								self.id,
-								self.securityManagers.securityManager!,
-								response,
-							);
-							cc.nonce = receiverNonce;
-
-							await self.sendToController(
-								createMockZWaveRequestFrame(cc, {
-									ackRequested: false,
-								}),
-							);
-
-							return { action: "stop" };
-						}
-					},
-				};
-				mockNode.defineBehavior(respondToS0CommandsSupportedGet);
-
-				// Respond to S0-encapsulated Basic Get with a level that increases with each request
+				// Respond to Basic Get with a level that increases with each request
 				let queryCount = 0;
-				const respondToS0BasicGet: MockNodeBehavior = {
+				const respondToBasicGet: MockNodeBehavior = {
 					async handleCC(controller, self, receivedCC) {
-						if (
-							receivedCC instanceof SecurityCCCommandEncapsulation
-							&& receivedCC.encapsulated instanceof BasicCCGet
-						) {
+						if (receivedCC instanceof BasicCCGet) {
 							// Introduce a delay in the response for the second query (after interview)
 							// so we can simulate the other node interfering
 							queryCount++;
@@ -153,73 +68,16 @@ integrationTest(
 								await wait(750);
 							}
 
-							const nonceGet = new SecurityCCNonceGet({
-								nodeId: controller.ownNodeId,
-							});
-							await self.sendToController(
-								createMockZWaveRequestFrame(nonceGet, {
-									ackRequested: false,
-								}),
-							);
-
-							const nonceReport = await self
-								.expectControllerFrame(
-									(
-										resp,
-									): resp is MockZWaveFrame & {
-										type: MockZWaveFrameType.Request;
-										payload: SecurityCCNonceReport;
-									} => resp.type
-											=== MockZWaveFrameType.Request
-										&& resp.payload
-											instanceof SecurityCCNonceReport,
-									{ timeout: 1000 },
-								);
-							const receiverNonce = nonceReport.payload.nonce;
-
 							const response = new BasicCCReport({
 								nodeId: controller.ownNodeId,
 								currentValue: queryCount,
 							});
-							const cc = SecurityCC.encapsulate(
-								self.id,
-								self.securityManagers.securityManager!,
-								response,
-							);
-							cc.nonce = receiverNonce;
 
-							await self.sendToController(
-								createMockZWaveRequestFrame(cc, {
-									ackRequested: false,
-								}),
-							);
-
-							return { action: "stop" };
+							return { action: "sendCC", cc: response };
 						}
 					},
 				};
-				mockNode.defineBehavior(respondToS0BasicGet);
-
-				// Parse Security CC commands. This MUST be defined last, since defineBehavior will prepend it to the list
-				const parseS0CC: MockNodeBehavior = {
-					async handleCC(controller, self, receivedCC) {
-						// We don't support sequenced commands here
-						if (
-							receivedCC instanceof SecurityCCCommandEncapsulation
-						) {
-							await receivedCC.mergePartialCCs([], {
-								sourceNodeId: controller.ownNodeId,
-								__internalIsMockNode: true,
-								frameType: "singlecast",
-								...self.encodingContext,
-								...self.securityManagers,
-							});
-						}
-						// This just decodes - we need to call further handlers
-						return undefined;
-					},
-				};
-				mockNode.defineBehavior(parseS0CC);
+				mockNode.defineBehavior(respondToBasicGet);
 			}
 		},
 

--- a/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2Collisions.test.ts
@@ -40,110 +40,23 @@ integrationTest(
 			"fixtures/s2CollisionsSupervised",
 		),
 
+		nodeCapabilities: {
+			securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
+		},
+
 		customSetup: async (driver, controller, mockNode) => {
-			// Create a security manager for the node
-			const smNode = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smNode.setKey(
-				SecurityClass.S2_AccessControl,
-				driver.options.securityKeys!.S2_AccessControl!,
-			);
-			await smNode.setKey(
-				SecurityClass.S2_Authenticated,
-				driver.options.securityKeys!.S2_Authenticated!,
-			);
-			await smNode.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			mockNode.securityManagers.securityManager2 = smNode;
-			mockNode.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Create a security manager for the controller
-			const smCtrlr = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smCtrlr.setKey(
-				SecurityClass.S2_AccessControl,
-				driver.options.securityKeys!.S2_AccessControl!,
-			);
-			await smCtrlr.setKey(
-				SecurityClass.S2_Authenticated,
-				driver.options.securityKeys!.S2_Authenticated!,
-			);
-			await smCtrlr.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Respond to Nonce Get
-			const respondToNonceGet: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof Security2CCNonceGet) {
-						const nonce = await smNode.generateNonce(
-							controller.ownNodeId,
-						);
-						const cc = new Security2CCNonceReport({
-							nodeId: controller.ownNodeId,
-							SOS: true,
-							MOS: false,
-							receiverEI: nonce,
-						});
-						return { action: "sendCC", cc };
-					}
-				},
-			};
-			mockNode.defineBehavior(respondToNonceGet);
-
-			// Handle decode errors
-			const handleInvalidCC: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof InvalidCC) {
-						if (
-							receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_CannotDecode
-							|| receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_NoSPAN
-						) {
-							const nonce = await smNode.generateNonce(
-								controller.ownNodeId,
-							);
-							const cc = new Security2CCNonceReport({
-								nodeId: controller.ownNodeId,
-								SOS: true,
-								MOS: false,
-								receiverEI: nonce,
-							});
-							return { action: "sendCC", cc };
-						}
-					}
-				},
-			};
-			mockNode.defineBehavior(handleInvalidCC);
-
 			// Just have the node respond to all Supervision Get positively
 			const respondToSupervisionGet: MockNodeBehavior = {
 				handleCC(controller, self, receivedCC) {
 					if (
-						receivedCC
-							instanceof Security2CCMessageEncapsulation
-						&& receivedCC.encapsulated
-							instanceof SupervisionCCGet
+						receivedCC instanceof SupervisionCCGet
 					) {
 						let cc: CommandClass = new SupervisionCCReport({
 							nodeId: controller.ownNodeId,
-							sessionId: receivedCC.encapsulated.sessionId,
+							sessionId: receivedCC.sessionId,
 							moreUpdatesFollow: false,
 							status: SupervisionStatus.Success,
 						});
-						cc = Security2CC.encapsulate(
-							cc,
-							self.id,
-							self.securityManagers,
-						);
 						return { action: "sendCC", cc };
 					}
 				},
@@ -207,89 +120,8 @@ integrationTest(
 			"fixtures/s2CollisionsUnsupervised",
 		),
 
-		customSetup: async (driver, controller, mockNode) => {
-			// Create a security manager for the node
-			const smNode = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smNode.setKey(
-				SecurityClass.S2_AccessControl,
-				driver.options.securityKeys!.S2_AccessControl!,
-			);
-			await smNode.setKey(
-				SecurityClass.S2_Authenticated,
-				driver.options.securityKeys!.S2_Authenticated!,
-			);
-			await smNode.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			mockNode.securityManagers.securityManager2 = smNode;
-			mockNode.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Create a security manager for the controller
-			const smCtrlr = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smCtrlr.setKey(
-				SecurityClass.S2_AccessControl,
-				driver.options.securityKeys!.S2_AccessControl!,
-			);
-			await smCtrlr.setKey(
-				SecurityClass.S2_Authenticated,
-				driver.options.securityKeys!.S2_Authenticated!,
-			);
-			await smCtrlr.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Respond to Nonce Get
-			const respondToNonceGet: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof Security2CCNonceGet) {
-						const nonce = await smNode.generateNonce(
-							controller.ownNodeId,
-						);
-						const cc = new Security2CCNonceReport({
-							nodeId: controller.ownNodeId,
-							SOS: true,
-							MOS: false,
-							receiverEI: nonce,
-						});
-						return { action: "sendCC", cc };
-					}
-				},
-			};
-			mockNode.defineBehavior(respondToNonceGet);
-
-			// Handle decode errors
-			const handleInvalidCC: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof InvalidCC) {
-						if (
-							receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_CannotDecode
-							|| receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_NoSPAN
-						) {
-							const nonce = await smNode.generateNonce(
-								controller.ownNodeId,
-							);
-							const cc = new Security2CCNonceReport({
-								nodeId: controller.ownNodeId,
-								SOS: true,
-								MOS: false,
-								receiverEI: nonce,
-							});
-							return { action: "sendCC", cc };
-						}
-					}
-				},
-			};
-			mockNode.defineBehavior(handleInvalidCC);
+		nodeCapabilities: {
+			securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
@@ -342,101 +174,20 @@ integrationTest(
 			"fixtures/s2CollisionsSupervised",
 		),
 
+		nodeCapabilities: {
+			securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
+		},
+
 		customSetup: async (driver, controller, mockNode) => {
-			// Create a security manager for the node
-			const smNode = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smNode.setKey(
-				SecurityClass.S2_AccessControl,
-				driver.options.securityKeys!.S2_AccessControl!,
-			);
-			await smNode.setKey(
-				SecurityClass.S2_Authenticated,
-				driver.options.securityKeys!.S2_Authenticated!,
-			);
-			await smNode.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			mockNode.securityManagers.securityManager2 = smNode;
-			mockNode.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Create a security manager for the controller
-			const smCtrlr = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smCtrlr.setKey(
-				SecurityClass.S2_AccessControl,
-				driver.options.securityKeys!.S2_AccessControl!,
-			);
-			await smCtrlr.setKey(
-				SecurityClass.S2_Authenticated,
-				driver.options.securityKeys!.S2_Authenticated!,
-			);
-			await smCtrlr.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			controller.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Respond to Nonce Get
-			const respondToNonceGet: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof Security2CCNonceGet) {
-						const nonce = await smNode.generateNonce(
-							controller.ownNodeId,
-						);
-						const cc = new Security2CCNonceReport({
-							nodeId: controller.ownNodeId,
-							SOS: true,
-							MOS: false,
-							receiverEI: nonce,
-						});
-						return { action: "sendCC", cc };
-					}
-				},
-			};
-			mockNode.defineBehavior(respondToNonceGet);
-
-			// Handle decode errors
-			const handleInvalidCC: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof InvalidCC) {
-						if (
-							receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_CannotDecode
-							|| receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_NoSPAN
-						) {
-							const nonce = await smNode.generateNonce(
-								controller.ownNodeId,
-							);
-							const cc = new Security2CCNonceReport({
-								nodeId: controller.ownNodeId,
-								SOS: true,
-								MOS: false,
-								receiverEI: nonce,
-							});
-							return { action: "sendCC", cc };
-						}
-					}
-				},
-			};
-			mockNode.defineBehavior(handleInvalidCC);
-
 			// Just have the node respond to all Supervision Get positively
 			const respondToSupervisionGet: MockNodeBehavior = {
 				handleCC(controller, self, receivedCC) {
 					if (
-						receivedCC
-							instanceof Security2CCMessageEncapsulation
-						&& receivedCC.encapsulated
-							instanceof SupervisionCCGet
+						receivedCC instanceof SupervisionCCGet
 					) {
 						let cc: CommandClass = new SupervisionCCReport({
 							nodeId: controller.ownNodeId,
-							sessionId: receivedCC.encapsulated.sessionId,
+							sessionId: receivedCC.sessionId,
 							moreUpdatesFollow: false,
 							status: SupervisionStatus.Success,
 						});
@@ -508,34 +259,6 @@ integrationTest(
 				status: SupervisionStatus.Success,
 			});
 			t.expect(confirmationResult).toBeDefined();
-
-			// // Now create a collision by having both parties send at the same time
-			// const nodeToHost = Security2CC.encapsulate(
-			// 	new BasicCCReport({
-			// 		nodeId: mockController.ownNodeId,
-			// 		currentValue: 99,
-			// 	}),
-			// );
-			// const p1 = mockNode.sendToController(
-			// 	createMockZWaveRequestFrame(nodeToHost, {
-			// 		ackRequested: true,
-			// 	}),
-			// );
-			// const p2 = node.commandClasses.Basic.set(0);
-
-			// const [, p2result] = await Promise.all([p1, p2]);
-
-			// // Give the node a chance to respond
-			// await wait(250);
-
-			// // If the collision was handled gracefully, we should now have the value reported by the node
-			// const currentValue = node.getValue(BasicCCValues.currentValue.id);
-			// t.is(currentValue, 99);
-
-			// // Ensure the Basic Set causing a collision eventually gets resolved
-			// t.like(p2result, {
-			// 	status: SupervisionStatus.Success,
-			// });
 		},
 	},
 );
@@ -551,102 +274,20 @@ integrationTest(
 			"fixtures/s2CollisionsSupervised",
 		),
 
+		nodeCapabilities: {
+			securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
+		},
+
 		customSetup: async (driver, controller, mockNode) => {
-			// Create a security manager for the node
-			const smNode = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smNode.setKey(
-				SecurityClass.S2_AccessControl,
-				driver.options.securityKeys!.S2_AccessControl!,
-			);
-			await smNode.setKey(
-				SecurityClass.S2_Authenticated,
-				driver.options.securityKeys!.S2_Authenticated!,
-			);
-			await smNode.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			mockNode.securityManagers.securityManager2 = smNode;
-			mockNode.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Create a security manager for the controller
-			const smCtrlr = await SecurityManager2.create();
-			// Copy keys from the driver
-			await smCtrlr.setKey(
-				SecurityClass.S2_AccessControl,
-				driver.options.securityKeys!.S2_AccessControl!,
-			);
-			await smCtrlr.setKey(
-				SecurityClass.S2_Authenticated,
-				driver.options.securityKeys!.S2_Authenticated!,
-			);
-			await smCtrlr.setKey(
-				SecurityClass.S2_Unauthenticated,
-				driver.options.securityKeys!.S2_Unauthenticated!,
-			);
-			controller.securityManagers.securityManager2 = smCtrlr;
-			controller.encodingContext.getHighestSecurityClass = () =>
-				SecurityClass.S2_Unauthenticated;
-
-			// Respond to Nonce Get
-			const respondToNonceGet: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof Security2CCNonceGet) {
-						const nonce = await smNode.generateNonce(
-							controller.ownNodeId,
-						);
-						const cc = new Security2CCNonceReport({
-							nodeId: controller.ownNodeId,
-							SOS: true,
-							MOS: false,
-							receiverEI: nonce,
-						});
-						return { action: "sendCC", cc };
-					}
-				},
-			};
-			mockNode.defineBehavior(respondToNonceGet);
-
-			// Handle decode errors
-			const handleInvalidCC: MockNodeBehavior = {
-				async handleCC(controller, self, receivedCC) {
-					if (receivedCC instanceof InvalidCC) {
-						if (
-							receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_CannotDecode
-							|| receivedCC.reason
-								=== ZWaveErrorCodes.Security2CC_NoSPAN
-						) {
-							const nonce = await smNode.generateNonce(
-								controller.ownNodeId,
-							);
-							const cc = new Security2CCNonceReport({
-								nodeId: controller.ownNodeId,
-								SOS: true,
-								MOS: false,
-								receiverEI: nonce,
-							});
-							return { action: "sendCC", cc };
-						}
-					}
-				},
-			};
-			mockNode.defineBehavior(handleInvalidCC);
-
 			// Just have the node respond to all Supervision Get positively
 			const respondToSupervisionGet: MockNodeBehavior = {
 				handleCC(controller, self, receivedCC) {
 					if (
-						receivedCC
-							instanceof Security2CCMessageEncapsulation
-						&& receivedCC.encapsulated
-							instanceof SupervisionCCGet
+						receivedCC instanceof SupervisionCCGet
 					) {
 						let cc: CommandClass = new SupervisionCCReport({
 							nodeId: controller.ownNodeId,
-							sessionId: receivedCC.encapsulated.sessionId,
+							sessionId: receivedCC.sessionId,
 							moreUpdatesFollow: false,
 							status: SupervisionStatus.Success,
 						});

--- a/packages/zwave-js/src/lib/test/driver/s2Encapsulation.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/s2Encapsulation.test.ts
@@ -1,0 +1,46 @@
+import { BasicCCGet, BasicCCReport } from "@zwave-js/cc";
+import { CommandClasses, SecurityClass } from "@zwave-js/core";
+import { type MockNodeBehavior } from "@zwave-js/testing";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest("Communication via Security S2 works", {
+	// debug: true,
+
+	nodeCapabilities: {
+		commandClasses: [
+			CommandClasses.Version,
+			CommandClasses["Security 2"],
+			{
+				ccId: CommandClasses.Basic,
+				secure: true,
+			},
+		],
+		securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
+	},
+
+	customSetup: async (driver, controller, mockNode) => {
+		// Respond to Basic Get with a level that increases with each request
+		let queryCount = 0;
+		const respondToBasicGet: MockNodeBehavior = {
+			async handleCC(controller, self, receivedCC) {
+				if (
+					receivedCC instanceof BasicCCGet
+				) {
+					const response = new BasicCCReport({
+						nodeId: controller.ownNodeId,
+						currentValue: ++queryCount,
+					});
+
+					return { action: "sendCC", cc: response };
+				}
+			},
+		};
+		mockNode.defineBehavior(respondToBasicGet);
+	},
+
+	testBody: async (t, driver, node, mockController, mockNode) => {
+		const result = await node.commandClasses.Basic.get();
+
+		t.expect(result?.currentValue).toBe(2);
+	},
+});

--- a/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponse.test.ts
@@ -60,7 +60,7 @@ integrationTest(
 				async handleCC(controller, self, receivedCC) {
 					if (receivedCC instanceof BasicCCGet) {
 						const cc = new BasicCCReport({
-							nodeId: self.id,
+							nodeId: controller.ownNodeId,
 							currentValue: 42,
 						});
 						return { action: "sendCC", cc };

--- a/packages/zwave-js/src/lib/test/driver/supervisionRepeatedReport.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/supervisionRepeatedReport.test.ts
@@ -43,7 +43,7 @@ integrationTest(
 				handleCC(controller, self, receivedCC) {
 					if (receivedCC instanceof SupervisionCCGet) {
 						const cc = new SupervisionCCReport({
-							nodeId: self.id,
+							nodeId: controller.ownNodeId,
 							sessionId: receivedCC.sessionId,
 							moreUpdatesFollow: false,
 							status: SupervisionStatus.Success,

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -110,6 +110,7 @@ function suite(
 			serial,
 			{
 				capabilities: controllerCapabilities,
+				securityKeys: driver.options.securityKeys,
 			},
 			[
 				{

--- a/packages/zwave-js/src/lib/test/integrationTestSuite.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuite.ts
@@ -105,7 +105,7 @@ function suite(
 		({
 			mockController,
 			mockNodes: [mockNode],
-		} = prepareMocks(
+		} = await prepareMocks(
 			mockPort,
 			serial,
 			{

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -106,6 +106,7 @@ function suite(
 			serial,
 			{
 				capabilities: controllerCapabilities,
+				securityKeys: driver.options.securityKeys,
 			},
 			// TODO: This isn't ideal as it requires us to provide the
 			// node capabilities in addition to the provisioning directory

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteMulti.ts
@@ -101,7 +101,7 @@ function suite(
 			debug,
 			additionalDriverOptions,
 		));
-		({ mockController, mockNodes } = prepareMocks(
+		({ mockController, mockNodes } = await prepareMocks(
 			mockPort,
 			serial,
 			{

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
@@ -70,7 +70,7 @@ export function prepareDriver(
 	});
 }
 
-export function prepareMocks(
+export async function prepareMocks(
 	mockPort: MockPort,
 	serial: ZWaveSerialStream,
 	controller: Pick<
@@ -78,11 +78,11 @@ export function prepareMocks(
 		"ownNodeId" | "homeId" | "capabilities" | "securityKeys"
 	> = {},
 	nodes: Pick<MockNodeOptions, "id" | "capabilities">[] = [],
-): {
+): Promise<{
 	mockController: MockController;
 	mockNodes: MockNode[];
-} {
-	const mockController = new MockController({
+}> {
+	const mockController = await MockController.create({
 		homeId: 0x7e570001,
 		ownNodeId: 1,
 		...controller,
@@ -94,7 +94,7 @@ export function prepareMocks(
 
 	const mockNodes: MockNode[] = [];
 	for (const node of nodes) {
-		const mockNode = new MockNode({
+		const mockNode = await MockNode.create({
 			...node,
 			controller: mockController,
 		});

--- a/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
+++ b/packages/zwave-js/src/lib/test/integrationTestSuiteShared.ts
@@ -75,7 +75,7 @@ export function prepareMocks(
 	serial: ZWaveSerialStream,
 	controller: Pick<
 		MockControllerOptions,
-		"ownNodeId" | "homeId" | "capabilities"
+		"ownNodeId" | "homeId" | "capabilities" | "securityKeys"
 	> = {},
 	nodes: Pick<MockNodeOptions, "id" | "capabilities">[] = [],
 ): {

--- a/packages/zwave-js/src/lib/test/node/Node.ccVersions.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.ccVersions.test.ts
@@ -22,8 +22,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/node/Node.constructor.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.constructor.test.ts
@@ -26,8 +26,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/node/Node.createCCInstance.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.createCCInstance.test.ts
@@ -28,8 +28,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/node/Node.getEndpoint.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.getEndpoint.test.ts
@@ -29,8 +29,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/node/Node.getSetValue.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.getSetValue.test.ts
@@ -27,8 +27,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/node/Node.status.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.status.test.ts
@@ -24,8 +24,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/node/Node.updateNodeInfo.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.updateNodeInfo.test.ts
@@ -32,8 +32,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/node/Node.valueEvents.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.valueEvents.test.ts
@@ -25,8 +25,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/lib/test/node/Node.waitForWakeup.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.waitForWakeup.test.ts
@@ -29,8 +29,8 @@ const test = baseTest.extend<LocalTestContext>({
 			const { driver } = await createAndStartTestingDriver({
 				skipNodeInterview: true,
 				loadConfiguration: false,
-				beforeStartup(mockPort, serial) {
-					const controller = new MockController({
+				async beforeStartup(mockPort, serial) {
+					const controller = await MockController.create({
 						mockPort,
 						serial,
 					});

--- a/packages/zwave-js/src/mockServer.ts
+++ b/packages/zwave-js/src/mockServer.ts
@@ -109,7 +109,7 @@ export class MockServer {
 
 		// Hook up a fake controller and nodes
 		({ mockController: this.mockController, mockNodes: this.mockNodes } =
-			prepareMocks(
+			await prepareMocks(
 				mockPort,
 				serial,
 				this.options.config?.controller,
@@ -228,13 +228,13 @@ export class MockServer {
 	}
 }
 
-function prepareMocks(
+async function prepareMocks(
 	mockPort: MockPort,
 	serial: ZWaveSerialStream,
 	controller: MockServerControllerOptions = {},
 	nodes: MockServerNodeOptions[] = [],
-): { mockController: MockController; mockNodes: MockNode[] } {
-	const mockController = new MockController({
+): Promise<{ mockController: MockController; mockNodes: MockNode[]; }> {
+	const mockController = await MockController.create({
 		homeId: 0x7e570001,
 		ownNodeId: 1,
 		...controller,
@@ -250,7 +250,7 @@ function prepareMocks(
 
 	const mockNodes: MockNode[] = [];
 	for (const node of nodes) {
-		const mockNode = new MockNode({
+		const mockNode = await MockNode.create({
 			...node,
 			controller: mockController,
 		});

--- a/packages/zwave-js/src/mockServer.ts
+++ b/packages/zwave-js/src/mockServer.ts
@@ -233,7 +233,7 @@ async function prepareMocks(
 	serial: ZWaveSerialStream,
 	controller: MockServerControllerOptions = {},
 	nodes: MockServerNodeOptions[] = [],
-): Promise<{ mockController: MockController; mockNodes: MockNode[]; }> {
+): Promise<{ mockController: MockController; mockNodes: MockNode[] }> {
 	const mockController = await MockController.create({
 		homeId: 0x7e570001,
 		ownNodeId: 1,


### PR DESCRIPTION
With this PR, S0 and S2 are now handled out of the box in integration tests and the mock server, without needing complicated SecurityManager and behavior setups per test. This also allows us to simulate the inclusion of secure devices and to reproduce some issues that are triggered by complex S2/Supervision/etc. interactions.