### PR TITLE
chore: run Oxlint on precommit

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-	"*.{js,ts,json,md}": "node maintenance/fmt-staged.js",
-	"*.{js,ts}": "yarn oxlint --type-aware"
+	"*.{js,ts}": "yarn oxlint --type-aware",
+	"*.{js,ts,json,md}": "node maintenance/fmt-staged.js"
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-	"*.{js,ts,json,md}": "node maintenance/fmt-staged.js"
+	"*.{js,ts,json,md}": "node maintenance/fmt-staged.js",
+	"*.{js,ts}": "yarn oxlint --type-aware"
 }


### PR DESCRIPTION
This is fast enough so it doesn't interrupt the workflow