### PR TITLE
fix: migrate broken v2 device config hash to a fixed format on load

### DIFF
--- a/packages/zwave-js/src/lib/test/node/Node.brokenV2DeviceConfigHash.test.ts
+++ b/packages/zwave-js/src/lib/test/node/Node.brokenV2DeviceConfigHash.test.ts
@@ -1,0 +1,76 @@
+import { CommandClasses } from "@zwave-js/core";
+import { Bytes } from "@zwave-js/shared";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"The broken V2 device config hash does not cause the device config to be unnecessarily changed",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			manufacturerId: 0xffff,
+			productType: 0xffff,
+			productId: 0xffff,
+
+			commandClasses: [
+				CommandClasses.Version,
+				CommandClasses["Manufacturer Specific"],
+			],
+		},
+
+		provisioningDirectory: path.join(
+			__dirname,
+			"fixtures/brokenV2DeviceConfigHash",
+		),
+
+		additionalDriverOptions: {
+			storage: {
+				deviceConfigPriorityDir: path.join(
+					__dirname,
+					"fixtures/brokenV2DeviceConfigHash",
+				),
+			},
+		},
+
+		async testBody(t, _driver, node) {
+			// The device config was hashed incorrectly in some versions, yielding the following hashable,
+			// which corresponds to the hash stored in the fixture's jsonl file:
+			// const hashableV2_broken = {
+			// 	endpoints: {
+			// 		"0": {
+			// 			paramInformation: [
+			// 				{
+			// 					parameterNumber: 1,
+			// 					valueSize: 1,
+			// 					minValue: 0,
+			// 					maxValue: 1,
+			// 					unsigned: false,
+			// 					defaultValue: 0,
+			// 					allowManualEntry: false,
+			// 					hidden: false, // This should not be here
+			// 					options: [{ value: 0 }, { value: 1 }],
+			// 				},
+			// 			],
+			// 		},
+			// 	},
+			// };
+
+			// This is the expected hash without the hidden property, encoded as hex for simplicity
+			const hashV2_fixed = Bytes.from(
+				"24763224ab465652ad640022302d8e860a22078da10e72100079089f1b0039f01001ca203c050e051db4a0042ac70c17a84a7818029d008d08835a1d38dbb03616086b6b01",
+				"hex",
+			);
+
+			// Hashing the brokenConfig as version 2 should yield the fixed hash:
+			const hashV2_actual = await node.deviceConfig!.getHash(2);
+			t.expect(Bytes.view(hashV2_actual)).toEqual(hashV2_fixed);
+
+			// Despite the mismatch between stored hash and actual hash, this node's device config should be considered unchanged
+			t.expect(
+				node.hasDeviceConfigChanged(),
+				"device config should not be considered changed",
+			).toBeFalsy();
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/node/fixtures/brokenV2DeviceConfigHash/7e570001.jsonl
+++ b/packages/zwave-js/src/lib/test/node/fixtures/brokenV2DeviceConfigHash/7e570001.jsonl
@@ -1,0 +1,26 @@
+{"k":"cacheFormat","v":2}
+{"k":"node.1.isListening","v":true}
+{"k":"node.1.isFrequentListening","v":false}
+{"k":"node.1.isRouting","v":true}
+{"k":"node.1.supportedDataRates","v":[40000,9600,100000]}
+{"k":"node.1.protocolVersion","v":3}
+{"k":"node.1.nodeType","v":"Controller"}
+{"k":"node.1.supportsSecurity","v":false}
+{"k":"node.1.supportsBeaming","v":true}
+{"k":"node.1.deviceClass","v":{"basic":2,"generic":2,"specific":7}}
+{"k":"node.1.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x20","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.endpoint.0.commandClass.0x60","v":{"isSupported":false,"isControlled":true,"secure":false,"version":0}}
+{"k":"node.1.interviewStage","v":"Complete"}
+
+{"k":"node.2.hasSUCReturnRoute","v":true}
+{"k":"node.2.isListening","v":false}
+{"k":"node.2.isFrequentListening","v":false}
+{"k":"node.2.endpoint.0.commandClass.0x72","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+{"k":"node.2.endpoint.0.commandClass.0x86","v":{"isSupported":true,"isControlled":false,"secure":false,"version":1}}
+
+{"k":"node.2.interviewStage","v":"Complete"}
+
+// This hash incorrectly includes the optional "hidden" property:
+{"k":"node.2.deviceConfigHash","v":"$v2$q0ZWUq1kACIwLY6GCiIHjaEOchAAeQifGwA58BAByiA8BQ4FHbSgBCrHDBeoyozMlJRUoAugXHiQAl0EjReDWh0427A2FghrawE="}

--- a/packages/zwave-js/src/lib/test/node/fixtures/brokenV2DeviceConfigHash/7e570001.values.jsonl
+++ b/packages/zwave-js/src/lib/test/node/fixtures/brokenV2DeviceConfigHash/7e570001.values.jsonl
@@ -1,0 +1,3 @@
+{"k":"{\"nodeId\":2,\"commandClass\":114,\"endpoint\":0,\"property\":\"productId\"}","v":65535,"ts":1769422406676}
+{"k":"{\"nodeId\":2,\"commandClass\":114,\"endpoint\":0,\"property\":\"productType\"}","v":65535,"ts":1769422406677}
+{"k":"{\"nodeId\":2,\"commandClass\":114,\"endpoint\":0,\"property\":\"manufacturerId\"}","v":65535,"ts":1769422406677}

--- a/packages/zwave-js/src/lib/test/node/fixtures/brokenV2DeviceConfigHash/config.json
+++ b/packages/zwave-js/src/lib/test/node/fixtures/brokenV2DeviceConfigHash/config.json
@@ -1,0 +1,30 @@
+{
+	"manufacturer": "Z-Wave JS",
+	"manufacturerId": "0xffff",
+	"label": "700 Series",
+	"description": "USB Controller",
+	"devices": [
+		{
+			"productType": "0xffff",
+			"productId": "0xffff"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"paramInformation": [
+		{
+			"#": 1,
+			"label": "This is ignored",
+			"valueSize": 1,
+			"unsigned": false,
+			"defaultValue": 0,
+			"allowManualEntry": false,
+			"options": [
+				{ "label": "Option 1", "value": 0 },
+				{ "label": "Option 2", "value": 1 }
+			]
+		}
+	]
+}


### PR DESCRIPTION
Some versions of Z-Wave JS incorrectly included `"hidden":false` in the device config hashes, causing false positives for a changed device configuration. After re-interviewing this was persisted in the cache, so https://github.com/zwave-js/zwave-js/pull/8554 caused another false positive for those users who had already re-interviewed, because it removed the property again.

With this PR, we now detect v2 hashes and remove the property from the cached hash on load, which should avoid the false positives once and for all.