### PR TITLE
feat(config): add Zooz Zen57 240V XS Relay

### DIFF
--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -777,7 +777,7 @@
 				"value": 9
 			},
 			{
-				"label": "Input type / Report type",
+				"label": "On/Off Report Only",
 				"value": 10
 			}
 		]

--- a/packages/config/config/devices/0x027a/templates/zooz_template.json
+++ b/packages/config/config/devices/0x027a/templates/zooz_template.json
@@ -732,6 +732,56 @@
 			}
 		]
 	},
+	"external_switch_type_0-10": {
+		"$import": "#external_switch_type_0-3",
+		"maxValue": 10,
+		"options": [
+			{
+				"label": "Automatic detection",
+				"value": 0
+			},
+			{
+				"label": "Toggle switch",
+				"value": 1
+			},
+			{
+				"label": "Momentary switch",
+				"value": 2
+			},
+			{
+				"label": "Toggle switch (reversed)",
+				"value": 3
+			},
+			{
+				"label": "Leak alarm (water sensor)",
+				"value": 4
+			},
+			{
+				"label": "Heat alarm",
+				"value": 5
+			},
+			{
+				"label": "Motion alert",
+				"value": 6
+			},
+			{
+				"label": "Open/Close alert (door sensor)",
+				"value": 7
+			},
+			{
+				"label": "CO alarm",
+				"value": 8
+			},
+			{
+				"label": "CO2 alarm",
+				"value": 9
+			},
+			{
+				"label": "Input type / Report type",
+				"value": 10
+			}
+		]
+	},
 	"external_switch_type_0-12": {
 		"$import": "#external_switch_type_0-3",
 		"maxValue": 12,

--- a/packages/config/config/devices/0x027a/zen57.json
+++ b/packages/config/config/devices/0x027a/zen57.json
@@ -89,7 +89,7 @@
 	],
 	"metadata": {
 		"inclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will blink green while processing. It will turn solid green for 2 seconds if inclusion is successful or turn solid red for 2 seconds if the pairing attempt fails.",
-		"exclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will blink green while processing. It will turn solid green for 2 seconds when exclusion is successful or turn solid red for 2 seconds if exclusion fails.",
+		"exclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will blink green while processing. It will turn solid green for 2 seconds if successful or solid red for 2 seconds if exclusion fails.",
 		"reset": "Click the Z-Wave button once and immediately after, press and hold the button for 15 seconds. The LED indicator will flash during the process and turn red for 3 seconds to confirm successful reset.",
 		"manual": "https://cdn.shopify.com/s/files/1/0218/7704/files/zooz-z-wave-long-range-240v-xs-relay-zen57-manual.pdf"
 	}

--- a/packages/config/config/devices/0x027a/zen57.json
+++ b/packages/config/config/devices/0x027a/zen57.json
@@ -84,7 +84,7 @@
 			"#": "13",
 			"$import": "~/templates/master_template.json#base_enable_disable",
 			"label": "Reversed Reports for Input",
-			"description": "Reverse the reported values for your selected input type (value 1). Expert users only. See manual for details."
+			"description": "Reverse the reported values for your selected input type. See manual for details."
 		}
 	],
 	"metadata": {

--- a/packages/config/config/devices/0x027a/zen57.json
+++ b/packages/config/config/devices/0x027a/zen57.json
@@ -88,7 +88,7 @@
 		}
 	],
 	"metadata": {
-		"inclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will blink green while processing. It will turn solid green for 2 seconds if inclusion is successful or turn solid red for 2 seconds if the pairing attempt fails.",
+		"inclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will blink green while processing. It will turn solid green for 2 seconds if successful or solid red for 2 seconds if inclusion fails.",
 		"exclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will blink green while processing. It will turn solid green for 2 seconds if successful or solid red for 2 seconds if exclusion fails.",
 		"reset": "Click the Z-Wave button once and immediately after, press and hold the button for 15 seconds. The LED indicator will flash during the process and turn red for 3 seconds to confirm successful reset.",
 		"manual": "https://cdn.shopify.com/s/files/1/0218/7704/files/zooz-z-wave-long-range-240v-xs-relay-zen57-manual.pdf"

--- a/packages/config/config/devices/0x027a/zen57.json
+++ b/packages/config/config/devices/0x027a/zen57.json
@@ -1,0 +1,96 @@
+{
+	"manufacturer": "Zooz",
+	"manufacturerId": "0x027a",
+	"label": "ZEN57",
+	"description": "240V XS Relay",
+	"devices": [
+		{
+			"productType": "0x0004",
+			"productId": "0x0321"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": "1",
+			"label": "LED Indicator",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Always off",
+					"value": 0
+				},
+				{
+					"label": "On when load is on",
+					"value": 1
+				}
+			]
+		},
+		{
+			"#": "2",
+			"$import": "~/templates/master_template.json#state_after_power_failure_off_on_prev"
+		},
+		{
+			"#": "3",
+			"$import": "templates/zooz_template.json#association_reports_binary"
+		},
+		{
+			"#": "4",
+			"$import": "templates/zooz_template.json#enable_scene_control",
+			"defaultValue": 1
+		},
+		{
+			"#": "5",
+			"$import": "templates/zooz_template.json#external_switch_type_0-10",
+			"description": "Some of these values have special behavior. Check the official device manual for specifics.",
+			"defaultValue": 0
+		},
+		{
+			"#": "6",
+			"$import": "templates/zooz_template.json#local_programming_inverted"
+		},
+		{
+			"#": "7",
+			"$import": "templates/zooz_template.json#auto_off_timer_5x",
+			"maxValue": 2678400
+		},
+		{
+			"#": "8",
+			"$import": "templates/zooz_template.json#auto_on_timer_5x",
+			"maxValue": 2678400
+		},
+		{
+			"#": "9",
+			"$import": "~/templates/master_template.json#smart_switch_mode_0-2"
+		},
+		{
+			"#": "10",
+			"$import": "templates/zooz_template.json#relay_type_behavior"
+		},
+		{
+			"#": "11",
+			"$import": "templates/zooz_template.json#input_trigger"
+		},
+		{
+			"#": "12",
+			"$import": "templates/zooz_template.json#zen5x_external_switch_multiple_click"
+		},
+		{
+			"#": "13",
+			"$import": "~/templates/master_template.json#base_enable_disable",
+			"label": "Reversed Reports for Input",
+			"description": "Reverse the reported values for your selected input type (value 1). Expert users only. See manual for details."
+		}
+	],
+	"metadata": {
+		"inclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will blink green while processing. It will turn solid green for 2 seconds if inclusion is successful or turn solid red for 2 seconds if the pairing attempt fails.",
+		"exclusion": "Click the Z-Wave button 3 times quickly. The LED indicator will blink green while processing. It will turn solid green for 2 seconds when exclusion is successful or turn solid red for 2 seconds if exclusion fails.",
+		"reset": "Click the Z-Wave button once and immediately after, press and hold the button for 15 seconds. The LED indicator will flash during the process and turn red for 3 seconds to confirm successful reset.",
+		"manual": "https://cdn.shopify.com/s/files/1/0218/7704/files/zooz-z-wave-long-range-240v-xs-relay-zen57-manual.pdf"
+	}
+}


### PR DESCRIPTION
Introduces device configuration for the Zooz Zen57 240V XS Relay, including parameter definitions, association groups, and imports for common template settings. This enables support and customization for the Zen57.

https://www.support.getzooz.com/kb/article/2057-zen57-240v-xs-relay-advanced-settings/

fixes #8504 
