### PR TITLE
feat(cc): implement `refreshValues` for Window Covering CC

### DIFF
--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -37,6 +37,7 @@ import {
 	type CCRaw,
 	CommandClass,
 	type InterviewContext,
+	type RefreshValuesContext,
 } from "../lib/CommandClass.js";
 import {
 	API,
@@ -609,6 +610,43 @@ ${
 
 		// Remember that the interview is complete
 		this.setInterviewComplete(ctx, true);
+	}
+
+	public async refreshValues(
+		ctx: RefreshValuesContext,
+	): Promise<void> {
+		const node = this.getNode(ctx)!;
+		const endpoint = this.getEndpoint(ctx)!;
+		const api = CCAPI.create(
+			CommandClasses["Window Covering"],
+			ctx,
+			endpoint,
+		).withOptions({
+			priority: MessagePriority.NodeQuery,
+		});
+
+		const parameters: number[] = this.getValue(
+			ctx,
+			WindowCoveringCCValues.supportedParameters,
+		) ?? [];
+
+		for (const param of parameters) {
+			if (param % 2 == 0) {
+				continue; // Even parameter, no position support, no need to query
+			}
+
+			ctx.logNode(node.id, {
+				endpoint: this.endpointIndex,
+				message: `querying position for parameter ${
+					getEnumMemberName(
+						WindowCoveringParameter,
+						param,
+					)
+				}...`,
+				direction: "outbound",
+			});
+			await api.get(param);
+		}
 	}
 
 	public translatePropertyKey(

--- a/packages/cc/src/cc/WindowCoveringCC.ts
+++ b/packages/cc/src/cc/WindowCoveringCC.ts
@@ -590,22 +590,10 @@ ${
 					ctx,
 					WindowCoveringCCValues.levelChangeDown(param),
 				);
-
-				// And for the odd parameters (with position support), query the position
-				if (param % 2 === 1) {
-					ctx.logNode(node.id, {
-						endpoint: this.endpointIndex,
-						message: `querying position for parameter ${
-							getEnumMemberName(
-								WindowCoveringParameter,
-								param,
-							)
-						}...`,
-						direction: "outbound",
-					});
-					await api.get(param);
-				}
 			}
+
+			// Query current values for all supported parameters
+			await this.refreshValues(ctx);
 		}
 
 		// Remember that the interview is complete
@@ -631,9 +619,8 @@ ${
 		) ?? [];
 
 		for (const param of parameters) {
-			if (param % 2 == 0) {
-				continue; // Even parameter, no position support, no need to query
-			}
+			// Only query odd parameters (with position support)
+			if (param % 2 == 0) continue;
 
 			ctx.logNode(node.id, {
 				endpoint: this.endpointIndex,


### PR DESCRIPTION
Previously, the "Refresh" button for Window Coverings was a no-op. This PR implements `WindowCoveringCC.refreshValues()` so that we actually query the device to refresh the values.

Tested with an iblinds v3 window covering.