### PR TITLE
fix(config): update Zooz ZEN35 config to firmware 1.10+

### DIFF
--- a/packages/config/config/devices/0x027a/zen35.json
+++ b/packages/config/config/devices/0x027a/zen35.json
@@ -312,6 +312,14 @@
 			"label": "Scene Control Multi-Tap",
 			"description": "When disabled, only single taps report via central scene.",
 			"defaultValue": 0
+		},
+		{
+			"#": "43",
+			"label": "Gamma Factor",
+			"description": "A higher gamma makes dimming more gradual at low levels, while a lower gamma results in a more linear or abrupt transition (10-50 = 1.0–5.0 gamma).",
+			"valueSize": 1,
+			"minValue": 10,
+			"maxValue": 50
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen35.json
+++ b/packages/config/config/devices/0x027a/zen35.json
@@ -307,7 +307,7 @@
 		},
 		{
 			"#": "42",
-			"$if": "firmwareVersion >= 1.20",
+			"$if": "firmwareVersion >= 1.10",
 			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
 			"label": "Scene Control Multi-Tap",
 			"description": "When disabled, only single taps report via central scene.",
@@ -315,6 +315,7 @@
 		},
 		{
 			"#": "43",
+			"$if": "firmwareVersion >= 1.10",
 			"label": "Gamma Factor",
 			"description": "A higher gamma makes dimming more gradual at low levels, while a lower gamma results in a more linear or abrupt transition (10-50 = 1.0–5.0 gamma).",
 			"valueSize": 1,

--- a/packages/config/config/devices/0x027a/zen35.json
+++ b/packages/config/config/devices/0x027a/zen35.json
@@ -304,6 +304,14 @@
 			"#": "41",
 			"$import": "templates/zooz_template.json#custom_brightness",
 			"label": "Custom Brightness Level (Z-Wave Control)"
+		},
+		{
+			"#": "42",
+			"$if": "firmwareVersion >= 1.20",
+			"$import": "~/templates/master_template.json#base_enable_disable_inverted",
+			"label": "Scene Control Multi-Tap",
+			"description": "When disabled, only single taps report via central scene.",
+			"defaultValue": 0
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen35.json
+++ b/packages/config/config/devices/0x027a/zen35.json
@@ -320,7 +320,8 @@
 			"description": "A higher gamma makes dimming more gradual at low levels, while a lower gamma results in a more linear or abrupt transition (10-50 = 1.0–5.0 gamma).",
 			"valueSize": 1,
 			"minValue": 10,
-			"maxValue": 50
+			"maxValue": 50,
+			"defaultValue": 10
 		}
 	],
 	"metadata": {


### PR DESCRIPTION
I have updated the ZEN35 configuration to accommodate the following firmware updates 
- As of 06/2025, Firmware version 1.10 added support for parameters 42 – Scene Control Multi-Tap, and 43 – Gamma Factor.

I have also made sure to include firmware version checks for these parameters.

Supporting Documentation:
- [ZEN35 Change Log (Look at 1.10)](https://www.support.getzooz.com/kb/article/1675-zen35-scene-dimmer-change-log/)
- [ZEN35 Advanced Configuration Documentation (Look at Parameter 42 & 43)](https://www.support.getzooz.com/kb/article/1673-zen35-scene-dimmer-advanced-settings/)