### PR TITLE
fix(config): update Zooz ZEN16 to support 800 series version

### DIFF
--- a/packages/config/config/devices/0x027a/zen16.json
+++ b/packages/config/config/devices/0x027a/zen16.json
@@ -303,21 +303,10 @@
 		{
 			"#": "12",
 			"$if": "firmwareVersion >= 3.0",
-			"label": "Switch 1: Input Trigger",
-			"description": "Choose whether the input (switch) on Sw1 triggers R1 or just sends input reports for monitoring.",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Input trigger disabled",
-					"value": 0
-				},
-				{
-					"label": "Input trigger enabled",
-					"value": 1
-				}
-			]
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Control Relay 1 with S1 Input",
+			"description": "If disabled, only a Z-Wave report will be sent",
+			"defaultValue": 1
 		},
 		{
 			"#": "13",
@@ -335,21 +324,10 @@
 		{
 			"#": "13",
 			"$if": "firmwareVersion >= 3.0",
-			"label": "Switch 2: Input Trigger",
-			"description": "Choose whether the input (switch) on Sw2 triggers R2 or just sends input reports for monitoring.",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Input trigger disabled",
-					"value": 0
-				},
-				{
-					"label": "Input trigger enabled",
-					"value": 1
-				}
-			]
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Control Relay 2 with S2 Input",
+			"description": "If disabled, only a Z-Wave report will be sent",
+			"defaultValue": 1
 		},
 		{
 			"#": "14",
@@ -367,21 +345,10 @@
 		{
 			"#": "14",
 			"$if": "firmwareVersion >= 3.0",
-			"label": "Switch 3: Input Trigger",
-			"description": "Choose whether the input (switch) on Sw3 triggers R3 or just sends input reports for monitoring.",
-			"valueSize": 1,
-			"defaultValue": 1,
-			"allowManualEntry": false,
-			"options": [
-				{
-					"label": "Input trigger disabled",
-					"value": 0
-				},
-				{
-					"label": "Input trigger enabled",
-					"value": 1
-				}
-			]
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Control Relay 3 with S3 Input",
+			"description": "If disabled, only a Z-Wave report will be sent",
+			"defaultValue": 1
 		},
 		{
 			"#": "21",

--- a/packages/config/config/devices/0x027a/zen16.json
+++ b/packages/config/config/devices/0x027a/zen16.json
@@ -280,7 +280,7 @@
 		},
 		{
 			"#": "12",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 3.0",
 			"label": "Switch 1: Manual Control",
 			"valueSize": 1,
 			"defaultValue": 1,
@@ -301,6 +301,25 @@
 			]
 		},
 		{
+			"#": "12",
+			"$if": "firmwareVersion >= 3.0",
+			"label": "Switch 1: Input Trigger",
+			"description": "Choose whether the input (switch) on Sw1 triggers R1 or just sends input reports for monitoring.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Input trigger disabled",
+					"value": 0
+				},
+				{
+					"label": "Input trigger enabled",
+					"value": 1
+				}
+			]
+		},
+		{
 			"#": "13",
 			"$if": "firmwareVersion < 1.2",
 			"$import": "~/templates/master_template.json#base_enable_disable",
@@ -309,9 +328,28 @@
 		},
 		{
 			"#": "13",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 3.0",
 			"$import": "templates/zooz_template.json#zen16_manual_control",
 			"label": "Switch 2: Manual Control"
+		},
+		{
+			"#": "13",
+			"$if": "firmwareVersion >= 3.0",
+			"label": "Switch 2: Input Trigger",
+			"description": "Choose whether the input (switch) on Sw2 triggers R2 or just sends input reports for monitoring.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Input trigger disabled",
+					"value": 0
+				},
+				{
+					"label": "Input trigger enabled",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "14",
@@ -322,9 +360,28 @@
 		},
 		{
 			"#": "14",
-			"$if": "firmwareVersion >= 1.2",
+			"$if": "firmwareVersion >= 1.2 && firmwareVersion < 3.0",
 			"$import": "templates/zooz_template.json#zen16_manual_control",
 			"label": "Switch 3: Manual Control"
+		},
+		{
+			"#": "14",
+			"$if": "firmwareVersion >= 3.0",
+			"label": "Switch 3: Input Trigger",
+			"description": "Choose whether the input (switch) on Sw3 triggers R3 or just sends input reports for monitoring.",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Input trigger disabled",
+					"value": 0
+				},
+				{
+					"label": "Input trigger enabled",
+					"value": 1
+				}
+			]
 		},
 		{
 			"#": "21",


### PR DESCRIPTION
The ZEN16 800LR (firmware 3.0+) uses different parameter options for input trigger settings compared to the 700 series. This adds conditional parameters that correctly expose the 800LR's 2-option input trigger configuration while preserving the 700 series' 3-option manual control.

Fixes #8200
