### PR TITLE
fix(zooz_template): change auto timer default to 0 for ZEN04 Smart Plug

### DIFF
--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -142,9 +142,9 @@
 	"auto_timer_duration_base": {
 		"valueSize": 4,
 		"unit": "minutes",
-		"minValue": 1,
+		"minValue": 0,
 		"maxValue": 65535,
-		"defaultValue": 60,
+		"defaultValue": 0,
 		"unsigned": true
 	},
 	"auto_off_timer_duration": {


### PR DESCRIPTION
Updated to match values for ZEN04 Smart Plug 
[ ZEN04 Smart Plug Advanced Settings ](https://www.support.getzooz.com/kb/article/1114-zen04-smart-plug-advanced-settings/)

Not sure if the previous defaults are accurate. If they are then maybe this should be a product specific change. 
