### PR TITLE
feat: support ranges with gaps and step sizes in config parameter definitions

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -104,10 +104,10 @@ For devices which do not allow auto-discovering associations, the associations m
 
 Before defining `associations` in a config file, please make sure that **at least one** of the following points applies:
 
-- The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
-- The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
-- Additional lifelines besides the primary one are **necessary** to get all desired reports
-- `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
+-   The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
+-   The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
+-   Additional lifelines besides the primary one are **necessary** to get all desired reports
+-   `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
 
 The property looks as follows:
 
@@ -211,24 +211,25 @@ This property defines all the existing configuration parameters. It looks like t
 
 where each parameter definition has the following properties:
 
-| Parameter property | Type    | Required? | Description                                                                                                                                                                                                                                                                                      |
-| ------------------ | ------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `#`                | string  |    yes    | The parameter number (e.g. `"1"`, `"2"`, ...). <br />For partial parameters, this includes the bitmask (e.g. `"5[0xff00]"`)                                                                                                                                                                      |
-| `label`            | string  |    yes    | A short name for the parameter. <br />This **must not** include unnecessary white-space, such as newlines or tabs.                                                                                                                                                                               |
-| `description`      | string  |    no     | An **optional** longer description of what the parameter does.<br />If a description does not add **significant** value (for example if it just repeats the allowed values), it should be removed instead.<br />This **must not** include unnecessary white-space, such as newlines or tabs.     |
-| `valueSize`        | number  |    yes    | How many bytes the device uses for this value                                                                                                                                                                                                                                                    |
-| `minValue`         | number  |    yes    | The minimum allowed value for this parameter                                                                                                                                                                                                                                                     |
-| `maxValue`         | number  |    yes    | The maximum allowed value for this parameter                                                                                                                                                                                                                                                     |
-| `defaultValue`     | number  |   maybe   | The factory default value of this parameter. This is required unless the parameter is `readOnly`.                                                                                                                                                                                                |
-| `recommendedValue` | number  |    no     | An optional recommended value for this parameter, which may provide better device performance or behavior than the default value and benefit most users. This value is only automatically applied during device interview when the `applyRecommendedConfigParamValues` driver option is enabled. |
-| `unit`             | string  |    no     | The unit for this parameter's values, e.g. `minutes`, `seconds`, `%`, `kWh`, `0.1 °C`, etc...                                                                                                                                                                                                    |
-| `unsigned`         | boolean |    no     | Whether this parameter is interpreted as an unsigned value by the device (default: `false`). This simplifies usage for the end user.                                                                                                                                                             |
-| `readOnly`         | boolean |    no     | Whether this parameter can only be read                                                                                                                                                                                                                                                          |
-| `writeOnly`        | boolean |    no     | Whether this parameter can only be written                                                                                                                                                                                                                                                       |
-| `destructive`      | boolean |    no     | Whether changing this parameter can have destructive consequences (e.g., factory reset, clearing settings). Applications should show a confirmation before setting such parameters.                                                                                                              |
-| `hidden`           | boolean |    no     | Whether this parameter should be hidden from UIs and normal API outputs. Use this for factory debug parameters, calibration data, or other settings that should not be exposed to end users. See [Hidden Parameters](config-files/hidden-parameters.md) for details.                             |
-| `allowManualEntry` | boolean |    no     | Whether this parameter accepts any value between `minValue` and `maxValue`. Defaults to `true` for writable parameters and `false` for `readOnly` parameters. If this is `false`, `options` must be used to specify the allowed values.                                                          |
-| `options`          | array   |    no     | If `allowManualEntry` is omitted or `false` and the value is writable, this property must contain an array of objects of the form `{"label": string, "value": number}`. Each entry defines one allowed value.                                                                                    |
+| Parameter property | Type    | Required? | Description                                                                                                                                                                                                                                                                                                                                         |
+| ------------------ | ------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#`                | string  |    yes    | The parameter number (e.g. `"1"`, `"2"`, ...). <br />For partial parameters, this includes the bitmask (e.g. `"5[0xff00]"`)                                                                                                                                                                                                                         |
+| `label`            | string  |    yes    | A short name for the parameter. <br />This **must not** include unnecessary white-space, such as newlines or tabs.                                                                                                                                                                                                                                  |
+| `description`      | string  |    no     | An **optional** longer description of what the parameter does.<br />If a description does not add **significant** value (for example if it just repeats the allowed values), it should be removed instead.<br />This **must not** include unnecessary white-space, such as newlines or tabs.                                                        |
+| `valueSize`        | number  |    yes    | How many bytes the device uses for this value                                                                                                                                                                                                                                                                                                       |
+| `minValue`         | number  |    yes    | The minimum allowed value for this parameter. **Not used** when `allowed` is specified.                                                                                                                                                                                                                                                             |
+| `maxValue`         | number  |    yes    | The maximum allowed value for this parameter. **Not used** when `allowed` is specified.                                                                                                                                                                                                                                                             |
+| `allowed`          | array   |    no     | Defines allowed values with support for ranges and gaps. Must contain at least one entry. Each entry must have either `{"value": number}` for a single value or `{"range": [from, to], "step"?: number}` for a range. Mutually exclusive with `minValue`/`maxValue` and `allowManualEntry: false`. See [Ranges with Gaps](#ranges-with-gaps) below. |
+| `defaultValue`     | number  |   maybe   | The factory default value of this parameter. This is required unless the parameter is `readOnly`.                                                                                                                                                                                                                                                   |
+| `recommendedValue` | number  |    no     | An optional recommended value for this parameter, which may provide better device performance or behavior than the default value and benefit most users. This value is only automatically applied during device interview when the `applyRecommendedConfigParamValues` driver option is enabled.                                                    |
+| `unit`             | string  |    no     | The unit for this parameter's values, e.g. `minutes`, `seconds`, `%`, `kWh`, `0.1 °C`, etc...                                                                                                                                                                                                                                                       |
+| `unsigned`         | boolean |    no     | Whether this parameter is interpreted as an unsigned value by the device (default: `false`). This simplifies usage for the end user.                                                                                                                                                                                                                |
+| `readOnly`         | boolean |    no     | Whether this parameter can only be read                                                                                                                                                                                                                                                                                                             |
+| `writeOnly`        | boolean |    no     | Whether this parameter can only be written                                                                                                                                                                                                                                                                                                          |
+| `destructive`      | boolean |    no     | Whether changing this parameter can have destructive consequences (e.g., factory reset, clearing settings). Applications should show a confirmation before setting such parameters.                                                                                                                                                                 |
+| `hidden`           | boolean |    no     | Whether this parameter should be hidden from UIs and normal API outputs. Use this for factory debug parameters, calibration data, or other settings that should not be exposed to end users. See [Hidden Parameters](config-files/hidden-parameters.md) for details.                                                                                |
+| `allowManualEntry` | boolean |    no     | Whether this parameter accepts any value between `minValue` and `maxValue`. Defaults to `true` for writable parameters and `false` for `readOnly` parameters. If this is `false`, `options` must be used to specify the allowed values.                                                                                                             |
+| `options`          | array   |    no     | If `allowManualEntry` is omitted or `false` and the value is writable, this property must contain an array of objects of the form `{"label": string, "value": number}`. Each entry defines one allowed value.                                                                                                                                       |
 
 ### Partial parameters
 
@@ -271,6 +272,81 @@ Partial parameters must follow these rules:
 
 <iframe height="270" width="400" src="config-files/bitmask-calculator.html" style="min-width: 0; width: 400px; height: 270px; border: 0; margin: 0 auto"></iframe>
 
+### Ranges with Gaps
+
+Some parameters accept values in multiple disconnected ranges, or ranges with specific step sizes. For these cases, use the `allowed` field instead of `minValue`/`maxValue`.
+
+#### Structure
+
+The `allowed` field is an array of objects, where each object defines either:
+
+-   A single allowed value: `{"value": number}`
+-   A range of values: `{"range": [from, to], "step"?: number}`
+
+#### Examples
+
+**Example 1: Multiple disconnected ranges**
+
+```json
+{
+	"#": "5",
+	"label": "Sensitivity",
+	"description": "1-10: Low sensitivity, 20-30: Medium sensitivity, 100: Maximum",
+	"valueSize": 1,
+	"defaultValue": 5,
+	"unsigned": true,
+	"allowed": [{ "range": [1, 10] }, { "range": [20, 30] }, { "value": 100 }]
+}
+```
+
+**Example 2: Range with step size**
+
+```json
+{
+	"#": "6",
+	"label": "Report Interval",
+	"valueSize": 1,
+	"defaultValue": 10,
+	"unsigned": true,
+	"unit": "seconds",
+	"allowed": [{ "range": [0, 60], "step": 5 }]
+}
+```
+
+This defines a parameter that accepts 0, 5, 10, 15, 20, ..., 60.
+
+**Example 3: Special value plus continuous range**
+
+```json
+{
+	"#": "7",
+	"label": "Auto-off Timer",
+	"valueSize": 1,
+	"defaultValue": 30,
+	"unsigned": true,
+	"unit": "seconds",
+	"allowed": [{ "value": 0 }, { "range": [10, 255] }],
+	"options": [{ "label": "Disabled", "value": 0 }]
+}
+```
+
+#### Validation Rules
+
+When using the `allowed` field:
+
+1. The array must contain at least one entry
+2. `allowed` and `minValue`/`maxValue` are mutually exclusive
+3. `allowed` and `allowManualEntry: false` are mutually exclusive
+4. Step size must be positive
+5. For ranges with step: `(to - from)` must be evenly divisible by `step`
+6. The envelope of all values (minimum to maximum) must fit within the parameter's `valueSize` and `unsigned` constraints
+7. The `defaultValue` must be one of the allowed values
+8. All `options` values must be in the allowed set
+
+#### Backwards Compatibility
+
+For backwards compatibility with applications that don't support `allowed`, Z-Wave JS automatically computes `minValue` and `maxValue` from the set of allowed values. Applications can use this envelope for basic validation, while applications that support `allowed` can perform more precise validation.
+
 ## `scenes`
 
 The `scenes` property allows defining custom labels and descriptions for Central Scenes instead of the default "Scene 001", "Scene 002" format. This helps create more user-friendly scene names in the UI.
@@ -294,8 +370,8 @@ Each scene is identified by a numeric key (which must be a positive integer betw
 
 Each scene entry consists of:
 
-- A **label** (required) - A user-friendly name for the scene
-- An optional **description** - Additional information about the scene
+-   A **label** (required) - A user-friendly name for the scene
+-   An optional **description** - Additional information about the scene
 
 Scene definitions can also use `$import` syntax and conditional logic (`$if`) just like other parts of device configuration.
 
@@ -428,18 +504,18 @@ Some legacy devices emit an NIF when a local event occurs (e.g. a button press) 
 
 `Basic CC::Report` commands are like their name implies, Basic. They contain no information about **what** they are reporting. By default, Z-Wave JS uses the device type to map these commands to a more appropriate CC. The `mapBasicReport` can influence this behavior. It has the following options:
 
-- `false`: treat the report verbatim without mapping
-- `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
-- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
+-   `false`: treat the report verbatim without mapping
+-   `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
+-   `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapBasicSet`
 
 `Basic CC::Set` commands are meant to control other devices, yet some devices use them to "report" their status or expose secondary functionality. The `mapBasicSet` flag defines how Z-Wave JS should handle these commands:
 
-- `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
-- `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
-- `"event"`: Emit a `value event` for the Basic `"event"` property.
-- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
+-   `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+-   `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+-   `"event"`: Emit a `value event` for the Basic `"event"` property.
+-   `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapRootReportsToEndpoint`
 

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -104,10 +104,10 @@ For devices which do not allow auto-discovering associations, the associations m
 
 Before defining `associations` in a config file, please make sure that **at least one** of the following points applies:
 
--   The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
--   The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
--   Additional lifelines besides the primary one are **necessary** to get all desired reports
--   `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
+- The device **does not** support `Z-Wave Plus CC` and `Association Group Info CC`
+- The auto-discovered labels are **bad** (content or formatting wise), like `GROUP_1` instead of something useful like `Multilevel Sensor Reports`
+- Additional lifelines besides the primary one are **necessary** to get all desired reports
+- `zwave-js` auto-assigns an endpoint association (node 1, endpoint 0) to the lifeline, but the device needs a node association (node 1, no endpoint) to report properly
 
 The property looks as follows:
 
@@ -280,8 +280,8 @@ Some parameters accept values in multiple disconnected ranges, or ranges with sp
 
 The `allowed` field is an array of objects, where each object defines either:
 
--   A single allowed value: `{"value": number}`
--   A range of values: `{"range": [from, to], "step"?: number}`
+- A single allowed value: `{"value": number}`
+- A range of values: `{"range": [from, to], "step"?: number}`
 
 #### Examples
 
@@ -370,8 +370,8 @@ Each scene is identified by a numeric key (which must be a positive integer betw
 
 Each scene entry consists of:
 
--   A **label** (required) - A user-friendly name for the scene
--   An optional **description** - Additional information about the scene
+- A **label** (required) - A user-friendly name for the scene
+- An optional **description** - Additional information about the scene
 
 Scene definitions can also use `$import` syntax and conditional logic (`$if`) just like other parts of device configuration.
 
@@ -504,18 +504,18 @@ Some legacy devices emit an NIF when a local event occurs (e.g. a button press) 
 
 `Basic CC::Report` commands are like their name implies, Basic. They contain no information about **what** they are reporting. By default, Z-Wave JS uses the device type to map these commands to a more appropriate CC. The `mapBasicReport` can influence this behavior. It has the following options:
 
--   `false`: treat the report verbatim without mapping
--   `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
--   `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
+- `false`: treat the report verbatim without mapping
+- `"auto"` **(default)**: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated verbatim without mapping.
+- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapBasicSet`
 
 `Basic CC::Set` commands are meant to control other devices, yet some devices use them to "report" their status or expose secondary functionality. The `mapBasicSet` flag defines how Z-Wave JS should handle these commands:
 
--   `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
--   `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
--   `"event"`: Emit a `value event` for the Basic `"event"` property.
--   `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
+- `"report"` **(default)**: The command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+- `"auto"`: Depending on the device type (Binary Switch, Multilevel Switch, or Binary Sensor), the command is mapped to the corresponding report for that device type. If no matching mapping is found, the command is treated like a `Basic CC::Report`, but the **target value** is used as the **current value**.
+- `"event"`: Emit a `value event` for the Basic `"event"` property.
+- `"Binary Sensor"`: Regardless of the device type, the command is treated like a `Binary Sensor CC::Report`.
 
 ### `mapRootReportsToEndpoint`
 

--- a/docs/config-files/style-guide.md
+++ b/docs/config-files/style-guide.md
@@ -260,9 +260,19 @@ Whenever a parameter only allows two options, formulate the label and/or descrip
 
 ### Min/Max Values
 
-A parameter must define the range of min/max values, however, that range should only be as large as is necessary. Frequently, imported config files have a range of 0-255 when the only possible range is 0-1. Please check the manual.
+A parameter must define the range of allowed values, however, that range should only be as large as is necessary. Frequently, imported config files have a range of 0-255 when the only possible range is 0-1. Please check the manual to be sure.
 
-An exception is parameters that accept a single special value outside the normal range, e.g. `10-255` and `0 (disable)`. There isn't a simple way to represent these gaps, so the value range should be `0-255` in that case.
+### Ranges with gaps
+
+Some parameters have gaps in their allowed values, e.g. a single special value outside the normal range, or ranges with a certain step size. In these cases, the `minValue` and `maxValue` fields are insufficient to describe the allowed values.
+
+For these parameters, use the `allowed` field instead. See [Ranges with Gaps](config-files/file-format.md#ranges-with-gaps) for more details.
+
+For example:
+
+- A parameter accepting 1-10, 20-30, and 100 should use `allowed` instead of `minValue: 1, maxValue: 100`
+- A parameter accepting a special value outside the normal range (e.g., `0` for disable and `10-255` for actual values) should use `allowed`: `[{"value": 0}, {"range": [10, 255]}]`
+- A parameter accepting only multiples of 5 from 0-60 should use `allowed`: `[{"range": [0, 60], "step": 5}]`
 
 ### Units
 

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -443,6 +443,45 @@
 					"type": "boolean",
 					"description": "Whether this parameter is destructive and should require confirmation before setting"
 				},
+				"allowed": {
+					"type": "array",
+					"description": "Defines the allowed values for this parameter as a combination of single values and ranges. Cannot be used together with minValue/maxValue or allowManualEntry: false.",
+					"minItems": 1,
+					"items": {
+						"oneOf": [
+							{
+								"type": "object",
+								"properties": {
+									"value": {
+										"type": "number",
+										"description": "A single allowed value"
+									}
+								},
+								"required": ["value"],
+								"additionalProperties": false
+							},
+							{
+								"type": "object",
+								"properties": {
+									"range": {
+										"type": "array",
+										"description": "A range of allowed values [from, to]",
+										"items": { "type": "number" },
+										"minItems": 2,
+										"maxItems": 2
+									},
+									"step": {
+										"type": "number",
+										"description": "Optional step size within the range (default: 1)",
+										"minimum": 1
+									}
+								},
+								"required": ["range"],
+								"additionalProperties": false
+							}
+						]
+					}
+				},
 				"options": {
 					"type": "array",
 					"minItems": 1,

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -1664,6 +1664,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				valueSize: info.valueSize,
 				min: info.minValue,
 				max: info.maxValue,
+				allowed: info.allowed,
 				default: info.defaultValue,
 				recommended: info.recommendedValue,
 				unit: info.unit,

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -1739,6 +1739,7 @@ export {
 	FibaroVenetianBlindCCSet,
 };
 
+/* eslint-disable */
 export function registerCCs(): void {
 	void AlarmSensorCCValues;
 	void AlarmSensorCC;

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -1739,7 +1739,7 @@ export {
 	FibaroVenetianBlindCCSet,
 };
 
-/* eslint-disable */
+ 
 export function registerCCs(): void {
 	void AlarmSensorCCValues;
 	void AlarmSensorCC;

--- a/packages/cc/src/cc/index.ts
+++ b/packages/cc/src/cc/index.ts
@@ -1739,7 +1739,6 @@ export {
 	FibaroVenetianBlindCCSet,
 };
 
- 
 export function registerCCs(): void {
 	void AlarmSensorCCValues;
 	void AlarmSensorCC;

--- a/packages/config/config/devices/0x0039/39357_39464_zw3011.json
+++ b/packages/config/config/devices/0x0039/39357_39464_zw3011.json
@@ -120,7 +120,7 @@
 			"description": "Set the default brightness level that the dimmer will turn on when being turned on manually",
 			"valueSize": 1,
 			"unit": "%",
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 99,
 			"defaultValue": 0
 		}

--- a/packages/config/config/devices/0x008b/trane_xr524.json
+++ b/packages/config/config/devices/0x008b/trane_xr524.json
@@ -117,7 +117,7 @@
 			"unit": "minutes",
 			"minValue": 3,
 			"maxValue": 9,
-			"defaultValue": 0
+			"defaultValue": 3
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x008b/xl624.json
+++ b/packages/config/config/devices/0x008b/xl624.json
@@ -136,7 +136,7 @@
 			"unit": "minutes",
 			"minValue": 3,
 			"maxValue": 9,
-			"defaultValue": 0
+			"defaultValue": 3
 		},
 		{
 			"#": "10",

--- a/packages/config/config/devices/0x015f/mh-dt311_411.json
+++ b/packages/config/config/devices/0x015f/mh-dt311_411.json
@@ -326,18 +326,30 @@
 			"label": "Alarm Threshold: Current",
 			"valueSize": 2,
 			"unit": "0.01 A",
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 5000,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "33",
 			"label": "Alarm Threshold: Voltage",
 			"valueSize": 2,
 			"unit": "0.1 V",
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 10000,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "34",

--- a/packages/config/config/devices/0x016a/ft116.json
+++ b/packages/config/config/devices/0x016a/ft116.json
@@ -145,8 +145,9 @@
 			"description": "Set the ON/OFF time of the LED when it is in Night light mode",
 			"valueSize": 4,
 			"minValue": 0,
-			"maxValue": 0,
-			"defaultValue": 301991936
+			"maxValue": 4294967295,
+			"defaultValue": 301991936,
+			"unsigned": true
 		},
 		{
 			"#": "86",
@@ -154,8 +155,9 @@
 			"description": "Set the ON time of output load.",
 			"valueSize": 4,
 			"minValue": 0,
-			"maxValue": 0,
-			"defaultValue": 8327680
+			"maxValue": 4294967295,
+			"defaultValue": 8327680,
+			"unsigned": true
 		},
 		{
 			"#": "87",

--- a/packages/config/config/devices/0x0190/adc-s2000-t-ra.json
+++ b/packages/config/config/devices/0x0190/adc-s2000-t-ra.json
@@ -21,8 +21,9 @@
 			"valueSize": 2,
 			"unit": "seconds",
 			"minValue": 10,
-			"maxValue": 32767,
-			"defaultValue": 32768
+			"maxValue": 32768,
+			"defaultValue": 32768,
+			"unsigned": true
 		},
 		{
 			"#": "2",

--- a/packages/config/config/devices/0x019a/11_02_022.json
+++ b/packages/config/config/devices/0x019a/11_02_022.json
@@ -137,7 +137,7 @@
 			"unit": "0.1 °C/°F",
 			"minValue": 5,
 			"maxValue": 100,
-			"defaultValue": 1
+			"defaultValue": 20
 		},
 		{
 			"#": "28",

--- a/packages/config/config/devices/0x0214/dp-32_ix-30_ix-32_6.0_255.255.json
+++ b/packages/config/config/devices/0x0214/dp-32_ix-30_ix-32_6.0_255.255.json
@@ -22,8 +22,10 @@
 			"#": "1",
 			"label": "Basic Set",
 			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 100,
+			"allowed": [
+				{ "range": [1, 99] },
+				{ "value": 255 }
+			],
 			"defaultValue": 255
 		},
 		{

--- a/packages/config/config/devices/0x0214/dp-32_ix-30_ix-32_6.0_255.255.json
+++ b/packages/config/config/devices/0x0214/dp-32_ix-30_ix-32_6.0_255.255.json
@@ -26,7 +26,8 @@
 				{ "range": [1, 99] },
 				{ "value": 255 }
 			],
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "2",

--- a/packages/config/config/devices/0x0214/es-61_0.0_5.255.json
+++ b/packages/config/config/devices/0x0214/es-61_0.0_5.255.json
@@ -23,8 +23,10 @@
 			"label": "Basic Set",
 			"description": "send BASIC Set = Value command",
 			"valueSize": 1,
-			"minValue": 1,
-			"maxValue": 100,
+			"allowed": [
+				{ "range": [1, 99] },
+				{ "value": 255 }
+			],
 			"defaultValue": 255
 		},
 		{

--- a/packages/config/config/devices/0x0214/es-61_0.0_5.255.json
+++ b/packages/config/config/devices/0x0214/es-61_0.0_5.255.json
@@ -27,7 +27,8 @@
 				{ "range": [1, 99] },
 				{ "value": 255 }
 			],
-			"defaultValue": 255
+			"defaultValue": 255,
+			"unsigned": true
 		},
 		{
 			"#": "2",

--- a/packages/config/config/devices/0x0344/he-hls01.json
+++ b/packages/config/config/devices/0x0344/he-hls01.json
@@ -87,18 +87,32 @@
 			"label": "High Load Timeout Protection: Power Threshold",
 			"valueSize": 2,
 			"unit": "W",
-			"minValue": 100,
-			"maxValue": 3500,
-			"defaultValue": 0
+			"allowed": [
+				{ "value": 0 },
+				{ "range": [100, 3500] }
+			],
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "27",
 			"label": "High Load Timeout Protection: Time Threshold",
 			"valueSize": 2,
 			"unit": "minutes",
-			"minValue": 1,
+			"minValue": 0,
 			"maxValue": 1440,
-			"defaultValue": 0
+			"defaultValue": 0,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "41",

--- a/packages/config/config/devices/0x0346/contact_sensor_gen2.json
+++ b/packages/config/config/devices/0x0346/contact_sensor_gen2.json
@@ -85,10 +85,18 @@
 			"description": "Device will wakeup once after the configured delay",
 			"valueSize": 2,
 			"unit": "seconds",
-			"minValue": 5,
-			"maxValue": 65535,
+			"allowed": [
+				{ "value": 0 },
+				{ "range": [5, 65535] }
+			],
 			"defaultValue": 0,
-			"unsigned": true
+			"unsigned": true,
+			"options": [
+				{
+					"label": "Idle",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "6",

--- a/packages/config/config/devices/0x0438/4512757.json
+++ b/packages/config/config/devices/0x0438/4512757.json
@@ -325,9 +325,10 @@
 			"description": "Allowable range: 5-100 (increment by 5)",
 			"valueSize": 4,
 			"unit": "°C",
-			"minValue": 5,
-			"maxValue": 100,
-			"defaultValue": 0
+			"allowed": [
+				{ "range": [5, 100], "step": 5 }
+			],
+			"defaultValue": 10
 		},
 		{
 			"#": "135",

--- a/packages/config/config/devices/0x0438/dimmer2-400w.json
+++ b/packages/config/config/devices/0x0438/dimmer2-400w.json
@@ -191,8 +191,14 @@
 			"valueSize": 2,
 			"unit": "W",
 			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 10
+			"maxValue": 32767,
+			"defaultValue": 10,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "15",
@@ -201,8 +207,14 @@
 			"valueSize": 1,
 			"unit": "%",
 			"minValue": 0,
-			"maxValue": 1,
-			"defaultValue": 20
+			"maxValue": 100,
+			"defaultValue": 20,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				}
+			]
 		},
 		{
 			"#": "21",

--- a/packages/config/config/eslint.config.mjs
+++ b/packages/config/config/eslint.config.mjs
@@ -47,6 +47,7 @@ export default [
 			"@zwave-js/no-useless-description": "error",
 			"@zwave-js/no-value-in-option-label": "error",
 			"@zwave-js/prefer-defaultvalue": "error",
+			"@zwave-js/valid-allowed-values": "error",
 		},
 	},
 ];

--- a/packages/config/config/eslint.config.mjs
+++ b/packages/config/config/eslint.config.mjs
@@ -39,6 +39,7 @@ export default [
 		rules: {
 			"@zwave-js/auto-unsigned": "error",
 			"@zwave-js/consistent-config-string-case": "error",
+			"@zwave-js/no-disallowed-values": "error",
 			"@zwave-js/consistent-device-config-property-order": "error",
 			"@zwave-js/consistent-param-units": "error",
 			"@zwave-js/no-misspelled-names": "error",

--- a/packages/config/config/eslint.config.mjs
+++ b/packages/config/config/eslint.config.mjs
@@ -39,7 +39,8 @@ export default [
 		rules: {
 			"@zwave-js/auto-unsigned": "error",
 			"@zwave-js/consistent-config-string-case": "error",
-			"@zwave-js/no-disallowed-values": "error",
+			"@zwave-js/no-disallowed-default-value": "warn",
+			"@zwave-js/no-disallowed-option-values": "error",
 			"@zwave-js/consistent-device-config-property-order": "error",
 			"@zwave-js/consistent-param-units": "error",
 			"@zwave-js/no-misspelled-names": "error",

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -741,7 +741,7 @@ function validateAllowedValuesDefinition(
 	}
 
 	// Validate envelope fits in valueSize
-	const limits = getIntegerLimits(valueSize as any, unsigned);
+	const limits = getIntegerLimits(valueSize as any, !unsigned);
 	if (globalMin < limits.min || globalMax > limits.max) {
 		addError(
 			file,

--- a/packages/config/maintenance/lintConfigFiles.ts
+++ b/packages/config/maintenance/lintConfigFiles.ts
@@ -1,6 +1,6 @@
 import { configDir } from "#config_dir";
 import {
-	AllowedConfigValue,
+	type AllowedConfigValue,
 	getBitMaskWidth,
 	getIntegerLimits,
 	getLegalRangeForBitMask,

--- a/packages/config/src/devices/ParamInformation.ts
+++ b/packages/config/src/devices/ParamInformation.ts
@@ -1,7 +1,5 @@
-import {
-	type AllowedConfigValue,
-	tryParseParamNumber,
-} from "@zwave-js/core";
+/* oxlint-disable typescript/no-unnecessary-type-assertion */
+import { type AllowedConfigValue, tryParseParamNumber } from "@zwave-js/core";
 import {
 	type JSONObject,
 	ObjectKeyMap,

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -173,8 +173,21 @@ export enum ConfigValueFormat {
 /** @publicAPI */
 export type ConfigValue = number;
 
+export type ConfigValueSingle = {
+	value: number;
+};
+
+export type ConfigValueRange = {
+	from: number;
+	to: number;
+	step?: number;
+};
+
+export type AllowedConfigValue = ConfigValueSingle | ConfigValueRange;
+
 export interface ConfigurationMetadata extends ValueMetadataAny {
 	// readable and writeable are inherited from ValueMetadataAny
+	allowed?: readonly AllowedConfigValue[];
 	min?: ConfigValue;
 	max?: ConfigValue;
 	default?: ConfigValue;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -7,6 +7,7 @@ import { consistentImportDeclarations } from "./rules/consistent-import-declarat
 import { consistentMockNodeBehaviors } from "./rules/consistent-mock-node-behaviors.js";
 import { consistentParamUnits } from "./rules/consistent-param-units.js";
 import { noDebugInTests } from "./rules/no-debug-in-tests.js";
+import { noDisallowedValues } from "./rules/no-disallowed-values.js";
 import { noForbiddenImports } from "./rules/no-forbidden-imports.js";
 import { noInternalCCTypes } from "./rules/no-internal-cc-types.js";
 import { noMisspelledNames } from "./rules/no-misspelled-names.js";
@@ -30,6 +31,7 @@ export default {
 		"consistent-mock-node-behaviors": consistentMockNodeBehaviors,
 		"consistent-param-units": consistentParamUnits,
 		"no-debug-in-tests": noDebugInTests,
+		"no-disallowed-values": noDisallowedValues,
 		"no-forbidden-imports": noForbiddenImports,
 		"no-internal-cc-types": noInternalCCTypes,
 		"no-misspelled-names": noMisspelledNames,

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -16,6 +16,7 @@ import { noUnnecessaryMinMaxValue } from "./rules/no-unnecessary-min-max-value.j
 import { noUselessDescription } from "./rules/no-useless-description.js";
 import { noValueInOptionLabel } from "./rules/no-value-in-option-label.js";
 import { preferDefaultValue } from "./rules/prefer-defaultvalue.js";
+import { validAllowedValues } from "./rules/valid-allowed-values.js";
 
 export default {
 	rules: {
@@ -38,5 +39,6 @@ export default {
 		"no-useless-description": noUselessDescription,
 		"no-value-in-option-label": noValueInOptionLabel,
 		"prefer-defaultvalue": preferDefaultValue,
+		"valid-allowed-values": validAllowedValues,
 	},
 };

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -7,7 +7,10 @@ import { consistentImportDeclarations } from "./rules/consistent-import-declarat
 import { consistentMockNodeBehaviors } from "./rules/consistent-mock-node-behaviors.js";
 import { consistentParamUnits } from "./rules/consistent-param-units.js";
 import { noDebugInTests } from "./rules/no-debug-in-tests.js";
-import { noDisallowedValues } from "./rules/no-disallowed-values.js";
+import {
+	noDisallowedDefaultValue,
+	noDisallowedOptionValues,
+} from "./rules/no-disallowed-values.js";
 import { noForbiddenImports } from "./rules/no-forbidden-imports.js";
 import { noInternalCCTypes } from "./rules/no-internal-cc-types.js";
 import { noMisspelledNames } from "./rules/no-misspelled-names.js";
@@ -31,7 +34,8 @@ export default {
 		"consistent-mock-node-behaviors": consistentMockNodeBehaviors,
 		"consistent-param-units": consistentParamUnits,
 		"no-debug-in-tests": noDebugInTests,
-		"no-disallowed-values": noDisallowedValues,
+		"no-disallowed-default-value": noDisallowedDefaultValue,
+		"no-disallowed-option-values": noDisallowedOptionValues,
 		"no-forbidden-imports": noForbiddenImports,
 		"no-internal-cc-types": noInternalCCTypes,
 		"no-misspelled-names": noMisspelledNames,

--- a/packages/eslint-plugin/src/rules/auto-unsigned.ts
+++ b/packages/eslint-plugin/src/rules/auto-unsigned.ts
@@ -1,13 +1,13 @@
 import { getIntegerLimits, tryParseParamNumber } from "@zwave-js/core";
 import type { AST } from "jsonc-eslint-parser";
 import {
-	inferMinMaxValueFromAllowed,
+	type JSONCRule,
 	getJSONBoolean,
 	getJSONNumber,
 	getJSONString,
+	inferMinMaxValueFromAllowed,
 	insertAfterJSONProperty,
 	insertBeforeJSONProperty,
-	type JSONCRule,
 	paramInfoPropertyOrder,
 	parseAllowedField,
 	removeJSONProperty,
@@ -99,7 +99,7 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 				let minValue: number;
 				let maxValue: number;
 				let isUsingOptions: boolean;
-				let isUsingAllowed: boolean = false;
+				let isUsingAllowed = false;
 
 				// Check for 'allowed' field first
 				const allowedProp = node.properties.find(

--- a/packages/eslint-plugin/src/rules/no-disallowed-values.ts
+++ b/packages/eslint-plugin/src/rules/no-disallowed-values.ts
@@ -1,0 +1,283 @@
+import type { AST } from "jsonc-eslint-parser";
+import type { JSONCRule } from "../utils.js";
+
+type ParsedEntry =
+	| { type: "value"; value: number }
+	| { type: "range"; from: number; to: number; step: number };
+
+function parseAllowedEntries(
+	allowedArray: AST.JSONArrayExpression,
+): ParsedEntry[] {
+	const entries: ParsedEntry[] = [];
+
+	for (const element of allowedArray.elements) {
+		if (!element || element.type !== "JSONObjectExpression") continue;
+
+		const valueProp = element.properties.find(
+			(p) => p.key.type === "JSONLiteral" && p.key.value === "value",
+		);
+		if (
+			valueProp
+			&& valueProp.value.type === "JSONLiteral"
+			&& typeof valueProp.value.value === "number"
+		) {
+			entries.push({ type: "value", value: valueProp.value.value });
+			continue;
+		}
+
+		const rangeProp = element.properties.find(
+			(p) => p.key.type === "JSONLiteral" && p.key.value === "range",
+		);
+		if (
+			rangeProp
+			&& rangeProp.value.type === "JSONArrayExpression"
+			&& rangeProp.value.elements.length === 2
+		) {
+			const [fromElem, toElem] = rangeProp.value.elements;
+			if (
+				fromElem?.type === "JSONLiteral"
+				&& typeof fromElem.value === "number"
+				&& toElem?.type === "JSONLiteral"
+				&& typeof toElem.value === "number"
+			) {
+				const stepProp = element.properties.find(
+					(p) =>
+						p.key.type === "JSONLiteral" && p.key.value === "step",
+				);
+				let step = 1;
+				if (
+					stepProp
+					&& stepProp.value.type === "JSONLiteral"
+					&& typeof stepProp.value.value === "number"
+				) {
+					step = stepProp.value.value;
+				}
+				entries.push({
+					type: "range",
+					from: fromElem.value,
+					to: toElem.value,
+					step,
+				});
+			}
+		}
+	}
+
+	return entries;
+}
+
+function isValueAllowed(value: number, entries: ParsedEntry[]): boolean {
+	for (const entry of entries) {
+		if (entry.type === "value") {
+			if (entry.value === value) return true;
+		} else {
+			if (value >= entry.from && value <= entry.to) {
+				if ((value - entry.from) % entry.step === 0) return true;
+			}
+		}
+	}
+	return false;
+}
+
+export const noDisallowedValues: JSONCRule.RuleModule = {
+	create(context) {
+		return {
+			"JSONProperty[key.value='paramInformation'] > JSONArrayExpression > JSONObjectExpression"(
+				node: AST.JSONObjectExpression,
+			) {
+				// Build the allowed entries from either explicit 'allowed' or minValue/maxValue
+				let allowedEntries: ParsedEntry[] = [];
+
+				const allowedProp = node.properties.find(
+					(p) =>
+						p.key.type === "JSONLiteral"
+						&& p.key.value === "allowed",
+				);
+				if (
+					allowedProp
+					&& allowedProp.value.type === "JSONArrayExpression"
+				) {
+					allowedEntries = parseAllowedEntries(allowedProp.value);
+				} else {
+					// Fall back to minValue/maxValue
+					const minValueProp = node.properties.find(
+						(p) =>
+							p.key.type === "JSONLiteral"
+							&& p.key.value === "minValue",
+					);
+					const maxValueProp = node.properties.find(
+						(p) =>
+							p.key.type === "JSONLiteral"
+							&& p.key.value === "maxValue",
+					);
+					if (
+						minValueProp
+						&& minValueProp.value.type === "JSONLiteral"
+						&& typeof minValueProp.value.value === "number"
+						&& maxValueProp
+						&& maxValueProp.value.type === "JSONLiteral"
+						&& typeof maxValueProp.value.value === "number"
+					) {
+						allowedEntries = [
+							{
+								type: "range",
+								from: minValueProp.value.value,
+								to: maxValueProp.value.value,
+								step: 1,
+							},
+						];
+					}
+				}
+
+				if (allowedEntries.length === 0) return;
+
+				// Track whether we're using explicit 'allowed' or minValue/maxValue
+				const hasExplicitAllowed = allowedProp !== undefined;
+				let minValue: number | undefined;
+				let maxValue: number | undefined;
+				if (!hasExplicitAllowed) {
+					const minProp = node.properties.find(
+						(p) =>
+							p.key.type === "JSONLiteral"
+							&& p.key.value === "minValue",
+					);
+					const maxProp = node.properties.find(
+						(p) =>
+							p.key.type === "JSONLiteral"
+							&& p.key.value === "maxValue",
+					);
+					if (
+						minProp?.value.type === "JSONLiteral"
+						&& typeof minProp.value.value === "number"
+					) {
+						minValue = minProp.value.value;
+					}
+					if (
+						maxProp?.value.type === "JSONLiteral"
+						&& typeof maxProp.value.value === "number"
+					) {
+						maxValue = maxProp.value.value;
+					}
+				}
+
+				// Check defaultValue
+				const defaultValueProp = node.properties.find(
+					(p) =>
+						p.key.type === "JSONLiteral"
+						&& p.key.value === "defaultValue",
+				);
+				if (
+					defaultValueProp
+					&& defaultValueProp.value.type === "JSONLiteral"
+					&& typeof defaultValueProp.value.value === "number"
+				) {
+					const defaultValue = defaultValueProp.value.value;
+					if (!isValueAllowed(defaultValue, allowedEntries)) {
+						if (hasExplicitAllowed) {
+							context.report({
+								loc: defaultValueProp.loc,
+								messageId: "default-value-not-allowed",
+								data: { value: defaultValue.toString() },
+							});
+						} else {
+							context.report({
+								loc: defaultValueProp.loc,
+								messageId: "default-value-outside-range",
+								data: {
+									value: defaultValue.toString(),
+									min: minValue?.toString() ?? "?",
+									max: maxValue?.toString() ?? "?",
+								},
+							});
+						}
+					}
+				}
+
+				// Check option values
+				const optionsProp = node.properties.find(
+					(p) =>
+						p.key.type === "JSONLiteral"
+						&& p.key.value === "options",
+				);
+				if (
+					optionsProp
+					&& optionsProp.value.type === "JSONArrayExpression"
+				) {
+					for (const optionElement of optionsProp.value.elements) {
+						if (
+							!optionElement
+							|| optionElement.type !== "JSONObjectExpression"
+						) {
+							continue;
+						}
+						const optionValueProp = optionElement.properties.find(
+							(p) =>
+								p.key.type === "JSONLiteral"
+								&& p.key.value === "value",
+						);
+						const optionLabelProp = optionElement.properties.find(
+							(p) =>
+								p.key.type === "JSONLiteral"
+								&& p.key.value === "label",
+						);
+						if (
+							optionValueProp
+							&& optionValueProp.value.type === "JSONLiteral"
+							&& typeof optionValueProp.value.value === "number"
+						) {
+							const optionValue = optionValueProp.value.value;
+							if (!isValueAllowed(optionValue, allowedEntries)) {
+								const label = optionLabelProp
+										&& optionLabelProp.value.type
+											=== "JSONLiteral"
+										&& typeof optionLabelProp.value.value
+											=== "string"
+									? optionLabelProp.value.value
+									: undefined;
+								if (hasExplicitAllowed) {
+									context.report({
+										loc: optionValueProp.loc,
+										messageId: "option-value-not-allowed",
+										data: {
+											value: optionValue.toString(),
+											label: label ? ` ("${label}")` : "",
+										},
+									});
+								} else {
+									context.report({
+										loc: optionValueProp.loc,
+										messageId: "option-value-outside-range",
+										data: {
+											value: optionValue.toString(),
+											label: label ? ` ("${label}")` : "",
+											min: minValue?.toString() ?? "?",
+											max: maxValue?.toString() ?? "?",
+										},
+									});
+								}
+							}
+						}
+					}
+				}
+			},
+		};
+	},
+	meta: {
+		// @ts-expect-error Something is off about the rule types
+		docs: {
+			description:
+				"Ensures that defaultValue and option values are within the allowed range",
+		},
+		schema: false,
+		messages: {
+			"default-value-not-allowed":
+				`Default value {{value}} is not in the allowed values.`,
+			"default-value-outside-range":
+				`Default value {{value}} is outside of the min/max value range {{min}}...{{max}}.`,
+			"option-value-not-allowed":
+				`Option value {{value}}{{label}} is not in the allowed values.`,
+			"option-value-outside-range":
+				`Option value {{value}}{{label}} is outside of the min/max value range {{min}}...{{max}}.`,
+		},
+		type: "problem",
+	},
+};

--- a/packages/eslint-plugin/src/rules/no-disallowed-values.ts
+++ b/packages/eslint-plugin/src/rules/no-disallowed-values.ts
@@ -1,10 +1,6 @@
 import type { AllowedConfigValue } from "@zwave-js/core";
 import type { AST } from "jsonc-eslint-parser";
-import {
-	isValueAllowed,
-	type JSONCRule,
-	parseAllowedField,
-} from "../utils.js";
+import { type JSONCRule, isValueAllowed, parseAllowedField } from "../utils.js";
 
 function getAllowedEntriesAndRange(node: AST.JSONObjectExpression): {
 	allowedEntries: AllowedConfigValue[];

--- a/packages/eslint-plugin/src/rules/valid-allowed-values.ts
+++ b/packages/eslint-plugin/src/rules/valid-allowed-values.ts
@@ -326,7 +326,11 @@ export const validAllowedValues: JSONCRule.RuleModule = {
 
 				const isValueInRange = (
 					value: number,
-					range: { from: number; to: number; step: number | undefined },
+					range: {
+						from: number;
+						to: number;
+						step: number | undefined;
+					},
 				): boolean => {
 					if (value < range.from || value > range.to) return false;
 					const step = range.step ?? 1;
@@ -369,21 +373,29 @@ export const validAllowedValues: JSONCRule.RuleModule = {
 				// Check if entries are sorted
 				let isSorted = true;
 				for (let i = 1; i < entries.length; i++) {
-					if (getStart(entries[i - 1].parsed) >= getStart(entries[i].parsed)) {
+					if (
+						getStart(entries[i - 1].parsed)
+							>= getStart(entries[i].parsed)
+					) {
 						isSorted = false;
 						break;
 					}
 				}
 
 				// Sort entries by start value to check for overlaps
-				const sortedEntries = [...entries].sort(
+				const sortedEntries = [...entries].toSorted(
 					(a, b) => getStart(a.parsed) - getStart(b.parsed),
 				);
 
 				// Check for overlaps in the sorted order
 				let hasOverlaps = false;
 				for (let i = 1; i < sortedEntries.length; i++) {
-					if (entriesOverlap(sortedEntries[i - 1].parsed, sortedEntries[i].parsed)) {
+					if (
+						entriesOverlap(
+							sortedEntries[i - 1].parsed,
+							sortedEntries[i].parsed,
+						)
+					) {
 						hasOverlaps = true;
 						break;
 					}
@@ -400,22 +412,30 @@ export const validAllowedValues: JSONCRule.RuleModule = {
 							const fullText = sourceCode.getText();
 							// Get the text of each element using range
 							const sortedTexts = sortedEntries.map(
-								(e) => fullText.slice(e.element.range![0], e.element.range![1]),
+								(e) =>
+									fullText.slice(
+										e.element.range![0],
+										e.element.range![1],
+									),
 							);
 							// Find indentation from first element
-							const firstElemStart = allowedArray.elements[0]!.loc.start;
+							const firstElemStart =
+								allowedArray.elements[0]!.loc.start;
 							const lineStart = sourceCode.getIndexFromLoc({
 								line: firstElemStart.line,
 								column: 0,
 							});
-							const elemStart = sourceCode.getIndexFromLoc(firstElemStart);
+							const elemStart = sourceCode.getIndexFromLoc(
+								firstElemStart,
+							);
 							const indent = fullText.slice(lineStart, elemStart);
 
 							const newContent = sortedTexts.join(",\n" + indent);
 							return fixer.replaceTextRange(
 								[
 									allowedArray.elements[0]!.range![0],
-									allowedArray.elements[allowedArray.elements.length - 1]!.range![1],
+									allowedArray
+										.elements.at(-1)!.range![1],
 								],
 								newContent,
 							);
@@ -492,8 +512,7 @@ export const validAllowedValues: JSONCRule.RuleModule = {
 				`Entries in "allowed" must be sorted. {{prev}} must come after {{curr}}.`,
 			"allowed-entries-not-sorted-fixable":
 				`Entries in "allowed" must be sorted.`,
-			"allowed-entries-overlap":
-				`{{curr}} overlaps with {{prev}}.`,
+			"allowed-entries-overlap": `{{curr}} overlaps with {{prev}}.`,
 		},
 		type: "problem",
 	},

--- a/packages/eslint-plugin/src/rules/valid-allowed-values.ts
+++ b/packages/eslint-plugin/src/rules/valid-allowed-values.ts
@@ -1,3 +1,5 @@
+/* oxlint-disable typescript/no-unnecessary-type-assertion */
+
 import type { AST } from "jsonc-eslint-parser";
 import { type JSONCRule, removeJSONProperty } from "../utils.js";
 

--- a/packages/eslint-plugin/src/rules/valid-allowed-values.ts
+++ b/packages/eslint-plugin/src/rules/valid-allowed-values.ts
@@ -1,0 +1,500 @@
+import type { AST } from "jsonc-eslint-parser";
+import { type JSONCRule, removeJSONProperty } from "../utils.js";
+
+export const validAllowedValues: JSONCRule.RuleModule = {
+	create(context) {
+		return {
+			"JSONProperty[key.value='paramInformation'] > JSONArrayExpression > JSONObjectExpression"(
+				node: AST.JSONObjectExpression,
+			) {
+				const allowedProperty = node.properties.find((p) =>
+					p.key.type === "JSONLiteral" && p.key.value === "allowed"
+				);
+
+				if (
+					!allowedProperty
+					|| allowedProperty.value.type !== "JSONArrayExpression"
+				) {
+					return;
+				}
+
+				const allowedArray = allowedProperty.value;
+
+				// Check that array is not empty
+				if (allowedArray.elements.length === 0) {
+					context.report({
+						loc: allowedProperty.loc,
+						messageId: "empty-allowed-array",
+					});
+					return;
+				}
+
+				// Note: minValue/maxValue conflict is handled by no-unnecessary-min-max-value rule
+
+				// Check mutual exclusivity with allowManualEntry: false
+				const allowManualEntry = node.properties.find((p) =>
+					p.key.type === "JSONLiteral"
+					&& p.key.value === "allowManualEntry"
+					&& p.value.type === "JSONLiteral"
+					&& p.value.value === false
+				);
+				if (allowManualEntry) {
+					context.report({
+						loc: allowManualEntry.loc,
+						messageId: "allowed-conflicts-with-allow-manual-entry",
+						fix: removeJSONProperty(context, allowManualEntry),
+					});
+				}
+
+				// Validate each element in the allowed array
+				for (let i = 0; i < allowedArray.elements.length; i++) {
+					const element = allowedArray.elements[i];
+
+					if (!element || element.type !== "JSONObjectExpression") {
+						context.report({
+							loc: element?.loc ?? allowedProperty.loc,
+							messageId: "allowed-element-not-object",
+							data: { index: i.toString() },
+						});
+						continue;
+					}
+
+					const hasValue = element.properties.some((p) =>
+						p.key.type === "JSONLiteral" && p.key.value === "value"
+					);
+					const hasRange = element.properties.some((p) =>
+						p.key.type === "JSONLiteral" && p.key.value === "range"
+					);
+
+					// Must have either value OR range, but not both
+					if (!hasValue && !hasRange) {
+						context.report({
+							loc: element.loc,
+							messageId: "allowed-element-missing-value-or-range",
+							data: { index: i.toString() },
+						});
+						continue;
+					}
+
+					if (hasValue && hasRange) {
+						context.report({
+							loc: element.loc,
+							messageId: "allowed-element-both-value-and-range",
+							data: { index: i.toString() },
+						});
+						continue;
+					}
+
+					// If it has a value property, check it's a number
+					if (hasValue) {
+						const valueProp = element.properties.find((p) =>
+							p.key.type === "JSONLiteral"
+							&& p.key.value === "value"
+						);
+						if (
+							valueProp && valueProp.value.type !== "JSONLiteral"
+						) {
+							context.report({
+								loc: valueProp.value.loc,
+								messageId: "allowed-element-value-not-number",
+								data: { index: i.toString() },
+							});
+						} else if (
+							valueProp
+							&& valueProp.value.type === "JSONLiteral"
+							&& typeof valueProp.value.value !== "number"
+						) {
+							context.report({
+								loc: valueProp.value.loc,
+								messageId: "allowed-element-value-not-number",
+								data: { index: i.toString() },
+							});
+						}
+					}
+
+					// If it has a range property, validate it
+					if (hasRange) {
+						const rangeProp = element.properties.find((p) =>
+							p.key.type === "JSONLiteral"
+							&& p.key.value === "range"
+						);
+
+						if (!rangeProp) continue;
+
+						if (rangeProp.value.type !== "JSONArrayExpression") {
+							context.report({
+								loc: rangeProp.value.loc,
+								messageId: "allowed-element-range-not-array",
+								data: { index: i.toString() },
+							});
+							continue;
+						}
+
+						const rangeArray = rangeProp.value;
+
+						// Range must have exactly 2 elements
+						if (rangeArray.elements.length !== 2) {
+							context.report({
+								loc: rangeProp.value.loc,
+								messageId: "allowed-element-range-wrong-length",
+								data: { index: i.toString() },
+							});
+							continue;
+						}
+
+						// Both elements must be numbers
+						const [fromElem, toElem] = rangeArray.elements;
+						let fromValue: number | undefined;
+						let toValue: number | undefined;
+
+						if (
+							!fromElem
+							|| fromElem.type !== "JSONLiteral"
+							|| typeof fromElem.value !== "number"
+						) {
+							context.report({
+								loc: fromElem?.loc ?? rangeProp.value.loc,
+								messageId:
+									"allowed-element-range-element-not-number",
+								data: {
+									index: i.toString(),
+									rangeIndex: "0",
+								},
+							});
+						} else {
+							fromValue = fromElem.value;
+						}
+
+						if (
+							!toElem
+							|| toElem.type !== "JSONLiteral"
+							|| typeof toElem.value !== "number"
+						) {
+							context.report({
+								loc: toElem?.loc ?? rangeProp.value.loc,
+								messageId:
+									"allowed-element-range-element-not-number",
+								data: {
+									index: i.toString(),
+									rangeIndex: "1",
+								},
+							});
+						} else {
+							toValue = toElem.value;
+						}
+
+						// If step property exists, validate it's a number and positive
+						const stepProp = element.properties.find((p) =>
+							p.key.type === "JSONLiteral"
+							&& p.key.value === "step"
+						);
+						let stepValue: number | undefined;
+						let stepValid = true;
+
+						if (stepProp) {
+							if (
+								stepProp.value.type !== "JSONLiteral"
+								|| typeof stepProp.value.value !== "number"
+							) {
+								context.report({
+									loc: stepProp.value.loc,
+									messageId:
+										"allowed-element-step-not-number",
+									data: { index: i.toString() },
+								});
+								stepValid = false;
+							} else {
+								stepValue = stepProp.value.value;
+								if (stepValue <= 0) {
+									context.report({
+										loc: stepProp.value.loc,
+										messageId:
+											"allowed-element-step-not-positive",
+										data: {
+											index: i.toString(),
+											step: stepValue.toString(),
+										},
+									});
+									stepValid = false;
+								}
+							}
+						}
+
+						// Semantic validation if both range elements are valid numbers
+						if (fromValue !== undefined && toValue !== undefined) {
+							// from must be <= to
+							if (fromValue > toValue) {
+								context.report({
+									loc: rangeProp.value.loc,
+									messageId: "allowed-element-range-inverted",
+									data: {
+										index: i.toString(),
+										from: fromValue.toString(),
+										to: toValue.toString(),
+									},
+								});
+							} else if (stepValid && stepValue !== undefined) {
+								// (to - from) must be evenly divisible by step
+								if ((toValue - fromValue) % stepValue !== 0) {
+									context.report({
+										loc: stepProp!.value.loc,
+										messageId:
+											"allowed-element-step-not-divisible",
+										data: {
+											index: i.toString(),
+											from: fromValue.toString(),
+											to: toValue.toString(),
+											step: stepValue.toString(),
+										},
+									});
+								}
+							}
+						}
+					}
+				}
+
+				// Validate that entries are sorted and non-overlapping
+				type ParsedEntry =
+					| { type: "value"; value: number }
+					| {
+						type: "range";
+						from: number;
+						to: number;
+						step: number | undefined;
+					};
+
+				const parseEntry = (
+					element: AST.JSONObjectExpression,
+				): ParsedEntry | undefined => {
+					const valueProp = element.properties.find((p) =>
+						p.key.type === "JSONLiteral" && p.key.value === "value"
+					);
+					if (
+						valueProp
+						&& valueProp.value.type === "JSONLiteral"
+						&& typeof valueProp.value.value === "number"
+					) {
+						return { type: "value", value: valueProp.value.value };
+					}
+
+					const rangeProp = element.properties.find((p) =>
+						p.key.type === "JSONLiteral" && p.key.value === "range"
+					);
+					if (
+						rangeProp
+						&& rangeProp.value.type === "JSONArrayExpression"
+						&& rangeProp.value.elements.length === 2
+					) {
+						const [from, to] = rangeProp.value.elements;
+						if (
+							from?.type === "JSONLiteral"
+							&& typeof from.value === "number"
+							&& to?.type === "JSONLiteral"
+							&& typeof to.value === "number"
+						) {
+							const stepProp = element.properties.find((p) =>
+								p.key.type === "JSONLiteral"
+								&& p.key.value === "step"
+							);
+							let step: number | undefined;
+							if (
+								stepProp
+								&& stepProp.value.type === "JSONLiteral"
+								&& typeof stepProp.value.value === "number"
+							) {
+								step = stepProp.value.value;
+							}
+							return {
+								type: "range",
+								from: from.value,
+								to: to.value,
+								step,
+							};
+						}
+					}
+
+					return undefined;
+				};
+
+				const formatEntry = (entry: ParsedEntry): string => {
+					if (entry.type === "value") return `value ${entry.value}`;
+					return `range [${entry.from}, ${entry.to}]`;
+				};
+
+				const getStart = (entry: ParsedEntry): number =>
+					entry.type === "value" ? entry.value : entry.from;
+
+				const isValueInRange = (
+					value: number,
+					range: { from: number; to: number; step: number | undefined },
+				): boolean => {
+					if (value < range.from || value > range.to) return false;
+					const step = range.step ?? 1;
+					return (value - range.from) % step === 0;
+				};
+
+				// Check if two entries overlap (assuming they're sorted by start)
+				const entriesOverlap = (
+					prev: ParsedEntry,
+					curr: ParsedEntry,
+				): boolean => {
+					if (prev.type === "range") {
+						if (curr.type === "value") {
+							return isValueInRange(curr.value, prev);
+						} else {
+							return prev.to >= curr.from;
+						}
+					}
+					return false;
+				};
+
+				// Parse all entries first
+				const entries: Array<{
+					element: AST.JSONObjectExpression;
+					parsed: ParsedEntry;
+				}> = [];
+
+				for (const element of allowedArray.elements) {
+					if (!element || element.type !== "JSONObjectExpression") {
+						continue;
+					}
+					const parsed = parseEntry(element);
+					if (parsed) {
+						entries.push({ element, parsed });
+					}
+				}
+
+				if (entries.length < 2) return;
+
+				// Check if entries are sorted
+				let isSorted = true;
+				for (let i = 1; i < entries.length; i++) {
+					if (getStart(entries[i - 1].parsed) >= getStart(entries[i].parsed)) {
+						isSorted = false;
+						break;
+					}
+				}
+
+				// Sort entries by start value to check for overlaps
+				const sortedEntries = [...entries].sort(
+					(a, b) => getStart(a.parsed) - getStart(b.parsed),
+				);
+
+				// Check for overlaps in the sorted order
+				let hasOverlaps = false;
+				for (let i = 1; i < sortedEntries.length; i++) {
+					if (entriesOverlap(sortedEntries[i - 1].parsed, sortedEntries[i].parsed)) {
+						hasOverlaps = true;
+						break;
+					}
+				}
+
+				// Report issues
+				if (!isSorted && !hasOverlaps) {
+					// Only sorting issue - provide a fix
+					context.report({
+						loc: allowedArray.loc,
+						messageId: "allowed-entries-not-sorted-fixable",
+						fix(fixer) {
+							const sourceCode = context.sourceCode;
+							const fullText = sourceCode.getText();
+							// Get the text of each element using range
+							const sortedTexts = sortedEntries.map(
+								(e) => fullText.slice(e.element.range![0], e.element.range![1]),
+							);
+							// Find indentation from first element
+							const firstElemStart = allowedArray.elements[0]!.loc.start;
+							const lineStart = sourceCode.getIndexFromLoc({
+								line: firstElemStart.line,
+								column: 0,
+							});
+							const elemStart = sourceCode.getIndexFromLoc(firstElemStart);
+							const indent = fullText.slice(lineStart, elemStart);
+
+							const newContent = sortedTexts.join(",\n" + indent);
+							return fixer.replaceTextRange(
+								[
+									allowedArray.elements[0]!.range![0],
+									allowedArray.elements[allowedArray.elements.length - 1]!.range![1],
+								],
+								newContent,
+							);
+						},
+					});
+				} else if (!isSorted || hasOverlaps) {
+					// Report individual issues without fix
+					for (let i = 1; i < entries.length; i++) {
+						const prev = entries[i - 1];
+						const curr = entries[i];
+
+						const prevStart = getStart(prev.parsed);
+						const currStart = getStart(curr.parsed);
+
+						if (prevStart >= currStart) {
+							context.report({
+								loc: curr.element.loc,
+								messageId: "allowed-entries-not-sorted",
+								data: {
+									prev: formatEntry(prev.parsed),
+									curr: formatEntry(curr.parsed),
+								},
+							});
+						} else if (entriesOverlap(prev.parsed, curr.parsed)) {
+							context.report({
+								loc: curr.element.loc,
+								messageId: "allowed-entries-overlap",
+								data: {
+									prev: formatEntry(prev.parsed),
+									curr: formatEntry(curr.parsed),
+								},
+							});
+						}
+					}
+				}
+			},
+		};
+	},
+	meta: {
+		// @ts-expect-error Something is off about the rule types
+		docs: {
+			description: "Ensures that the allowed field has a valid structure",
+		},
+		fixable: "code",
+		schema: false,
+		messages: {
+			"empty-allowed-array":
+				`The "allowed" array must contain at least one entry.`,
+			"allowed-conflicts-with-allow-manual-entry":
+				`The "allowed" field cannot be used with "allowManualEntry: false".`,
+			"allowed-element-not-object":
+				`Element at index {{index}} must be an object.`,
+			"allowed-element-missing-value-or-range":
+				`Element at index {{index}} must have either a "value" or "range" property.`,
+			"allowed-element-both-value-and-range":
+				`Element at index {{index}} cannot have both "value" and "range" properties.`,
+			"allowed-element-value-not-number":
+				`Element at index {{index}}: "value" property must be a number.`,
+			"allowed-element-range-not-array":
+				`Element at index {{index}}: "range" property must be an array.`,
+			"allowed-element-range-wrong-length":
+				`Element at index {{index}}: "range" array must have exactly 2 elements [from, to].`,
+			"allowed-element-range-element-not-number":
+				`Element at index {{index}}: range[{{rangeIndex}}] must be a number.`,
+			"allowed-element-step-not-number":
+				`Element at index {{index}}: "step" property must be a number.`,
+			"allowed-element-step-not-positive":
+				`Element at index {{index}}: "step" must be positive (got {{step}}).`,
+			"allowed-element-range-inverted":
+				`Element at index {{index}}: range "from" ({{from}}) must be <= "to" ({{to}}).`,
+			"allowed-element-step-not-divisible":
+				`Element at index {{index}}: (to - from) must be evenly divisible by step. Range: {{from}}-{{to}}, step: {{step}}.`,
+			"allowed-entries-not-sorted":
+				`Entries in "allowed" must be sorted. {{prev}} must come after {{curr}}.`,
+			"allowed-entries-not-sorted-fixable":
+				`Entries in "allowed" must be sorted.`,
+			"allowed-entries-overlap":
+				`{{curr}} overlaps with {{prev}}.`,
+		},
+		type: "problem",
+	},
+};

--- a/packages/eslint-plugin/src/rules/valid-allowed-values.ts
+++ b/packages/eslint-plugin/src/rules/valid-allowed-values.ts
@@ -1,7 +1,11 @@
 /* oxlint-disable typescript/no-unnecessary-type-assertion */
 
 import type { AST } from "jsonc-eslint-parser";
-import { type JSONCRule, removeJSONProperty } from "../utils.js";
+import {
+	type JSONCRule,
+	removeJSONArrayElement,
+	removeJSONProperty,
+} from "../utils.js";
 
 export const validAllowedValues: JSONCRule.RuleModule = {
 	create(context) {
@@ -350,6 +354,9 @@ export const validAllowedValues: JSONCRule.RuleModule = {
 						} else {
 							return prev.to >= curr.from;
 						}
+					} else if (curr.type === "value") {
+						// Two single values overlap if they're equal
+						return prev.value === curr.value;
 					}
 					return false;
 				};
@@ -371,6 +378,43 @@ export const validAllowedValues: JSONCRule.RuleModule = {
 				}
 
 				if (entries.length < 2) return;
+
+				// First check for duplicate single values across all entries
+				const seenValues = new Map<
+					number,
+					{ element: AST.JSONObjectExpression; index: number }
+				>();
+				let hasDuplicates = false;
+
+				for (let i = 0; i < entries.length; i++) {
+					const entry = entries[i];
+					if (entry.parsed.type === "value") {
+						const existing = seenValues.get(entry.parsed.value);
+						if (existing) {
+							hasDuplicates = true;
+							context.report({
+								loc: entry.element.loc,
+								messageId: "allowed-entries-duplicate",
+								data: {
+									value: entry.parsed.value.toString(),
+								},
+								fix: removeJSONArrayElement(
+									context,
+									allowedArray,
+									entry.element,
+								),
+							});
+						} else {
+							seenValues.set(entry.parsed.value, {
+								element: entry.element,
+								index: i,
+							});
+						}
+					}
+				}
+
+				// If there are duplicates, don't check sorting/overlaps yet
+				if (hasDuplicates) return;
 
 				// Check if entries are sorted
 				let isSorted = true;
@@ -452,19 +496,20 @@ export const validAllowedValues: JSONCRule.RuleModule = {
 						const prevStart = getStart(prev.parsed);
 						const currStart = getStart(curr.parsed);
 
-						if (prevStart >= currStart) {
+						if (entriesOverlap(prev.parsed, curr.parsed)) {
 							context.report({
 								loc: curr.element.loc,
-								messageId: "allowed-entries-not-sorted",
+								messageId: "allowed-entries-overlap",
 								data: {
 									prev: formatEntry(prev.parsed),
 									curr: formatEntry(curr.parsed),
 								},
 							});
-						} else if (entriesOverlap(prev.parsed, curr.parsed)) {
+						} else if (prevStart >= currStart) {
+							// Not sorted and not overlapping
 							context.report({
 								loc: curr.element.loc,
-								messageId: "allowed-entries-overlap",
+								messageId: "allowed-entries-not-sorted",
 								data: {
 									prev: formatEntry(prev.parsed),
 									curr: formatEntry(curr.parsed),
@@ -515,6 +560,7 @@ export const validAllowedValues: JSONCRule.RuleModule = {
 			"allowed-entries-not-sorted-fixable":
 				`Entries in "allowed" must be sorted.`,
 			"allowed-entries-overlap": `{{curr}} overlaps with {{prev}}.`,
+			"allowed-entries-duplicate": `Duplicate value {{value}}.`,
 		},
 		type: "problem",
 	},

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -461,6 +461,7 @@ export const paramInfoPropertyOrder: string[] = [
 	"description",
 	"valueSize",
 	"unit",
+	"allowed",
 	"minValue",
 	"maxValue",
 	"defaultValue",

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -287,9 +287,9 @@ export function removeJSONArrayElement(
 		// - If there's a previous element, remove from end of previous to end of current
 		// - If it's the only element, just remove the element itself
 		if (nextElem) {
-			return fixer.removeRange([element.range![0], nextElem.range![0]]);
+			return fixer.removeRange([element.range[0], nextElem.range[0]]);
 		} else if (prevElem) {
-			return fixer.removeRange([prevElem.range![1], element.range![1]]);
+			return fixer.removeRange([prevElem.range[1], element.range[1]]);
 		} else {
 			return fixer.remove(element as any);
 		}


### PR DESCRIPTION
This PR adds support for a new `allowed` field on device config parameters that explicitly defines valid values as single values (`{ "value": 5 }`) or ranges with an optional step size (`{ "range": [0, 100], "step": 5 }`).
This will allow us to drop the workaround we've been doing by mentioning the allowable range in the description field.