### PR TITLE
fix(config): remove unnecessary firmware version check from Zooz ZEN35

### DIFF
--- a/packages/config/config/devices/0x027a/zen35.json
+++ b/packages/config/config/devices/0x027a/zen35.json
@@ -105,7 +105,6 @@
 		},
 		{
 			"#": "8",
-			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "templates/zooz_template.json#led_indicator_color_extended",
 			"label": "LED Indicator Color (Button 2)",
 			"defaultValue": 0


### PR DESCRIPTION
Back when ZooZ added extended button LED color options to its ZEN32 Scene Controllers, we had to add firmware logic to make sure that the additional colors only appeared in the configuration when the firmware version supported it. However, the [ZEN35's original 1.00 firmware](https://www.support.getzooz.com/kb/article/1675-zen35-scene-dimmer-change-log/) release supported the extended button LED colors so we do not have to do a version check. (Also I suspect that since this is the only line with the logic it is just a remnant that was accidentally left in when this configuration was cloned from the ZEN32 Scene controller)

Before this fix, this is how the logic caused the configuration to display.
<img width="1357" height="722" alt="image" src="https://github.com/user-attachments/assets/7c58990a-6051-4cb3-a6cb-3e7d5d296d74" />

