### PR TITLE
fix(config): update Zooz ZEN32 config to the latest firmware 

### DIFF
--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -284,6 +284,14 @@
 			"label": "LED Indicator (Scene Control)",
 			"description": "When enabled, LED indicator will flash to confirm scene activation.",
 			"defaultValue": 0
+		},
+		{
+			"#": "28",
+			"$if": "firmwareVersion >= 3.20 && firmwareVersion < 10.0",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Scene Control Multi-Tap",
+			"description": "when disabled, only single taps report via central scene.",
+			"defaultValue": 0
 		}
 	],
 	"compat": {

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -241,11 +241,6 @@
 			"defaultValue": 0
 		},
 		{
-			"#": "26",
-			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
-			"$import": "templates/zooz_template.json#enable_scene_control_3way"
-		},
-		{
 			"#": "25[0x01]",
 			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
 			"$import": "~/templates/master_template.json#base_enable_disable",
@@ -276,6 +271,11 @@
 			"label": "Send Status Change Report: Timer",
 			"description": "Determine whether a trigger of this type should prompt a status change report to associated devices.",
 			"defaultValue": 1
+		},
+		{
+			"#": "26",
+			"$if": "firmwareVersion >= 10.40 || firmwareVersion >= 2.10 && firmwareVersion < 10.0",
+			"$import": "templates/zooz_template.json#enable_scene_control_3way"
 		},
 		{
 			"#": "27",

--- a/packages/config/config/devices/0x027a/zen32.json
+++ b/packages/config/config/devices/0x027a/zen32.json
@@ -279,7 +279,7 @@
 		},
 		{
 			"#": "27",
-			"$if": "firmwareVersion >= 2.40 && firmwareVersion < 10.0",
+			"$if": "firmwareVersion >= 10.50 || firmwareVersion >= 2.40 && firmwareVersion < 10.0",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "LED Indicator (Scene Control)",
 			"description": "When enabled, LED indicator will flash to confirm scene activation.",

--- a/packages/config/config/devices/0x027a/zen35.json
+++ b/packages/config/config/devices/0x027a/zen35.json
@@ -312,6 +312,14 @@
 			"label": "Scene Control Multi-Tap",
 			"description": "when disabled, only single taps report via central scene.",
 			"defaultValue": 0
+		},
+		{
+			"#": "43",
+			"label": "Gamma Factor",
+			"description": "A higher gamma makes dimming more gradual at low levels, while a lower gamma results in a more linear or abrupt transition (10-50 = 1.0–5.0 gamma).",
+			"valueSize": 1,
+			"minValue": 10,
+			"maxValue": 50,
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen35.json
+++ b/packages/config/config/devices/0x027a/zen35.json
@@ -304,6 +304,14 @@
 			"#": "41",
 			"$import": "templates/zooz_template.json#custom_brightness",
 			"label": "Custom Brightness Level (Z-Wave Control)"
+		},
+		{
+			"#": "42",
+			"$if": "firmwareVersion >= 1.20",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Scene Control Multi-Tap",
+			"description": "when disabled, only single taps report via central scene.",
+			"defaultValue": 0
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
I have updated the ZEN32 configuration to accommodate the following firmware updates 
- As of released 9/2023, Firmware version 10.50 added support for parameter 27 for Version 1.0 hardware. 
- As of 08/2025, Firmware version 3.20 added support for parameter 28 for Version 3.0 hardware.

I have also moved parameter 26 in the configuration below 25

Supporting Documentation:
- [ZEN32 Change Log (Look at 10.50 & 3.20)](https://www.support.getzooz.com/kb/article/706-zen32-scene-controller-change-log/)
- [ZEN32 Advanced Configuration Documentation (Look at Parameter 28)](https://www.support.getzooz.com/kb/article/608-zen32-scene-controller-advanced-settings/)
