### PR TITLE
feat(config): add MCO Home MH-5900 thermostat

### DIFF
--- a/packages/config/config/devices/0x015f/mh-5900.json
+++ b/packages/config/config/devices/0x015f/mh-5900.json
@@ -1,16 +1,16 @@
 {
-  "manufacturer": "MCO Home",
-  "manufacturerId": "0x015f",
-  "label": "MH-5900 Thermostat",
-  "description": "Z-Wave thermostat",
-  "devices": [
-    {
-      "productType": "0x810a",
-      "productId": "0x5900",
-      "firmwareVersion": {
-        "min": "0.0",
-        "max": "255.255"
-      }
-    }
-  ]
+	"manufacturer": "MCO Home",
+	"manufacturerId": "0x015f",
+	"label": "MH-5900",
+	"description": "Thermostat",
+	"devices": [
+		{
+			"productType": "0x810a",
+			"productId": "0x5900"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	}
 }

--- a/packages/config/config/devices/0x015f/mh-5900.json
+++ b/packages/config/config/devices/0x015f/mh-5900.json
@@ -1,0 +1,16 @@
+{
+  "manufacturer": "MCO Home",
+  "manufacturerId": "0x015f",
+  "label": "MH-5900 Thermostat",
+  "description": "Z-Wave thermostat",
+  "devices": [
+    {
+      "productType": "0x810a",
+      "productId": "0x5900",
+      "firmwareVersion": {
+        "min": "0.0",
+        "max": "255.255"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds initial device configuration entry for the MCO Home MH-5900 thermostat
(0x015f:0x810a:0x5900).

This PR fixes issue #8552. The device was previously missing entirely
from the Z-Wave JS Config DB.

Follow-up PR will add full parameter metadata using existing MCO templates.

fixes #8552 