### PR TITLE
feat: implement support for hidden device configuration parameters

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -46,6 +46,7 @@
 
   - [Overview](config-files/overview.md)
   - [File format](config-files/file-format.md)
+  - [Hidden parameters](config-files/hidden-parameters.md)
   - [Contributing device files](config-files/contributing-files.md)
   - [Importing files from other sources](config-files/importing-from-others.md)
   <!-- - [Using telemetry data](config-files/using-telemetry-data.md) -->

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -104,10 +104,10 @@ For devices which do not allow auto-discovering associations, the associations m
 
 Before defining `associations` in a config file, please make sure that **at least one** of the following points applies:
 
-- The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
-- The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
-- Additional lifelines besides the primary one are **necessary** to get all desired reports
-- `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
+-   The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
+-   The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
+-   Additional lifelines besides the primary one are **necessary** to get all desired reports
+-   `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
 
 The property looks as follows:
 
@@ -226,6 +226,7 @@ where each parameter definition has the following properties:
 | `readOnly`         | boolean |    no     | Whether this parameter can only be read                                                                                                                                                                                                                                                          |
 | `writeOnly`        | boolean |    no     | Whether this parameter can only be written                                                                                                                                                                                                                                                       |
 | `destructive`      | boolean |    no     | Whether changing this parameter can have destructive consequences (e.g., factory reset, clearing settings). Applications should show a confirmation before setting such parameters.                                                                                                              |
+| `hidden`           | boolean |    no     | Whether this parameter should be hidden from UIs and normal API outputs. Use this for factory debug parameters, calibration data, or other settings that should not be exposed to end users. See [Hidden Parameters](config-files/hidden-parameters.md) for details.                             |
 | `allowManualEntry` | boolean |    no     | Whether this parameter accepts any value between `minValue` and `maxValue`. Defaults to `true` for writable parameters and `false` for `readOnly` parameters. If this is `false`, `options` must be used to specify the allowed values.                                                          |
 | `options`          | array   |    no     | If `allowManualEntry` is omitted or `false` and the value is writable, this property must contain an array of objects of the form `{"label": string, "value": number}`. Each entry defines one allowed value.                                                                                    |
 
@@ -293,8 +294,8 @@ Each scene is identified by a numeric key (which must be a positive integer betw
 
 Each scene entry consists of:
 
-- A **label** (required) - A user-friendly name for the scene
-- An optional **description** - Additional information about the scene
+-   A **label** (required) - A user-friendly name for the scene
+-   An optional **description** - Additional information about the scene
 
 Scene definitions can also use `$import` syntax and conditional logic (`$if`) just like other parts of device configuration.
 
@@ -427,18 +428,18 @@ Some legacy devices emit an NIF when a local event occurs (e.g. a button press) 
 
 `Basic CC::Report` commands are like their name implies, Basic. They contain no information about **what** they are reporting. By default, Z-Wave JS uses the device type to map these commands to a more appropriate CC. The `mapBasicReport` can influence this behavior. It has the following options:
 
-- `false`: treat the report verbatim without mapping
-- `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
-- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
+-   `false`: treat the report verbatim without mapping
+-   `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
+-   `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapBasicSet`
 
 `Basic CC::Set` commands are meant to control other devices, yet some devices use them to "report" their status or expose secondary functionality. The `mapBasicSet` flag defines how Z-Wave JS should handle these commands:
 
-- `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
-- `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
-- `"event"`: Emit a `value event` for the Basic `"event"` property.
-- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
+-   `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+-   `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+-   `"event"`: Emit a `value event` for the Basic `"event"` property.
+-   `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapRootReportsToEndpoint`
 

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -104,10 +104,10 @@ For devices which do not allow auto-discovering associations, the associations m
 
 Before defining `associations` in a config file, please make sure that **at least one** of the following points applies:
 
--   The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
--   The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
--   Additional lifelines besides the primary one are **necessary** to get all desired reports
--   `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
+- The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
+- The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
+- Additional lifelines besides the primary one are **necessary** to get all desired reports
+- `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
 
 The property looks as follows:
 
@@ -294,8 +294,8 @@ Each scene is identified by a numeric key (which must be a positive integer betw
 
 Each scene entry consists of:
 
--   A **label** (required) - A user-friendly name for the scene
--   An optional **description** - Additional information about the scene
+- A **label** (required) - A user-friendly name for the scene
+- An optional **description** - Additional information about the scene
 
 Scene definitions can also use `$import` syntax and conditional logic (`$if`) just like other parts of device configuration.
 
@@ -428,18 +428,18 @@ Some legacy devices emit an NIF when a local event occurs (e.g. a button press) 
 
 `Basic CC::Report` commands are like their name implies, Basic. They contain no information about **what** they are reporting. By default, Z-Wave JS uses the device type to map these commands to a more appropriate CC. The `mapBasicReport` can influence this behavior. It has the following options:
 
--   `false`: treat the report verbatim without mapping
--   `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
--   `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
+- `false`: treat the report verbatim without mapping
+- `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
+- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapBasicSet`
 
 `Basic CC::Set` commands are meant to control other devices, yet some devices use them to "report" their status or expose secondary functionality. The `mapBasicSet` flag defines how Z-Wave JS should handle these commands:
 
--   `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
--   `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
--   `"event"`: Emit a `value event` for the Basic `"event"` property.
--   `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
+- `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+- `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+- `"event"`: Emit a `value event` for the Basic `"event"` property.
+- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapRootReportsToEndpoint`
 

--- a/docs/config-files/hidden-parameters.md
+++ b/docs/config-files/hidden-parameters.md
@@ -1,0 +1,94 @@
+# Hidden Configuration Parameters
+
+The Z-Wave JS configuration files support a `hidden` field for device configuration parameters. This feature allows device manufacturers and contributors to mark certain parameters as hidden, preventing them from being displayed in user interfaces or API outputs.
+
+> **Related Issue**: [Add a way to hide existing config parameters #8138](https://github.com/zwave-js/zwave-js/issues/8138)
+
+## Purpose
+
+The `hidden` parameter field is designed to improve user experience by:
+
+1. **Hiding Factory/Debug Parameters**: Parameters intended only for factory testing or debugging that could confuse or potentially harm device operation if modified by end users
+2. **Concealing Calibration Data**: Internal calibration parameters that should not be exposed to users
+3. **Removing Advanced Settings**: Very advanced or dangerous parameters that should only be accessed by support personnel
+4. **Decluttering UIs**: Reducing the number of parameters shown to users to focus on the most relevant settings
+
+## Usage
+
+To mark a configuration parameter as hidden, simply add `"hidden": true` to the parameter definition in the device configuration file:
+
+```json
+{
+	"#": "252",
+	"label": "Factory Test Mode",
+	"description": "This parameter is used for factory testing only.",
+	"valueSize": 1,
+	"minValue": 0,
+	"maxValue": 255,
+	"defaultValue": 0,
+	"hidden": true
+}
+```
+
+## Examples of Parameters to Hide
+
+Consider marking the following types of parameters as hidden:
+
+1. **Factory Test Modes**: Parameters that enable special test modes used during manufacturing
+2. **Calibration Data**: Internal calibration values that should never be modified by users
+3. **Debug Settings**: Logging levels, debug modes, or diagnostic parameters
+4. **Service Codes**: Parameters that require special codes or sequences for factory resets or service operations
+5. **Reserved Parameters**: Parameters documented as "reserved" or "do not use" in manufacturer documentation
+
+## Complete Example
+
+Here's an example showing both visible and hidden parameters:
+
+```json
+{
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "LED Indicator",
+			"description": "Controls the LED indicator behavior",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 2,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "LED on when switch is off",
+					"value": 0
+				},
+				{
+					"label": "LED on when switch is on",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "252",
+			"label": "Factory Test Mode",
+			"description": "For factory testing only. Do not modify.",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0,
+			"hidden": true
+		}
+	]
+}
+```
+
+## Implementation Details
+
+When a parameter is marked as hidden:
+
+- The parameter will still be stored in the configuration metadata
+- The Z-Wave JS driver can still read and write the parameter value
+- The parameter will be excluded from:
+  - User interface parameter lists
+  - API responses that list available parameters (unless specifically requested)
+  - Configuration exports intended for end users
+

--- a/docs/config-files/hidden-parameters.md
+++ b/docs/config-files/hidden-parameters.md
@@ -91,4 +91,3 @@ When a parameter is marked as hidden:
   - User interface parameter lists
   - API responses that list available parameters (unless specifically requested)
   - Configuration exports intended for end users
-

--- a/docs/config-files/hidden-parameters.md
+++ b/docs/config-files/hidden-parameters.md
@@ -85,9 +85,11 @@ Here's an example showing both visible and hidden parameters:
 
 When a parameter is marked as hidden:
 
-- The parameter will still be stored in the configuration metadata
-- The Z-Wave JS driver can still read and write the parameter value
-- The parameter will be excluded from:
+- The parameter will be completely filtered out during configuration loading
+- No metadata will be created for the parameter
+- No values will be persisted for the parameter
+- The parameter will be invisible to:
   - User interface parameter lists
-  - API responses that list available parameters (unless specifically requested)
-  - Configuration exports intended for end users
+  - API responses that list available parameters
+  - Configuration exports
+  - All Z-Wave JS applications and integrations

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -474,6 +474,10 @@
 						],
 						"additionalProperties": false
 					}
+				},
+				"hidden": {
+					"type": "boolean",
+					"description": "Whether this parameter should be hidden in UIs and outputs"
 				}
 			},
 			"additionalProperties": false,

--- a/maintenance/test.mts
+++ b/maintenance/test.mts
@@ -1,6 +1,6 @@
 // Test runner that automatically chooses which workspace to run tests in
 
-import execa from "execa";
+import { execa } from "execa";
 import path from "node:path";
 import { readJSON } from "../packages/shared/src/fs";
 

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -1651,6 +1651,11 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 		);
 
 		for (const [param, info] of config.entries()) {
+			// Skip hidden parameters entirely - don't create metadata or persist values
+			if (info.hidden) {
+				continue;
+			}
+
 			// We need to make the config information compatible with the
 			// format that ConfigurationCC reports
 			const paramInfo: Partial<ConfigurationMetadata> = stripUndefined({
@@ -1680,7 +1685,6 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				description: info.description,
 				isFromConfig: true,
 				destructive: info.destructive,
-				hidden: info.hidden,
 			});
 			this.extendParamInformation(
 				ctx,

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -1805,6 +1805,16 @@ export class ConfigurationCCReport extends ConfigurationCC {
 	public persistValues(ctx: PersistValuesContext): boolean {
 		if (!super.persistValues(ctx)) return false;
 
+		// Skip hidden parameters entirely - don't persist values
+		const paramInfo = getParamInformationFromConfigFile(
+			ctx,
+			this.nodeId as number,
+			this.endpointIndex,
+		);
+		if (paramInfo?.get({ parameter: this.parameter })?.hidden) {
+			return true;
+		}
+
 		const ccVersion = getEffectiveCCVersion(ctx, this);
 
 		// This parameter may be a partial param in the following cases:

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -1680,6 +1680,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				description: info.description,
 				isFromConfig: true,
 				destructive: info.destructive,
+				hidden: info.hidden,
 			});
 			this.extendParamInformation(
 				ctx,

--- a/packages/config/src/devices/ParamInformation.ts
+++ b/packages/config/src/devices/ParamInformation.ts
@@ -207,6 +207,18 @@ Parameter #${parameterNumber}: options is malformed!`,
 			(opt: any) =>
 				new ConditionalConfigOption(opt.value, opt.label, opt.$if),
 		) ?? [];
+
+		if (
+			definition.hidden != undefined
+			&& typeof definition.hidden !== "boolean"
+		) {
+			throwInvalidConfig(
+				"devices",
+				`packages/config/config/devices/${parent.filename}:
+Parameter #${parameterNumber} has a non-boolean property hidden`,
+			);
+		}
+		this.hidden = definition.hidden === true;
 	}
 
 	private parent: ConditionalDeviceConfig;
@@ -226,6 +238,7 @@ Parameter #${parameterNumber}: options is malformed!`,
 	public readonly allowManualEntry: boolean;
 	public readonly destructive?: boolean;
 	public readonly options: readonly ConditionalConfigOption[];
+	public readonly hidden?: boolean;
 
 	public readonly condition?: string;
 
@@ -251,6 +264,7 @@ Parameter #${parameterNumber}: options is malformed!`,
 				"writeOnly",
 				"allowManualEntry",
 				"destructive",
+				"hidden",
 			]),
 			options: evaluateDeep(this.options, deviceId, true),
 		};

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -190,7 +190,6 @@ export interface ConfigurationMetadata extends ValueMetadataAny {
 	allowManualEntry?: boolean;
 	isFromConfig?: boolean;
 	destructive?: boolean;
-	hidden?: boolean;
 }
 
 export type ValueMetadata =

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -190,6 +190,7 @@ export interface ConfigurationMetadata extends ValueMetadataAny {
 	allowManualEntry?: boolean;
 	isFromConfig?: boolean;
 	destructive?: boolean;
+	hidden?: boolean;
 }
 
 export type ValueMetadata =

--- a/packages/zwave-js/src/lib/test/cc/ConfigurationCC.hidden.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ConfigurationCC.hidden.test.ts
@@ -1,0 +1,146 @@
+import { CommandClasses } from "@zwave-js/core";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Hidden configuration parameters should not expose values or metadata after interview",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			manufacturerId: 0xdead,
+			productType: 0xbeef,
+			productId: 0xcafe,
+
+			commandClasses: [
+				{
+					ccId: CommandClasses.Configuration,
+					// Configure the CC capabilities with our parameters
+					parameters: [
+						{
+							"#": 1,
+							defaultValue: 50,
+							valueSize: 1,
+						},
+						{
+							"#": 2,
+							defaultValue: 0,
+							valueSize: 1,
+						},
+						{
+							"#": 3,
+							defaultValue: 100,
+							valueSize: 2,
+						},
+					],
+				},
+				CommandClasses.Version,
+				CommandClasses["Manufacturer Specific"],
+			],
+		},
+
+		additionalDriverOptions: {
+			storage: {
+				deviceConfigPriorityDir: path.join(
+					__dirname,
+					"fixtures/ConfigurationCC.hidden",
+				),
+			},
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			// Verify device config is loaded
+			t.expect(node.deviceConfig).toBeDefined();
+			t.expect(node.deviceConfig?.label).toBe("Test Device");
+
+			// Verify the paramInformation is loaded from device config
+			const paramInfo = node.deviceConfig?.paramInformation;
+			t.expect(paramInfo).toBeDefined();
+
+			// Hidden parameter is present in config with hidden flag
+			const param2Info = paramInfo?.get({ parameter: 2 });
+			t.expect(param2Info).toBeDefined();
+			t.expect(param2Info?.hidden).toBe(true);
+
+			// But visible parameters should not have hidden flag
+			const param1Info = paramInfo?.get({ parameter: 1 });
+			t.expect(param1Info?.hidden).toBe(false);
+
+			// Get all value IDs from the node
+			const valueIDs = node.getDefinedValueIDs();
+
+			// Filter to Configuration CC value IDs
+			const configValueIDs = valueIDs.filter(
+				(v) => v.commandClass === CommandClasses.Configuration,
+			);
+
+			// Get the property numbers that are exposed
+			const exposedProperties = new Set(configValueIDs
+				.filter((v) => typeof v.property === "number")
+				.map((v) => v.property as number));
+
+			// Visible parameters (1 and 3) should be exposed
+			t.expect(
+				exposedProperties.has(1),
+				"Parameter 1 (visible) should be exposed",
+			).toBe(true);
+			t.expect(
+				exposedProperties.has(3),
+				"Parameter 3 (visible) should be exposed",
+			).toBe(true);
+
+			// Hidden parameter (2) should NOT be exposed
+			t.expect(
+				exposedProperties.has(2),
+				"Parameter 2 (hidden) should NOT be exposed",
+			).toBe(false);
+
+			// Also verify values - visible parameters should have values
+			const param1Value = node.getValue({
+				commandClass: CommandClasses.Configuration,
+				property: 1,
+			});
+			const param3Value = node.getValue({
+				commandClass: CommandClasses.Configuration,
+				property: 3,
+			});
+			const param2Value = node.getValue({
+				commandClass: CommandClasses.Configuration,
+				property: 2,
+			});
+
+			t.expect(param1Value, "Parameter 1 should have a value").toBe(50);
+			t.expect(param3Value, "Parameter 3 should have a value").toBe(100);
+			t.expect(
+				param2Value,
+				"Parameter 2 (hidden) should not have a value",
+			).toBeUndefined();
+
+			// Verify metadata - visible parameters should have metadata
+			const param1Meta = node.getValueMetadata({
+				commandClass: CommandClasses.Configuration,
+				property: 1,
+			});
+			const param3Meta = node.getValueMetadata({
+				commandClass: CommandClasses.Configuration,
+				property: 3,
+			});
+			const param2Meta = node.getValueMetadata({
+				commandClass: CommandClasses.Configuration,
+				property: 2,
+			});
+
+			t.expect(param1Meta.label, "Parameter 1 should have metadata").toBe(
+				"Visible Parameter",
+			);
+			t.expect(param3Meta.label, "Parameter 3 should have metadata").toBe(
+				"Another Visible Parameter",
+			);
+			// Hidden parameter should not have metadata with a label
+			t.expect(
+				param2Meta.label,
+				"Parameter 2 (hidden) should not have metadata with label",
+			).toBeUndefined();
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/cc/ConfigurationCC.hidden.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/ConfigurationCC.hidden.test.ts
@@ -75,9 +75,11 @@ integrationTest(
 			);
 
 			// Get the property numbers that are exposed
-			const exposedProperties = new Set(configValueIDs
-				.filter((v) => typeof v.property === "number")
-				.map((v) => v.property as number));
+			const exposedProperties = new Set(
+				configValueIDs
+					.filter((v) => typeof v.property === "number")
+					.map((v) => v.property as number),
+			);
 
 			// Visible parameters (1 and 3) should be exposed
 			t.expect(

--- a/packages/zwave-js/src/lib/test/cc/fixtures/ConfigurationCC.hidden/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/cc/fixtures/ConfigurationCC.hidden/deviceConfig.json
@@ -1,0 +1,43 @@
+{
+	"manufacturer": "Test Manufacturer",
+	"manufacturerId": "0xdead",
+	"label": "Test Device",
+	"description": "Test device for hidden parameter",
+	"devices": [
+		{
+			"productType": "0xbeef",
+			"productId": "0xcafe"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "Visible Parameter",
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 100,
+			"defaultValue": 50
+		},
+		{
+			"#": "2",
+			"label": "Hidden Parameter",
+			"hidden": true,
+			"valueSize": 1,
+			"minValue": 0,
+			"maxValue": 255,
+			"defaultValue": 0
+		},
+		{
+			"#": "3",
+			"label": "Another Visible Parameter",
+			"valueSize": 2,
+			"minValue": 0,
+			"maxValue": 1000,
+			"defaultValue": 100
+		}
+	]
+}


### PR DESCRIPTION
revives #8161 by @oniseun

Add support for hiding device configuration parameters from user interfaces
and API outputs. This addresses issue https://github.com/zwave-js/zwave-js/issues/8138 by allowing device manufacturers
and contributors to mark parameters as hidden to improve user experience.

Hidden parameters are now completely invisible to applications - no metadata
is created and no values are persisted. This allows hiding factory test
parameters, calibration data, debug settings, and other parameters that
should not be exposed to end users.

Closes https://github.com/zwave-js/zwave-js/issues/8138