### PR TITLE
fix: ignore Basic CC when constructing node instance from a NIF

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -112,6 +112,7 @@
 	"chat.tools.terminal.autoApprove": {
 		"git show": true,
 		"yarn fmt": true,
+		"yarn vitest run": true,
 		"rm": false,
 		"rmdir": false,
 		"del": false,

--- a/packages/zwave-js/src/lib/node/Endpoint.ts
+++ b/packages/zwave-js/src/lib/node/Endpoint.ts
@@ -75,6 +75,16 @@ export class Endpoint
 		// Add optional CCs
 		if (supportedCCs != undefined) {
 			for (const cc of supportedCCs) {
+				if (cc === CommandClasses.Basic) {
+					// This codepath is only taken when we construct
+					// a node instance with info from a NIF.
+					//
+					// Basic CC MUST not be in the NIF. If it is anyways, we ignore it.
+					// If we blindly add it here as supported, it will always be exposed.
+					//
+					// Whether or not it should be exposed is determined at a later stage.
+					continue;
+				}
 				this.addCC(cc, { isSupported: true });
 			}
 		}

--- a/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/basicCCSupportWhenForbidden.test.ts
@@ -1,7 +1,15 @@
-import { BasicCCValues } from "@zwave-js/cc";
+import {
+	BasicCCValues,
+	ZWaveProtocolCCNodeInformationFrame,
+	ZWaveProtocolCCRequestNodeInformationFrame,
+} from "@zwave-js/cc";
 import { CommandClasses } from "@zwave-js/core";
+import { type MockNodeBehavior } from "@zwave-js/testing";
 import path from "node:path";
+import { InclusionStrategy } from "../../controller/Inclusion.js";
+import { type ZWaveNode } from "../../node/Node.js";
 import { integrationTest } from "../integrationTestSuite.js";
+import { integrationTest as integrationTestMulti } from "../integrationTestSuiteMulti.js";
 
 integrationTest(
 	"On devices that MUST not support Basic CC, and treat Basic Set as a report, ONLY currentValue should be exposed",
@@ -92,6 +100,117 @@ integrationTest(
 
 		async testBody(t, driver, node, mockController, mockNode) {
 			const valueIDs = node.getDefinedValueIDs();
+			t.expect(
+				valueIDs.some((v) => BasicCCValues.currentValue.is(v)),
+				"Found Basic CC currentValue although it shouldn't be exposed",
+			).toBe(false);
+			t.expect(
+				valueIDs.some((v) => BasicCCValues.targetValue.is(v)),
+				"Found Basic CC targetValue although it shouldn't be exposed",
+			).toBe(false);
+			t.expect(
+				valueIDs.some((v) => BasicCCValues.duration.is(v)),
+				"Found Basic CC duration although it shouldn't be exposed",
+			).toBe(false);
+			t.expect(
+				valueIDs.some((v) => BasicCCValues.restorePrevious.is(v)),
+				"Found Basic CC restorePrevious although it shouldn't be exposed",
+			).toBe(false);
+
+			t.expect(
+				valueIDs.some((v) => BasicCCValues.compatEvent.is(v)),
+				"Found Basic CC compatEvent although it shouldn't be exposed",
+			).toBe(false);
+		},
+	},
+);
+
+integrationTestMulti(
+	"After including a device with support for an actuator CC, NO Basic CC values should be exposed, even if it is explicitly listed in the NIF",
+	{
+		// Repro for #8408
+		// debug: true,
+
+		async testBody(t, driver, nodes, mockController, mockNodes) {
+			mockController.nodePendingInclusion = {
+				id: 2,
+				capabilities: {
+					manufacturerId: 0xdead,
+					productType: 0xbeef,
+					productId: 0xcafe,
+
+					commandClasses: [
+						CommandClasses["Binary Switch"],
+						CommandClasses.Version,
+						CommandClasses["Manufacturer Specific"],
+						CommandClasses.Basic,
+					],
+				},
+
+				setup(node) {
+					// Override the node's behavior to include Basic CC in the NIF
+					const respondToRequestNodeInfoWithBasicCC:
+						MockNodeBehavior = {
+							handleCC(controller, self, receivedCC) {
+								if (
+									receivedCC
+										instanceof ZWaveProtocolCCRequestNodeInformationFrame
+								) {
+									const cc =
+										new ZWaveProtocolCCNodeInformationFrame(
+											{
+												// eslint-disable-next-line @zwave-js/consistent-mock-node-behaviors
+												nodeId: self.id, // We actually need to set this like this for the NIF
+												...self.capabilities,
+												supportedCCs: [
+													...self.implementedCCs,
+												]
+													// Only include supported CCs
+													.filter(([, info]) =>
+														info.isSupported
+													)
+													// FIXME: Filter out secure CCs if the node isn't secure
+													.map(([ccId]) => ccId),
+											},
+										);
+									return { action: "sendCC", cc };
+								}
+							},
+						};
+					node.defineBehavior(
+						respondToRequestNodeInfoWithBasicCC,
+					);
+				},
+			};
+
+			// Set up a promise to wait for the "node added" event
+			let includedNode: ZWaveNode | undefined;
+			const nodeAddedPromise = new Promise<void>((resolve) => {
+				driver.controller.once("node added", (node) => {
+					includedNode = node;
+					resolve();
+				});
+			});
+
+			// Start the inclusion process with S2
+			await driver.controller.beginInclusion({
+				strategy: InclusionStrategy.Insecure,
+			});
+
+			// Wait for the "node added" event
+			await nodeAddedPromise;
+
+			// Wait for the interview to complete
+			const interviewCompletePromise = new Promise<void>((resolve) => {
+				includedNode!.once("interview completed", () => {
+					resolve();
+				});
+			});
+			await interviewCompletePromise;
+
+			t.expect(includedNode).toBeDefined();
+
+			const valueIDs = includedNode!.getDefinedValueIDs();
 			t.expect(
 				valueIDs.some((v) => BasicCCValues.currentValue.is(v)),
 				"Found Basic CC currentValue although it shouldn't be exposed",


### PR DESCRIPTION
This PR fixes an issue where Basic CC values would incorrectly be exposed on a device that supports another actuator CC. This was the case after inclusion when the NIF of the device incorrectly includes Basic CC.

We now ignore the Basic CC at that stage and only add it back during the following interview if necessary.