### PR TITLE
feat(config): hide VZW32-SN test parameter from production use

### DIFF
--- a/packages/config/config/devices/0x031e/vzw32-sn.json
+++ b/packages/config/config/devices/0x031e/vzw32-sn.json
@@ -712,43 +712,43 @@
 		},
 		{
 			"#": "109[0xff]",
-			"label": "Future Use",
-			"description": "Do not use except for testing with Inovelli",
+			"label": "After Hours Time Range Start Hour",
+			"description": "The UTC hour where After Hours mode should start",
 			"valueSize": 4,
 			"minValue": -1,
 			"maxValue": 23,
 			"defaultValue": -1,
-			"readOnly": true
+			"hidden": true
 		},
 		{
 			"#": "109[0xff00]",
-			"label": "Future Use",
-			"description": "Do not use except for testing with Inovelli",
+			"label": "After Hours Time Range Start Minute",
+			"description": "The minute where After Hours mode should start",
 			"valueSize": 4,
 			"minValue": -1,
 			"maxValue": 59,
 			"defaultValue": -1,
-			"readOnly": true
+			"hidden": true
 		},
 		{
 			"#": "109[0xff0000]",
-			"label": "Future Use",
-			"description": "Do not use except for testing with Inovelli",
+			"label": "After Hours Time Range End Hour",
+			"description": "The UTC hour where After Hours mode should end",
 			"valueSize": 4,
 			"minValue": -1,
 			"maxValue": 23,
 			"defaultValue": -1,
-			"readOnly": true
+			"hidden": true
 		},
 		{
 			"#": "109[0xff000000]",
-			"label": "Future Use",
-			"description": "Do not use except for testing with Inovelli",
+			"label": "After Hours Time Range End Minute",
+			"description": "The minute where After Hours mode should end",
 			"valueSize": 4,
 			"minValue": -1,
 			"maxValue": 59,
 			"defaultValue": -1,
-			"readOnly": true
+			"hidden": true
 		},
 		{
 			"#": "110",

--- a/packages/config/config/devices/0x031e/vzw32-sn.json
+++ b/packages/config/config/devices/0x031e/vzw32-sn.json
@@ -711,44 +711,44 @@
 			"unsigned": true
 		},
 		{
+			"hidden": true,
 			"#": "109[0xff]",
 			"label": "After Hours Time Range Start Hour",
 			"description": "The UTC hour where After Hours mode should start",
 			"valueSize": 4,
 			"minValue": -1,
 			"maxValue": 23,
-			"defaultValue": -1,
-			"hidden": true
+			"defaultValue": -1
 		},
 		{
+			"hidden": true,
 			"#": "109[0xff00]",
 			"label": "After Hours Time Range Start Minute",
 			"description": "The minute where After Hours mode should start",
 			"valueSize": 4,
 			"minValue": -1,
 			"maxValue": 59,
-			"defaultValue": -1,
-			"hidden": true
+			"defaultValue": -1
 		},
 		{
+			"hidden": true,
 			"#": "109[0xff0000]",
 			"label": "After Hours Time Range End Hour",
 			"description": "The UTC hour where After Hours mode should end",
 			"valueSize": 4,
 			"minValue": -1,
 			"maxValue": 23,
-			"defaultValue": -1,
-			"hidden": true
+			"defaultValue": -1
 		},
 		{
+			"hidden": true,
 			"#": "109[0xff000000]",
 			"label": "After Hours Time Range End Minute",
 			"description": "The minute where After Hours mode should end",
 			"valueSize": 4,
 			"minValue": -1,
 			"maxValue": 59,
-			"defaultValue": -1,
-			"hidden": true
+			"defaultValue": -1
 		},
 		{
 			"#": "110",


### PR DESCRIPTION
This paramater was previously marked read-only.  This change depends on #8492.