### PR TITLE
fix(config): update Zooz ZSE42 config to firmware 2.30

### DIFF
--- a/packages/config/config/devices/0x027a/zse42.json
+++ b/packages/config/config/devices/0x027a/zse42.json
@@ -47,6 +47,7 @@
 		},
 		{
 			"#": "5",
+			"$if": "firmwareVersion < 2.20",
 			"label": "Group 2: Basic Set Commands",
 			"valueSize": 1,
 			"defaultValue": 1,
@@ -57,12 +58,42 @@
 					"value": 0
 				},
 				{
-					"label": "0xff (On) when water detected; 0x00 (Off) when cleared",
+					"label": "0x00 (Off) when water detected; 0xff (On) when cleared",
 					"value": 1
 				},
 				{
-					"label": "0x00 (Off) when water detected; 0xff (On) when cleared",
+					"label": "0xff (On) when water detected; 0x00 (Off) when cleared",
 					"value": 2
+				}
+			]
+		},
+		{
+			"#": "5",
+			"$if": "firmwareVersion >= 2.20",
+			"label": "Group 2: Basic Set Commands",
+			"valueSize": 1,
+			"defaultValue": 1,
+			"allowManualEntry": false,
+			"options": [
+				{
+					"label": "Disable",
+					"value": 0
+				},
+				{
+					"label": "0x00 (Off) when water detected; 0xff (On) when cleared",
+					"value": 1
+				},
+				{
+					"label": "0xff (On) when water detected; 0x00 (Off) when cleared",
+					"value": 2
+				},
+				{
+					"label": "0xff (On) when water cleared; No report when detected",
+					"value": 3
+				},
+				{
+					"label": "0x00 (Off) when water detected; No report when cleared",
+					"value": 4
 				}
 			]
 		}


### PR DESCRIPTION

<!--
  Did you know? 🥳

  We now have preconfigured online instances of VSCode that help you through the contributing process
  without having to download and install a bunch of stuff on your system.
  These have auto-formatting and let you run checks, so prefer using them over editing config files on Github.

  https://gitpod.io/#/https://github.com/zwave-js/zwave-js
-->

### Summary

- Adds support for additional Parameter 5 settings for firmware >=2.20
- Updated parameter 5 (Group 2: Basic Set Commands) with firmware version conditions:
- Corrected Parameter 5 descriptions per Zooz records

[Firmware Changelog](https://www.support.getzooz.com/kb/article/998-zse42-water-leak-xs-sensor-change-log/)
[Zooz "Advanced Settings" Definitions](https://www.support.getzooz.com/kb/article/749-zse42-water-leak-xs-sensor-advanced-settings/)

**Firmware < 2.20: Original 3 options (0-2)**

0: Disable
1: 0x00 (Off) when water detected; 0xff (On) when cleared
2: 0xff (On) when water detected; 0x00 (Off) when cleared

**Firmware >= 2.20: Extended to 5 options (0-4)**

0: Disable
1: 0x00 (Off) when water detected; 0xff (On) when cleared
2: 0xff (On) when water detected; 0x00 (Off) when cleared
3: 0xff (On) when water cleared; No report when detected
4: 0x00 (Off) when water detected; No report when cleared