### PR TITLE
fix: handle out of order S2 nonce reports when aborting transmission

### DIFF
--- a/packages/serial/src/message/Message.ts
+++ b/packages/serial/src/message/Message.ts
@@ -402,6 +402,9 @@ export class Message {
 		return false;
 	}
 
+	/** Gets set by the driver to remember an expected node update for this message that arrived before the Serial API command has finished. */
+	public prematureNodeUpdate: Message | undefined;
+
 	/** Finds the ID of the target or source node in a message, if it contains that information */
 	public getNodeId(): number | undefined {
 		if (hasNodeId(this)) return this.nodeId;

--- a/packages/zwave-js/src/lib/test/driver/fixtures/s2AndSupervisionEncap/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/driver/fixtures/s2AndSupervisionEncap/7e570001.jsonl
@@ -1,0 +1,40 @@
+{"k":"cacheFormat","v":1}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+{"k":"node.2.isListening","v":true}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.isRouting","v":true}
+{"k":"node.2.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.2.protocolVersion","v":3}
+{"k":"node.2.nodeType","v":"End Node"}
+{"k":"node.2.supportsSecurity","v":false}
+{"k":"node.2.supportsBeaming","v":true}
+{"k":"node.2.deviceClass","v":{"basic":4,"generic":6,"specific":1}}
+{"k":"node.2.interviewStage","v":"Complete"}
+{"k":"node.2.endpoint.0.commandClass.0x20","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+{"k":"node.2.endpoint.0.commandClass.0x98","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+{"k":"node.2.endpoint.0.commandClass.0x9f","v":{"isSupported":true,"isControlled":false,"secure":true,"version":1}}
+
+# Supervision is supported
+{"k":"node.2.endpoint.0.commandClass.0x6c","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+
+# S2 is supported and granted. Not sure about S0 yet:
+{"k":"node.2.securityClasses.S2_AccessControl","v":false}
+{"k":"node.2.securityClasses.S2_Authenticated","v":false}
+{"k":"node.2.securityClasses.S2_Unauthenticated","v":true}
+{"k":"node.2.securityClasses.S0_Legacy","v":false}
+
+{"k":"node.2.interviewStage","v":"Complete"}
+{"k":"node.2.hasSUCReturnRoute","v":true}

--- a/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponse.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponse.test.ts
@@ -1,17 +1,5 @@
-import {
-	BasicCCGet,
-	BasicCCReport,
-	CommandClass,
-	Security2CC,
-	SupervisionCCGet,
-	SupervisionCCReport,
-} from "@zwave-js/cc";
-import {
-	SecurityClass,
-	SupervisionStatus,
-	TransmitStatus,
-	isSupervisionResult,
-} from "@zwave-js/core";
+import { BasicCCGet, BasicCCReport } from "@zwave-js/cc";
+import { TransmitStatus } from "@zwave-js/core";
 import {
 	FunctionType,
 	SendDataAbort,
@@ -21,7 +9,6 @@ import {
 import {
 	type MockControllerBehavior,
 	type MockNodeBehavior,
-	createMockZWaveAckFrame,
 } from "@zwave-js/testing";
 import path from "node:path";
 import {

--- a/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponseS2Supervision.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponseS2Supervision.test.ts
@@ -1,8 +1,6 @@
 import {
 	BasicCCGet,
 	BasicCCReport,
-	CommandClass,
-	Security2CC,
 	SupervisionCCGet,
 	SupervisionCCReport,
 } from "@zwave-js/cc";
@@ -13,7 +11,6 @@ import {
 	isSupervisionResult,
 } from "@zwave-js/core";
 import {
-	FunctionType,
 	SendDataAbort,
 	SendDataBridgeRequest,
 	SendDataRequestTransmitReport,
@@ -21,7 +18,6 @@ import {
 import {
 	type MockControllerBehavior,
 	type MockNodeBehavior,
-	createMockZWaveAckFrame,
 } from "@zwave-js/testing";
 import path from "node:path";
 import {

--- a/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponseS2Supervision.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/sendDataAbortAfterPrematureResponseS2Supervision.test.ts
@@ -30,12 +30,26 @@ import {
 } from "../../controller/MockControllerState.js";
 import { integrationTest } from "../integrationTestSuite.js";
 
+// For some reason the test runner throws an error after the test is done
+// when this test is run in the same context as the test in
+// sendDataAbortAfterPrematureResponse.test.ts
+// Therefore this needs to be its own file.
+
 integrationTest(
-	"Abort SendData transaction when expected response is received prematurely",
+	"A premature S2 Nonce Report does not cause an error for a supervised transaction",
 	{
+		// Repro for #8406
 		// debug: true,
 
-		provisioningDirectory: path.join(__dirname, "fixtures/base_2_nodes"),
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/s2AndSupervisionEncap",
+		),
+
+		nodeCapabilities: {
+			// For now this is needed, because the security classes are not taken from the provisioning cache
+			securityClasses: new Set([SecurityClass.S2_Unauthenticated]),
+		},
 
 		async customSetup(driver, mockController, mockNode) {
 			let lastCallbackId: number | undefined;
@@ -63,6 +77,9 @@ integrationTest(
 							MockControllerCommunicationState.Idle,
 						);
 
+						// Return to normal operation
+						mockNode.autoAckControllerFrames = true;
+
 						return true;
 					}
 				},
@@ -81,23 +98,41 @@ integrationTest(
 				},
 			};
 			mockNode.defineBehavior(respondToBasicGet);
+
+			// Just have the node respond to all Supervision Get positively
+			const respondToSupervisionGet: MockNodeBehavior = {
+				handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC instanceof SupervisionCCGet
+					) {
+						const cc = new SupervisionCCReport({
+							nodeId: controller.ownNodeId,
+							sessionId: receivedCC.sessionId,
+							moreUpdatesFollow: false,
+							status: SupervisionStatus.Success,
+						});
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+			mockNode.defineBehavior(respondToSupervisionGet);
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
+			// Send a Basic CC Get to synchronize the SPAN state
+			await node.commandClasses.Basic.get();
+
 			// Disable automatic ACKs to simulate poor connectivity
 			mockNode.autoAckControllerFrames = false;
 
-			// Send Basic CC Get - this should resolve due to premature response
-			const result = await node.commandClasses.Basic.get();
-			t.expect(result?.currentValue).toBe(42);
-
-			// Assert that the controller received a SendDataAbort
-			// This proves that the ongoing transaction was aborted when the
-			// premature response arrived
-			await mockController.expectHostMessage(
-				(msg) => msg.functionType === FunctionType.SendDataAbort,
-				{ timeout: 500 },
+			// Cause a de-sync
+			mockNode.securityManagers.securityManager2?.deleteNonce(
+				mockController.ownNodeId,
 			);
+
+			// Send a supervised command. The NonceReport should arrive before the transmit report.
+			const result = await node.commandClasses.Basic.set(99);
+			t.expect(isSupervisionResult(result)).toBe(true);
 		},
 	},
 );


### PR DESCRIPTION
PR #8196 added an optimization where we abort an ongoing transmission when the expected response is received before the ACK. This caused issues with S2 nonce reports though, because those are not a valid final result of the transaction.

In this case we no longer short-circuit the transaction and only abort the transmission.

fixes: https://github.com/zwave-js/zwave-js/issues/8406
fixes: https://github.com/home-assistant/core/issues/155515