### PR TITLE
fix: handle `allowed` field in device config hash comparison

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,7 @@ export * from "./test/assertZWaveError.js";
 export type * from "./traits/index.js";
 export type * from "./util/_Types.js";
 export * from "./util/compareVersions.js";
-export { deflateSync, gunzipSync } from "./util/compression.js";
+export { deflateSync, gunzipSync, inflateSync } from "./util/compression.js";
 export * from "./util/config.js";
 export * from "./util/crc.js";
 export * from "./util/date.js";

--- a/packages/core/src/index_browser.ts
+++ b/packages/core/src/index_browser.ts
@@ -20,7 +20,7 @@ export * from "./security/ctr_drbg.js";
 export type * from "./traits/index.js";
 export type * from "./util/_Types.js";
 export * from "./util/compareVersions.js";
-export { deflateSync, gunzipSync } from "./util/compression.js";
+export { deflateSync, gunzipSync, inflateSync } from "./util/compression.js";
 export * from "./util/config.js";
 export * from "./util/crc.js";
 export * from "./util/date.js";

--- a/packages/core/src/index_safe.ts
+++ b/packages/core/src/index_safe.ts
@@ -14,7 +14,7 @@ export * from "./registries/Scales.js";
 export * from "./registries/Sensors.js";
 export type * from "./traits/index.js";
 export * from "./util/_Types.js";
-export { deflateSync, gunzipSync } from "./util/compression.js";
+export { deflateSync, gunzipSync, inflateSync } from "./util/compression.js";
 export * from "./util/config.js";
 export * from "./util/crc.js";
 export * from "./util/graph.js";


### PR DESCRIPTION
Followup to #8547 that prevents the internal `min/maxValue` to `allowed` normalization to falsely trigger the device config changed diagnostic.