### PR TITLE
fix(config): add product id `0x03b9` to Kwikset 918

### DIFF
--- a/packages/config/config/devices/0x0090/918.json
+++ b/packages/config/config/devices/0x0090/918.json
@@ -10,6 +10,10 @@
 		},
 		{
 			"productType": "0x0811",
+			"productId": "0x03b9"
+		},
+		{
+			"productType": "0x0811",
 			"productId": "0x00b9"
 		}
 	],


### PR DESCRIPTION
<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

fixes: #8431
