### PR TITLE
feat: try to find Z-Wave QR code strings in longer strings

### DIFF
--- a/packages/cc/maintenance/generateCCExports.ts
+++ b/packages/cc/maintenance/generateCCExports.ts
@@ -216,7 +216,6 @@ export async function generateCCExports(): Promise<void> {
 	}
 
 	fileContent += `
-/* eslint-disable */
 export function registerCCs(): void {
 ${registerFunctionContent}
 }

--- a/packages/core/src/qr/index.ts
+++ b/packages/core/src/qr/index.ts
@@ -9,5 +9,5 @@ export {
 	type QRProvisioningInformation,
 	minQRCodeLength,
 } from "./definitions.js";
-export { parseQRCodeString } from "./parse.js";
+export { parseQRCodeString, tryExtractQRCodeString } from "./parse.js";
 export * from "./utils.js";

--- a/packages/core/src/qr/index.ts
+++ b/packages/core/src/qr/index.ts
@@ -9,5 +9,5 @@ export {
 	type QRProvisioningInformation,
 	minQRCodeLength,
 } from "./definitions.js";
-export { parseQRCodeString, tryExtractQRCodeString } from "./parse.js";
+export { parseQRCodeString } from "./parse.js";
 export * from "./utils.js";

--- a/packages/core/src/qr/parse.test.ts
+++ b/packages/core/src/qr/parse.test.ts
@@ -2,11 +2,7 @@ import { test } from "vitest";
 import { SecurityClass } from "../definitions/SecurityClass.js";
 import { ZWaveErrorCodes } from "../error/ZWaveError.js";
 import { assertZWaveError } from "../test/assertZWaveError.js";
-import {
-	QRCodeVersion,
-	parseQRCodeString,
-	tryExtractQRCodeString,
-} from "./index.js";
+import { QRCodeVersion, parseQRCodeString } from "./index.js";
 
 function createDummyQR(firstDigits: string): string {
 	return firstDigits + "0".repeat(52 - firstDigits.length);
@@ -118,33 +114,6 @@ test("QR code parsing -> Example case: Acme Light Dimmer w/o SmartStart", async 
 	});
 });
 
-test("QR code parsing -> ignore surrounding whitespace", async (t) => {
-	const result = await parseQRCodeString(
-		"	900032782003515253545541424344453132333435212223242500100435301537022065520001000000300578  ",
-	);
-	t.expect(result).toStrictEqual({
-		version: QRCodeVersion.S2,
-		securityClasses: [
-			SecurityClass.S2_Unauthenticated,
-			SecurityClass.S2_Authenticated,
-		],
-		requestedSecurityClasses: [
-			SecurityClass.S2_Unauthenticated,
-			SecurityClass.S2_Authenticated,
-		],
-		dsk: "51525-35455-41424-34445-31323-33435-21222-32425",
-		applicationVersion: "2.66",
-		genericDeviceClass: 0x11,
-		specificDeviceClass: 0x01,
-		installerIconType: 0x0601,
-		manufacturerId: 0xfff0,
-		productType: 0x0064,
-		productId: 0x0003,
-	});
-});
-
-// Tests for tryExtractQRCodeString
-
 const validQRCode =
 	"900132782003515253545541424344453132333435212223242500100435301537022065520001000000300578";
 const expectedResult = {
@@ -167,56 +136,40 @@ const expectedResult = {
 	productId: 0x0003,
 };
 
-test("tryExtractQRCodeString -> extracts QR code with garbage before", async (t) => {
-	const result = await tryExtractQRCodeString(
-		`some garbage text before ${validQRCode}`,
-	);
+test("QR code parsing -> handles surrounding whitespace", async (t) => {
+	const result = await parseQRCodeString(`	${validQRCode}  `);
 	t.expect(result).toStrictEqual(expectedResult);
 });
 
-test("tryExtractQRCodeString -> extracts QR code with garbage after", async (t) => {
-	const result = await tryExtractQRCodeString(
-		`${validQRCode} some garbage after`,
-	);
+test("QR code parsing -> handles garbage text before", async (t) => {
+	const result = await parseQRCodeString(`some garbage text before ${validQRCode}`);
 	t.expect(result).toStrictEqual(expectedResult);
 });
 
-test("tryExtractQRCodeString -> extracts QR code with garbage before and after", async (t) => {
-	const result = await tryExtractQRCodeString(
-		`garbage before ${validQRCode} garbage after`,
-	);
+test("QR code parsing -> handles garbage text after", async (t) => {
+	const result = await parseQRCodeString(`${validQRCode} some garbage after`);
 	t.expect(result).toStrictEqual(expectedResult);
 });
 
-test("tryExtractQRCodeString -> extracts QR code with extra digits after", async (t) => {
-	const result = await tryExtractQRCodeString(
-		`${validQRCode}123456789`,
-	);
+test("QR code parsing -> handles extra digits after", async (t) => {
+	const result = await parseQRCodeString(`${validQRCode}123456789`);
 	t.expect(result).toStrictEqual(expectedResult);
 });
 
-test("tryExtractQRCodeString -> returns undefined when no valid QR code found", async (t) => {
-	const result = await tryExtractQRCodeString(
-		"this string contains no valid QR code 90123",
-	);
-	t.expect(result).toBeUndefined();
-});
-
-test("tryExtractQRCodeString -> returns undefined for empty string", async (t) => {
-	const result = await tryExtractQRCodeString("");
-	t.expect(result).toBeUndefined();
-});
-
-test("tryExtractQRCodeString -> skips invalid 90 sequences and finds valid one", async (t) => {
-	const result = await tryExtractQRCodeString(
-		`90123456 not a valid QR ${validQRCode}`,
-	);
+test("QR code parsing -> handles whitespace in the middle", async (t) => {
+	const qrWithSpaces = validQRCode.slice(0, 20) + " " + validQRCode.slice(20, 40) + " " + validQRCode.slice(40);
+	const result = await parseQRCodeString(qrWithSpaces);
 	t.expect(result).toStrictEqual(expectedResult);
 });
 
-test("tryExtractQRCodeString -> works with newlines in surrounding text", async (t) => {
-	const result = await tryExtractQRCodeString(
-		`some text\n${validQRCode}\nmore text`,
-	);
+test("QR code parsing -> handles newlines in the middle", async (t) => {
+	const qrWithNewlines = validQRCode.slice(0, 30) + "\n" + validQRCode.slice(30, 60) + "\n" + validQRCode.slice(60);
+	const result = await parseQRCodeString(qrWithNewlines);
+	t.expect(result).toStrictEqual(expectedResult);
+});
+
+test("QR code parsing -> handles mixed whitespace in the middle", async (t) => {
+	const qrWithMixedWhitespace = validQRCode.slice(0, 10) + " " + validQRCode.slice(10, 30) + "\n" + validQRCode.slice(30, 50) + "\t" + validQRCode.slice(50);
+	const result = await parseQRCodeString(qrWithMixedWhitespace);
 	t.expect(result).toStrictEqual(expectedResult);
 });

--- a/packages/core/src/qr/parse.test.ts
+++ b/packages/core/src/qr/parse.test.ts
@@ -114,62 +114,91 @@ test("QR code parsing -> Example case: Acme Light Dimmer w/o SmartStart", async 
 	});
 });
 
-const validQRCode =
-	"900132782003515253545541424344453132333435212223242500100435301537022065520001000000300578";
-const expectedResult = {
-	version: QRCodeVersion.SmartStart,
-	securityClasses: [
-		SecurityClass.S2_Unauthenticated,
-		SecurityClass.S2_Authenticated,
-	],
-	requestedSecurityClasses: [
-		SecurityClass.S2_Unauthenticated,
-		SecurityClass.S2_Authenticated,
-	],
-	dsk: "51525-35455-41424-34445-31323-33435-21222-32425",
-	applicationVersion: "2.66",
-	genericDeviceClass: 0x11,
-	specificDeviceClass: 0x01,
-	installerIconType: 0x0601,
-	manufacturerId: 0xfff0,
-	productType: 0x0064,
-	productId: 0x0003,
-};
+{
+	const validQRCode =
+		"900132782003515253545541424344453132333435212223242500100435301537022065520001000000300578";
+	const expectedResult = {
+		version: QRCodeVersion.SmartStart,
+		securityClasses: [
+			SecurityClass.S2_Unauthenticated,
+			SecurityClass.S2_Authenticated,
+		],
+		requestedSecurityClasses: [
+			SecurityClass.S2_Unauthenticated,
+			SecurityClass.S2_Authenticated,
+		],
+		dsk: "51525-35455-41424-34445-31323-33435-21222-32425",
+		applicationVersion: "2.66",
+		genericDeviceClass: 0x11,
+		specificDeviceClass: 0x01,
+		installerIconType: 0x0601,
+		manufacturerId: 0xfff0,
+		productType: 0x0064,
+		productId: 0x0003,
+	};
 
-test("QR code parsing -> handles surrounding whitespace", async (t) => {
-	const result = await parseQRCodeString(`	${validQRCode}  `);
-	t.expect(result).toStrictEqual(expectedResult);
-});
+	test("QR code parsing -> handles surrounding whitespace", async (t) => {
+		const result = await parseQRCodeString(`	${validQRCode}  `);
+		t.expect(result).toStrictEqual(expectedResult);
+	});
 
-test("QR code parsing -> handles garbage text before", async (t) => {
-	const result = await parseQRCodeString(`some garbage text before ${validQRCode}`);
-	t.expect(result).toStrictEqual(expectedResult);
-});
+	test("QR code parsing -> handles garbage text before", async (t) => {
+		const result = await parseQRCodeString(
+			`some garbage text before ${validQRCode}`,
+		);
+		t.expect(result).toStrictEqual(expectedResult);
+	});
 
-test("QR code parsing -> handles garbage text after", async (t) => {
-	const result = await parseQRCodeString(`${validQRCode} some garbage after`);
-	t.expect(result).toStrictEqual(expectedResult);
-});
+	test("QR code parsing -> handles garbage text after", async (t) => {
+		const result = await parseQRCodeString(
+			`${validQRCode} some garbage after`,
+		);
+		t.expect(result).toStrictEqual(expectedResult);
+	});
 
-test("QR code parsing -> handles extra digits after", async (t) => {
-	const result = await parseQRCodeString(`${validQRCode}123456789`);
-	t.expect(result).toStrictEqual(expectedResult);
-});
+	test("QR code parsing -> handles extra digits after", async (t) => {
+		const result = await parseQRCodeString(`${validQRCode}123456789`);
+		t.expect(result).toStrictEqual(expectedResult);
+	});
 
-test("QR code parsing -> handles whitespace in the middle", async (t) => {
-	const qrWithSpaces = validQRCode.slice(0, 20) + " " + validQRCode.slice(20, 40) + " " + validQRCode.slice(40);
-	const result = await parseQRCodeString(qrWithSpaces);
-	t.expect(result).toStrictEqual(expectedResult);
-});
+	test("QR code parsing -> handles whitespace in the middle", async (t) => {
+		const qrWithSpaces = validQRCode.slice(0, 20)
+			+ " "
+			+ validQRCode.slice(20, 40)
+			+ " "
+			+ validQRCode.slice(40);
+		const result = await parseQRCodeString(qrWithSpaces);
+		t.expect(result).toStrictEqual(expectedResult);
+	});
 
-test("QR code parsing -> handles newlines in the middle", async (t) => {
-	const qrWithNewlines = validQRCode.slice(0, 30) + "\n" + validQRCode.slice(30, 60) + "\n" + validQRCode.slice(60);
-	const result = await parseQRCodeString(qrWithNewlines);
-	t.expect(result).toStrictEqual(expectedResult);
-});
+	test("QR code parsing -> handles newlines in the middle", async (t) => {
+		const qrWithNewlines = validQRCode.slice(0, 30)
+			+ "\n"
+			+ validQRCode.slice(30, 60)
+			+ "\n"
+			+ validQRCode.slice(60);
+		const result = await parseQRCodeString(qrWithNewlines);
+		t.expect(result).toStrictEqual(expectedResult);
+	});
 
-test("QR code parsing -> handles mixed whitespace in the middle", async (t) => {
-	const qrWithMixedWhitespace = validQRCode.slice(0, 10) + " " + validQRCode.slice(10, 30) + "\n" + validQRCode.slice(30, 50) + "\t" + validQRCode.slice(50);
-	const result = await parseQRCodeString(qrWithMixedWhitespace);
-	t.expect(result).toStrictEqual(expectedResult);
-});
+	test("QR code parsing -> handles mixed whitespace in the middle", async (t) => {
+		const qrWithMixedWhitespace = validQRCode.slice(0, 10)
+			+ " "
+			+ validQRCode.slice(10, 30)
+			+ "\n"
+			+ validQRCode.slice(30, 50)
+			+ "\t"
+			+ validQRCode.slice(50);
+		const result = await parseQRCodeString(qrWithMixedWhitespace);
+		t.expect(result).toStrictEqual(expectedResult);
+	});
+
+	test("QR code parsing -> handles multiple candidates", async (t) => {
+		const result = await parseQRCodeString(
+			`${validQRCode.slice(0, 14)}${validQRCode}${
+				validQRCode.slice(5)
+			}90`,
+		);
+		t.expect(result).toStrictEqual(expectedResult);
+	});
+}

--- a/packages/core/src/qr/parse.ts
+++ b/packages/core/src/qr/parse.ts
@@ -2,6 +2,7 @@ import { Bytes } from "@zwave-js/shared";
 import { digest } from "../crypto/index.js";
 import { SecurityClass } from "../definitions/SecurityClass.js";
 import { dskToString } from "../dsk/index.js";
+import { ZWaveError, ZWaveErrorCodes } from "../error/ZWaveError.js";
 import { parseBitMask } from "../values/Primitive.js";
 import {
 	ProvisioningInformationType,
@@ -11,6 +12,9 @@ import {
 	onlyDigitsRegex,
 } from "./definitions.js";
 import { fail, parseTLV, readLevel, readUInt16, readUInt8 } from "./utils.js";
+
+// Regex to find "90" followed by at least (minQRCodeLength - 2) digits
+const qrCodeCandidateRegex = new RegExp(`90\\d{${minQRCodeLength - 2},}`, "g");
 
 /** Parses a string that has been decoded from a Z-Wave (S2 or SmartStart) QR code */
 export async function parseQRCodeString(
@@ -83,4 +87,112 @@ export async function parseQRCodeString(
 	}
 
 	return ret;
+}
+
+/**
+ * Tries to find the length of a valid QR code string starting at position 0.
+ * Returns the length if found, or undefined if not valid.
+ *
+ * The QR code structure is:
+ * - 2 digits: "90" (Z indicator)
+ * - 2 digits: version
+ * - 5 digits: checksum
+ * - 3 digits: requested keys
+ * - 40 digits: DSK (8 blocks of 5)
+ * - Variable: TLV blocks (each has 2-digit type, 2-digit length, then data)
+ */
+function tryDetermineQRCodeLength(candidate: string): number | undefined {
+	// Must start with 90 and have minimum length
+	if (!candidate.startsWith("90") || candidate.length < minQRCodeLength) {
+		return undefined;
+	}
+
+	// Version must be valid (0 or 1)
+	const version = parseInt(candidate.slice(2, 4), 10);
+	if (version > QRCodeVersion.SmartStart) {
+		return undefined;
+	}
+
+	// Start after the fixed portion (90 + version + checksum + keys + DSK = 52 chars)
+	let offset = minQRCodeLength;
+
+	// Walk through TLV blocks to find the end
+	while (offset < candidate.length) {
+		// Need at least 4 chars for type (2) and length (2)
+		if (candidate.length - offset < 4) {
+			// Not enough for another TLV block, this is the end
+			break;
+		}
+
+		const typeStr = candidate.slice(offset, offset + 2);
+		const lengthStr = candidate.slice(offset + 2, offset + 4);
+
+		// Validate that type and length are valid 2-digit numbers
+		if (!/^\d{2}$/.test(typeStr) || !/^\d{2}$/.test(lengthStr)) {
+			break;
+		}
+
+		const tlvLength = parseInt(lengthStr, 10);
+
+		// Check if we have enough data for this TLV block
+		if (candidate.length - offset - 4 < tlvLength) {
+			// Not enough data for this TLV block, this is the end
+			break;
+		}
+
+		// Validate that the TLV data contains only digits
+		const tlvData = candidate.slice(offset + 4, offset + 4 + tlvLength);
+		if (!/^\d*$/.test(tlvData)) {
+			break;
+		}
+
+		offset += 4 + tlvLength;
+	}
+
+	return offset;
+}
+
+/**
+ * Tries to extract and parse a Z-Wave QR code string from within a longer string.
+ * This is useful when a QR code string has been copied with extraneous characters.
+ *
+ * @param input The input string that may contain a QR code
+ * @returns The parsed QR code information, or undefined if no valid QR code was found
+ */
+export async function tryExtractQRCodeString(
+	input: string,
+): Promise<QRProvisioningInformation | undefined> {
+	// Find all potential QR code candidates (sequences starting with 90 followed by enough digits)
+	const candidates = input.matchAll(qrCodeCandidateRegex);
+
+	for (const match of candidates) {
+		const candidate = match[0];
+
+		// Try to determine where this QR code ends based on its structure
+		const qrLength = tryDetermineQRCodeLength(candidate);
+		if (qrLength === undefined) {
+			continue;
+		}
+
+		const qrCode = candidate.slice(0, qrLength);
+
+		try {
+			// Try to parse this candidate
+			const result = await parseQRCodeString(qrCode);
+			return result;
+		} catch (e) {
+			// If it's not a valid QR code (checksum failed, etc.), continue searching
+			if (
+				e instanceof ZWaveError
+				&& e.code === ZWaveErrorCodes.Security2CC_InvalidQRCode
+			) {
+				continue;
+			}
+			// Re-throw unexpected errors
+			throw e;
+		}
+	}
+
+	// No valid QR code found
+	return undefined;
 }

--- a/packages/core/src/qr/parse.ts
+++ b/packages/core/src/qr/parse.ts
@@ -16,13 +16,10 @@ import { fail, parseTLV, readLevel, readUInt16, readUInt8 } from "./utils.js";
 // Regex to find "90" followed by at least (minQRCodeLength - 2) digits
 const qrCodeCandidateRegex = new RegExp(`90\\d{${minQRCodeLength - 2},}`, "g");
 
-/** Parses a string that has been decoded from a Z-Wave (S2 or SmartStart) QR code */
-export async function parseQRCodeString(
+/** Internal parsing function that expects a clean QR code string */
+async function parseQRCodeStringInternal(
 	qr: string,
 ): Promise<QRProvisioningInformation> {
-	// Trim off whitespace that might have been copied by accident
-	qr = qr.trim();
-	// Validate the QR code
 	if (!qr.startsWith("90")) fail("must start with 90");
 	if (qr.length < minQRCodeLength) fail("too short");
 	if (!onlyDigitsRegex.test(qr)) fail("contains invalid characters");
@@ -30,13 +27,7 @@ export async function parseQRCodeString(
 	const version = readLevel(qr, 2);
 	if (version > QRCodeVersion.SmartStart) fail("invalid version");
 
-	const checksum = readUInt16(qr, 4);
-	// The checksum covers the remaining data
-	const checksumInput = new TextEncoder().encode(qr.slice(9));
-
-	const hashResult = await digest("sha-1", checksumInput);
-	const expectedChecksum = Bytes.view(hashResult).readUInt16BE(0);
-	if (checksum !== expectedChecksum) fail("invalid checksum");
+	const expectedChecksum = readUInt16(qr, 4);
 
 	const requestedKeysBitmask = readUInt8(qr, 9);
 	const requestedSecurityClasses = parseBitMask(
@@ -66,7 +57,18 @@ export async function parseQRCodeString(
 	let hasProductID = false;
 	let hasProductType = false;
 
-	while (offset < qr.length) {
+	// Helper to compute checksum for content up to current offset
+	async function checksumMatches(): Promise<boolean> {
+		const checksumInput = new TextEncoder().encode(qr.slice(9, offset));
+		const hashResult = await digest("sha-1", checksumInput);
+		return Bytes.view(hashResult).readUInt16BE(0) === expectedChecksum;
+	}
+
+	// Parse TLV blocks until checksum matches (indicating end of QR code)
+	while (offset + 4 <= qr.length) {
+		const tlvLength = parseInt(qr.slice(offset + 2, offset + 4), 10);
+		if (offset + 4 + tlvLength > qr.length) break;
+
 		const {
 			entry: { type, ...data },
 			charsRead,
@@ -79,6 +81,11 @@ export async function parseQRCodeString(
 			hasProductType = true;
 		}
 		Object.assign(ret, data);
+
+		// Check if we've found the end of the QR code
+		if (hasProductID && hasProductType && await checksumMatches()) {
+			return ret;
+		}
 	}
 
 	// Ensure the required fields are present
@@ -86,113 +93,53 @@ export async function parseQRCodeString(
 		fail("missing required fields");
 	}
 
+	// Final checksum validation
+	if (!await checksumMatches()) {
+		fail("invalid checksum");
+	}
+
 	return ret;
 }
 
 /**
- * Tries to find the length of a valid QR code string starting at position 0.
- * Returns the length if found, or undefined if not valid.
- *
- * The QR code structure is:
- * - 2 digits: "90" (Z indicator)
- * - 2 digits: version
- * - 5 digits: checksum
- * - 3 digits: requested keys
- * - 40 digits: DSK (8 blocks of 5)
- * - Variable: TLV blocks (each has 2-digit type, 2-digit length, then data)
+ * Parses a string that has been decoded from a Z-Wave (S2 or SmartStart) QR code.
+ * Automatically handles whitespace and tries to find a valid QR code within
+ * longer strings that may contain extraneous characters.
  */
-function tryDetermineQRCodeLength(candidate: string): number | undefined {
-	// Must start with 90 and have minimum length
-	if (!candidate.startsWith("90") || candidate.length < minQRCodeLength) {
-		return undefined;
-	}
+export async function parseQRCodeString(
+	qr: string,
+): Promise<QRProvisioningInformation> {
+	// Remove all whitespace to handle QR codes with spaces/newlines in the middle
+	const normalized = qr.replace(/\s/g, "");
 
-	// Version must be valid (0 or 1)
-	const version = parseInt(candidate.slice(2, 4), 10);
-	if (version > QRCodeVersion.SmartStart) {
-		return undefined;
-	}
-
-	// Start after the fixed portion (90 + version + checksum + keys + DSK = 52 chars)
-	let offset = minQRCodeLength;
-
-	// Walk through TLV blocks to find the end
-	while (offset < candidate.length) {
-		// Need at least 4 chars for type (2) and length (2)
-		if (candidate.length - offset < 4) {
-			// Not enough for another TLV block, this is the end
-			break;
-		}
-
-		const typeStr = candidate.slice(offset, offset + 2);
-		const lengthStr = candidate.slice(offset + 2, offset + 4);
-
-		// Validate that type and length are valid 2-digit numbers
-		if (!/^\d{2}$/.test(typeStr) || !/^\d{2}$/.test(lengthStr)) {
-			break;
-		}
-
-		const tlvLength = parseInt(lengthStr, 10);
-
-		// Check if we have enough data for this TLV block
-		if (candidate.length - offset - 4 < tlvLength) {
-			// Not enough data for this TLV block, this is the end
-			break;
-		}
-
-		// Validate that the TLV data contains only digits
-		const tlvData = candidate.slice(offset + 4, offset + 4 + tlvLength);
-		if (!/^\d*$/.test(tlvData)) {
-			break;
-		}
-
-		offset += 4 + tlvLength;
-	}
-
-	return offset;
-}
-
-/**
- * Tries to extract and parse a Z-Wave QR code string from within a longer string.
- * This is useful when a QR code string has been copied with extraneous characters.
- *
- * @param input The input string that may contain a QR code
- * @returns The parsed QR code information, or undefined if no valid QR code was found
- */
-export async function tryExtractQRCodeString(
-	input: string,
-): Promise<QRProvisioningInformation | undefined> {
-	// Find all potential QR code candidates (sequences starting with 90 followed by enough digits)
-	const candidates = input.matchAll(qrCodeCandidateRegex);
-
-	for (const match of candidates) {
-		const candidate = match[0];
-
-		// Try to determine where this QR code ends based on its structure
-		const qrLength = tryDetermineQRCodeLength(candidate);
-		if (qrLength === undefined) {
-			continue;
-		}
-
-		const qrCode = candidate.slice(0, qrLength);
-
-		try {
-			// Try to parse this candidate
-			const result = await parseQRCodeString(qrCode);
-			return result;
-		} catch (e) {
-			// If it's not a valid QR code (checksum failed, etc.), continue searching
-			if (
-				e instanceof ZWaveError
-				&& e.code === ZWaveErrorCodes.Security2CC_InvalidQRCode
-			) {
-				continue;
-			}
-			// Re-throw unexpected errors
+	// Optimize for the common case: the entire string is the complete QR code
+	try {
+		return await parseQRCodeStringInternal(normalized);
+	} catch (e) {
+		if (
+			!(e instanceof ZWaveError)
+			|| e.code !== ZWaveErrorCodes.Security2CC_InvalidQRCode
+		) {
 			throw e;
 		}
 	}
 
+	// Fall back to searching for a valid QR code within the string
+	const regex = new RegExp(qrCodeCandidateRegex);
+	let match: RegExpExecArray | null;
+	while ((match = regex.exec(normalized)) !== null) {
+		try {
+			return await parseQRCodeStringInternal(match[0]);
+		} catch (e) {
+			if (
+				!(e instanceof ZWaveError)
+				|| e.code !== ZWaveErrorCodes.Security2CC_InvalidQRCode
+			) {
+				throw e;
+			}
+		}
+	}
+
 	// No valid QR code found
-	return undefined;
+	fail("no valid QR code found");
 }


### PR DESCRIPTION
Added `tryExtractQRCodeString()` function that attempts to extract and
parse a valid Z-Wave QR code from within a longer string that may contain
extraneous characters. This is useful when a QR code string has been
copied from a different scanner with garbage around it.

The function searches for sequences starting with "90" followed by enough
digits, then uses the TLV structure to determine where the QR code ends.
Each candidate is validated via checksum before being returned.

Fixes #7392