### PR TITLE
fix: clear user codes on initial interview unless `queryAllUserCodes` driver option is set

### DIFF
--- a/packages/cc/src/lib/API.ts
+++ b/packages/cc/src/lib/API.ts
@@ -19,6 +19,7 @@ import {
 	NOT_KNOWN,
 	type NodeId,
 	type PhysicalNodes,
+	type QueryNodeInterviewStage,
 	type QueryNodeStatus,
 	type SecurityManagers,
 	type SendCommandOptions,
@@ -181,7 +182,11 @@ export type CCAPIHost<TNode extends CCAPINode = CCAPINode> =
 	& LogNode;
 
 // Defines the necessary traits a node passed to a CC API must have
-export type CCAPINode = NodeId & ListenBehavior & QueryNodeStatus;
+export type CCAPINode =
+	& NodeId
+	& ListenBehavior
+	& QueryNodeStatus
+	& QueryNodeInterviewStage;
 
 // Defines the necessary traits an endpoint passed to a CC API must have
 export type CCAPIEndpoint =

--- a/packages/core/src/traits/Nodes.ts
+++ b/packages/core/src/traits/Nodes.ts
@@ -1,3 +1,4 @@
+import { type InterviewStage } from "../definitions/InterviewStage.js";
 import type { FLiRS } from "../definitions/NodeInfo.js";
 import type { NodeStatus } from "../definitions/NodeStatus.js";
 import type { MaybeNotKnown } from "../values/Primitive.js";
@@ -37,12 +38,25 @@ export interface ListenBehavior {
 	readonly canSleep: MaybeNotKnown<boolean>;
 }
 
-/** Allows querying whether a node's status */
+/** Allows querying a node's status */
 export interface QueryNodeStatus {
 	/**
 	 * Which status the node is believed to be in
 	 */
 	readonly status: NodeStatus;
+}
+
+/** Allows querying a node's interview stage */
+export interface QueryNodeInterviewStage {
+	/**
+	 * Which interview stage was last completed
+	 */
+	interviewStage: InterviewStage;
+
+	/**
+	 * Whether the node has been fully interviewed at least once
+	 */
+	bootstrapped: boolean;
 }
 
 export interface PhysicalNodes<T extends NodeId> {

--- a/packages/zwave-js/src/lib/driver/NetworkCache.ts
+++ b/packages/zwave-js/src/lib/driver/NetworkCache.ts
@@ -62,6 +62,7 @@ export const cacheKeys = {
 			_securityClassBaseKey: `${nodeBaseKey}securityClasses`,
 			_priorityReturnRouteBaseKey: `${nodeBaseKey}priorityReturnRoute`,
 			interviewStage: `${nodeBaseKey}interviewStage`,
+			bootstrapped: `${nodeBaseKey}bootstrapped`,
 			deviceClass: `${nodeBaseKey}deviceClass`,
 			isListening: `${nodeBaseKey}isListening`,
 			isFrequentListening: `${nodeBaseKey}isFrequentListening`,

--- a/packages/zwave-js/src/lib/node/Node.ts
+++ b/packages/zwave-js/src/lib/node/Node.ts
@@ -2646,6 +2646,8 @@ protocol version:      ${this.protocolVersion}`;
 		// Mark already-interviewed nodes as potentially ready
 		if (this.interviewStage === InterviewStage.Complete) {
 			this.updateReadyMachine({ value: "RESTART_FROM_CACHE" });
+			// If the `bootstrapped` flag is missing, set it now
+			this.bootstrapped = true;
 		}
 	}
 

--- a/packages/zwave-js/src/lib/node/mixins/20_Status.ts
+++ b/packages/zwave-js/src/lib/node/mixins/20_Status.ts
@@ -55,6 +55,12 @@ export interface NodeWithStatus {
 	 * Which interview stage was last completed
 	 */
 	interviewStage: InterviewStage;
+
+	/**
+	 * @internal
+	 * Whether the node has been fully interviewed at least once
+	 */
+	bootstrapped: boolean;
 }
 
 export abstract class NodeStatusMixin extends NodeEventsMixin
@@ -206,5 +212,21 @@ export abstract class NodeStatusMixin extends NodeEventsMixin
 	}
 	public set interviewStage(value: InterviewStage) {
 		this.driver.cacheSet(cacheKeys.node(this.id).interviewStage, value);
+		// Mark the node as bootstrapped once the interview is complete
+		if (value === InterviewStage.Complete) {
+			this.bootstrapped = true;
+		}
+	}
+
+	public get bootstrapped(): boolean {
+		return (
+			this.driver.cacheGet(cacheKeys.node(this.id).bootstrapped)
+				// When the cache entry is missing, we assume the node is bootstrapped
+				// only if the interview is complete
+				?? this.interviewStage === InterviewStage.Complete
+		);
+	}
+	public set bootstrapped(value: boolean) {
+		this.driver.cacheSet(cacheKeys.node(this.id).bootstrapped, value);
 	}
 }


### PR DESCRIPTION
During certification testing it was found that the current behavior is not compliant. During the initial interview, we're supposed to either delete all codes, or query them (if the checksum isn't 0).

Now we do.