### PR TITLE
fix: ignore `ApplicationUpdateRequestNodeAdded` during inclusion

### DIFF
--- a/packages/zwave-js/src/lib/controller/Controller.ts
+++ b/packages/zwave-js/src/lib/controller/Controller.ts
@@ -3800,6 +3800,12 @@ export class ZWaveController
 				return;
 			}
 
+			// It can also happen that this is received while we're including that node ourselves.
+			// In this case, we also ignore the message, otherwise we'd fail security bootstrapping.
+			if (this.inclusionState === InclusionState.Including) {
+				return;
+			}
+
 			const deviceClass = new DeviceClass(
 				nodeInfo.basicDeviceClass,
 				nodeInfo.genericDeviceClass,


### PR DESCRIPTION
For some reason this command can be received while we're including a node. In that case we need to ignore it or it gets mis-interpreted as a secondary controller notifying us of the inclusion, causing security bootstrapping to fail