### PR TITLE
feat: automatically reset `toneId` to 0 after tone duration elapses

### DIFF
--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -1739,6 +1739,7 @@ export {
 	FibaroVenetianBlindCCSet,
 };
 
+/* eslint-disable */
 export function registerCCs(): void {
 	void AlarmSensorCCValues;
 	void AlarmSensorCC;

--- a/packages/zwave-js/src/lib/node/CCHandlers/SoundSwitchCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/SoundSwitchCC.ts
@@ -1,0 +1,52 @@
+import { SoundSwitchCC, SoundSwitchCCValues } from "@zwave-js/cc";
+import type { GetValueDB } from "@zwave-js/core";
+import { type Timer, setTimer } from "@zwave-js/shared";
+import type { ZWaveNode } from "../Node.js";
+
+export interface SoundSwitchHandlerStore {
+	// Map of endpoint index -> auto-reset timer
+	autoResetTimers: Map<number, Timer>;
+}
+
+export function getDefaultSoundSwitchHandlerStore(): SoundSwitchHandlerStore {
+	return {
+		autoResetTimers: new Map(),
+	};
+}
+
+/** Handles timer management after setting the toneId value */
+export function handleSoundSwitchSetValue(
+	ctx: GetValueDB,
+	node: ZWaveNode,
+	store: SoundSwitchHandlerStore,
+	endpointIndex: number,
+	toneId: number,
+): void {
+	// Cancel any existing timer for this endpoint
+	const existingTimer = store.autoResetTimers.get(endpointIndex);
+	if (existingTimer) {
+		existingTimer.clear();
+		store.autoResetTimers.delete(endpointIndex);
+	}
+
+	// Schedule auto-reset timer if playing a tone with known duration
+	if (toneId > 0) {
+		const durationSeconds = SoundSwitchCC.getToneDurationCached(
+			ctx,
+			{ nodeId: node.id, index: endpointIndex, virtual: false },
+			toneId,
+		);
+		if (durationSeconds !== undefined && durationSeconds > 0) {
+			const timeoutMs = durationSeconds * 1000;
+			const timer = setTimer(() => {
+				node.valueDB.setValue(
+					SoundSwitchCCValues.toneId.endpoint(endpointIndex),
+					0,
+				);
+				store.autoResetTimers.delete(endpointIndex);
+			}, timeoutMs).unref();
+
+			store.autoResetTimers.set(endpointIndex, timer);
+		}
+	}
+}

--- a/packages/zwave-js/src/lib/test/cc/SoundSwitchCC.test.ts
+++ b/packages/zwave-js/src/lib/test/cc/SoundSwitchCC.test.ts
@@ -1,0 +1,87 @@
+import { SoundSwitchCCValues } from "@zwave-js/cc";
+import { CommandClasses } from "@zwave-js/core";
+import { ccCaps } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { describe } from "vitest";
+import { integrationTest } from "../integrationTestSuite.js";
+
+describe("SoundSwitchCC", () => {
+	integrationTest(
+		"When playing a tone with known duration, toneId should auto-reset to 0 after duration elapses",
+		{
+			nodeCapabilities: {
+				commandClasses: [
+					ccCaps({
+						ccId: CommandClasses["Sound Switch"],
+						isSupported: true,
+						version: 2,
+						tones: [
+							{ duration: 2, name: "Short Beep" },
+							{ duration: 5, name: "Long Beep" },
+						],
+					}),
+				],
+			},
+
+			testBody: async (t, driver, node, mockController, mockNode) => {
+				const toneIdValue = SoundSwitchCCValues.toneId.endpoint(0);
+
+				// Play tone 1 (2 second duration)
+				await node.setValue(toneIdValue, 1);
+
+				// Verify tone is playing (optimistically updated)
+				t.expect(node.getValue(toneIdValue)).toBe(1);
+
+				// Wait for duration to elapse (plus small buffer)
+				await wait(2100);
+
+				// Verify tone was auto-reset to 0
+				t.expect(node.getValue(toneIdValue)).toBe(0);
+			},
+		},
+	);
+
+	integrationTest(
+		"When playing a new tone before the current finishes, the old timer should be cancelled",
+		{
+			nodeCapabilities: {
+				commandClasses: [
+					ccCaps({
+						ccId: CommandClasses["Sound Switch"],
+						isSupported: true,
+						version: 2,
+						tones: [
+							{ duration: 2, name: "Short Beep" },
+							{ duration: 5, name: "Long Beep" },
+						],
+					}),
+				],
+			},
+
+			testBody: async (t, driver, node, mockController, mockNode) => {
+				const toneIdValue = SoundSwitchCCValues.toneId.endpoint(0);
+
+				// Play tone 1 (2 second duration)
+				await node.setValue(toneIdValue, 1);
+				t.expect(node.getValue(toneIdValue)).toBe(1);
+
+				// After 1 second, play tone 2 (5 second duration)
+				// This should cancel tone 1's timer
+				await wait(1000);
+				await node.setValue(toneIdValue, 2);
+				t.expect(node.getValue(toneIdValue)).toBe(2);
+
+				// Wait past when tone 1 would have finished (2s from start)
+				// but tone 2 should still be "playing"
+				await wait(1500);
+				t.expect(node.getValue(toneIdValue)).toBe(2);
+
+				// Wait for tone 2 to finish (5 seconds from when it started + buffer)
+				await wait(3600);
+
+				// Should be reset to 0 after tone 2's duration
+				t.expect(node.getValue(toneIdValue)).toBe(0);
+			},
+		},
+	);
+});


### PR DESCRIPTION
fixes: https://github.com/zwave-js/zwave-js/issues/6973