### PR TITLE
feat: support gaps in value range of arbitrary CC values

### DIFF
--- a/docs/api/valueid.md
+++ b/docs/api/valueid.md
@@ -88,6 +88,7 @@ interface ValueMetadataNumeric extends ValueMetadataAny {
 	min?: number;
 	max?: number;
 	steps?: number;
+	allowed?: readonly AllowedValue[];
 	default?: number;
 	states?: Record<number, string>;
 	allowManualEntry?: boolean;
@@ -95,9 +96,18 @@ interface ValueMetadataNumeric extends ValueMetadataAny {
 }
 ```
 
+<!-- #import AllowedValue from "zwave-js" with no-jsdoc -->
+
+```ts
+type AllowedValue =
+	| { value: number }
+	| { from: number; to: number; step?: number };
+```
+
 - `min`: The minimum value that can be assigned to this value
 - `max`: The maximum value that can be assigned to this value
 - `steps`: When only certain values between min and max are allowed, this determines the step size
+- `allowed`: Defines the allowed values as a combination of single values and/or ranges. When present, this takes precedence over `min`/`max`/`steps` for determining which values are valid. Each entry is either `{ value: number }` for a single value or `{ from: number, to: number, step?: number }` for a range. The `min`/`max`/`steps` fields are still set for backwards compatibility.
 - `default`: The default value
 - `states`: Human-readable names for numeric values, for example `{0: "off", 1: "on"}`.
 - `unit`: An optional unit for numeric values

--- a/packages/cc/src/cc/ConfigurationCC.ts
+++ b/packages/cc/src/cc/ConfigurationCC.ts
@@ -1522,7 +1522,7 @@ alters capabilities: ${!!properties.altersCapabilities}`;
 				ctx,
 				ConfigurationCCValues.paramInformation(parameter, valueBitMask),
 			) ?? {
-				...ValueMetadata.Any,
+				...ValueMetadata.Number,
 			}
 		);
 	}

--- a/packages/cc/src/cc/SoundSwitchCC.ts
+++ b/packages/cc/src/cc/SoundSwitchCC.ts
@@ -461,8 +461,13 @@ duration: ${info.duration} seconds`;
 		// Remember tone count and info on the tone ID metadata
 		this.setMetadata(ctx, SoundSwitchCCValues.toneId, {
 			...SoundSwitchCCValues.toneId.meta,
+			allowed: [
+				{ value: 0 },
+				{ from: 1, to: toneCount },
+				{ value: 0xff },
+			],
 			min: 0,
-			max: toneCount,
+			max: 0xff,
 			states: {
 				0: "off",
 				...metadataStates,

--- a/packages/cc/src/cc/WakeUpCC.ts
+++ b/packages/cc/src/cc/WakeUpCC.ts
@@ -526,10 +526,18 @@ export class WakeUpCCIntervalCapabilitiesReport extends WakeUpCC {
 			},
 			{
 				...ValueMetadata.WriteOnlyUInt24,
-				min: this.minWakeUpInterval,
+				allowed: [
+					{ value: 0 },
+					{
+						from: this.minWakeUpInterval,
+						to: this.maxWakeUpInterval,
+						step: this.wakeUpIntervalSteps,
+					},
+				],
+				min: 0,
 				max: this.maxWakeUpInterval,
-				steps: this.wakeUpIntervalSteps,
 				default: this.defaultWakeUpInterval,
+				states: { 0: "Disabled" },
 			},
 		);
 

--- a/packages/config/src/devices/ParamInformation.ts
+++ b/packages/config/src/devices/ParamInformation.ts
@@ -1,5 +1,5 @@
 /* oxlint-disable typescript/no-unnecessary-type-assertion */
-import { type AllowedConfigValue, tryParseParamNumber } from "@zwave-js/core";
+import { type AllowedValue, tryParseParamNumber } from "@zwave-js/core";
 import {
 	type JSONObject,
 	ObjectKeyMap,
@@ -260,7 +260,7 @@ Parameter #${parameterNumber}: "allowed" array must contain at least one entry!`
 			}
 
 			// Parse each value definition
-			const parsedValues: AllowedConfigValue[] = [];
+			const parsedValues: AllowedValue[] = [];
 			for (let i = 0; i < definition.allowed.length; i++) {
 				const def = definition.allowed[i];
 
@@ -355,7 +355,7 @@ Parameter #${parameterNumber}: allowed[${i}] must have either "value" or "range"
 	public readonly label: string;
 	public readonly description?: string;
 	public readonly valueSize: number;
-	public readonly allowed?: readonly AllowedConfigValue[];
+	public readonly allowed?: readonly AllowedValue[];
 	public readonly minValue?: number;
 	public readonly maxValue?: number;
 	public readonly unsigned?: boolean;

--- a/packages/core/src/values/Metadata.ts
+++ b/packages/core/src/values/Metadata.ts
@@ -86,6 +86,13 @@ const define = <TBase extends ValueMetadataAny>() =>
 
 const defineAny = define<ValueMetadataAny>();
 
+export type AllowedValue =
+	| { value: number }
+	| { from: number; to: number; step?: number };
+
+/** @deprecated Use {@link AllowedValue} instead. */
+export type AllowedConfigValue = AllowedValue;
+
 export interface ValueMetadataNumeric extends ValueMetadataAny {
 	type: "number";
 	/** The minimum value that can be assigned to a CC value (optional) */
@@ -94,6 +101,8 @@ export interface ValueMetadataNumeric extends ValueMetadataAny {
 	max?: number;
 	/** When only certain values between min and max are allowed, this determines the step size */
 	steps?: number;
+	/** Defines the allowed values as a combination of single values and ranges. When present, min/max/steps are inferred from this for backwards compatibility. */
+	allowed?: readonly AllowedValue[];
 	/** The default value */
 	default?: number;
 	/** Speaking names for numeric values */
@@ -173,34 +182,15 @@ export enum ConfigValueFormat {
 /** @publicAPI */
 export type ConfigValue = number;
 
-export type ConfigValueSingle = {
-	value: number;
-};
-
-export type ConfigValueRange = {
-	from: number;
-	to: number;
-	step?: number;
-};
-
-export type AllowedConfigValue = ConfigValueSingle | ConfigValueRange;
-
-export interface ConfigurationMetadata extends ValueMetadataAny {
-	// readable and writeable are inherited from ValueMetadataAny
-	allowed?: readonly AllowedConfigValue[];
+export interface ConfigurationMetadata extends ValueMetadataNumeric {
 	min?: ConfigValue;
 	max?: ConfigValue;
 	default?: ConfigValue;
 	recommended?: ConfigValue;
-	unit?: string;
 	valueSize?: number;
 	format?: ConfigValueFormat;
-	label?: string;
-	description?: string;
 	isAdvanced?: boolean;
 	requiresReInclusion?: boolean;
-	states?: Record<number, string>;
-	allowManualEntry?: boolean;
 	isFromConfig?: boolean;
 	destructive?: boolean;
 }
@@ -213,8 +203,6 @@ export type ValueMetadata =
 	| ValueMetadataDuration
 	| ValueMetadataBuffer
 	| ConfigurationMetadata;
-
-// TODO: lists of allowed values, etc...
 
 // Mixins for value metadata
 const _default = defineAny(
@@ -764,3 +752,56 @@ export const ValueMetadata = {
 	/** A buffer (writeonly) */
 	WriteOnlyBuffer: Object.freeze(WriteOnlyBuffer),
 };
+
+/**
+ * Checks if a value is allowed by the given entries.
+ */
+export function isValueAllowed(
+	value: number,
+	entries: readonly AllowedValue[],
+): boolean {
+	for (const entry of entries) {
+		if ("value" in entry) {
+			if (entry.value === value) return true;
+		} else {
+			if (value >= entry.from && value <= entry.to) {
+				const step = entry.step ?? 1;
+				if ((value - entry.from) % step === 0) return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * Computes the min, max, and (if possible) steps values from parsed allowed entries.
+ */
+export function inferMinMaxStepsFromAllowed(
+	entries: readonly AllowedValue[],
+): { min: number; max: number; steps?: number } | undefined {
+	let min = Infinity;
+	let max = -Infinity;
+
+	const rangeEntries: Array<{ from: number; to: number; step?: number }> = [];
+	for (const entry of entries) {
+		if ("value" in entry) {
+			min = Math.min(min, entry.value);
+			max = Math.max(max, entry.value);
+		} else {
+			min = Math.min(min, entry.from);
+			max = Math.max(max, entry.to);
+			rangeEntries.push(entry);
+		}
+	}
+
+	if (min === Infinity || max === -Infinity) {
+		return undefined;
+	}
+
+	// If there is exactly one range entry with a step, use it as the top-level steps value
+	const steps = rangeEntries.length === 1
+		? rangeEntries[0].step
+		: undefined;
+
+	return { min, max, steps };
+}

--- a/packages/eslint-plugin/src/rules/auto-unsigned.ts
+++ b/packages/eslint-plugin/src/rules/auto-unsigned.ts
@@ -5,7 +5,7 @@ import {
 	getJSONBoolean,
 	getJSONNumber,
 	getJSONString,
-	inferMinMaxValueFromAllowed,
+	inferMinMaxStepsFromAllowed,
 	insertAfterJSONProperty,
 	insertBeforeJSONProperty,
 	paramInfoPropertyOrder,
@@ -111,7 +111,7 @@ export const autoUnsigned: JSONCRule.RuleModule = {
 
 				const parsedAllowed = parseAllowedField(node);
 				if (parsedAllowed) {
-					const minMax = inferMinMaxValueFromAllowed(parsedAllowed);
+					const minMax = inferMinMaxStepsFromAllowed(parsedAllowed);
 					if (minMax) {
 						// allowedProp must exist if parseAllowedField returned data
 						minValueNode = allowedProp!;

--- a/packages/eslint-plugin/src/rules/no-disallowed-values.ts
+++ b/packages/eslint-plugin/src/rules/no-disallowed-values.ts
@@ -1,9 +1,9 @@
-import type { AllowedConfigValue } from "@zwave-js/core";
+import type { AllowedValue } from "@zwave-js/core";
 import type { AST } from "jsonc-eslint-parser";
 import { type JSONCRule, isValueAllowed, parseAllowedField } from "../utils.js";
 
 function getAllowedEntriesAndRange(node: AST.JSONObjectExpression): {
-	allowedEntries: AllowedConfigValue[];
+	allowedEntries: AllowedValue[];
 	hasExplicitAllowed: boolean;
 	minValue: number | undefined;
 	maxValue: number | undefined;

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -3,7 +3,12 @@ import {
 	type TSESLint,
 	type TSESTree,
 } from "@typescript-eslint/utils";
-import { type AllowedConfigValue, CommandClasses } from "@zwave-js/core";
+import {
+	type AllowedValue,
+	CommandClasses,
+	inferMinMaxStepsFromAllowed,
+	isValueAllowed,
+} from "@zwave-js/core";
 import type { Rule as ESLintRule } from "eslint";
 import type { AST as JSONC_AST, RuleListener } from "jsonc-eslint-parser";
 import path from "node:path";
@@ -513,7 +518,7 @@ export const paramInfoPropertyOrder: string[] = [
  */
 export function parseAllowedField(
 	node: JSONC_AST.JSONObjectExpression,
-): AllowedConfigValue[] | undefined {
+): AllowedValue[] | undefined {
 	const allowedProp = node.properties.find(
 		(p) =>
 			p.key.type === "JSONLiteral"
@@ -525,7 +530,7 @@ export function parseAllowedField(
 		return undefined;
 	}
 
-	const entries: AllowedConfigValue[] = [];
+	const entries: AllowedValue[] = [];
 
 	for (const element of allowedProp.value.elements) {
 		if (!element || element.type !== "JSONObjectExpression") continue;
@@ -583,48 +588,5 @@ export function parseAllowedField(
 	return entries;
 }
 
-/**
- * Checks if a value is allowed by the given entries.
- */
-export function isValueAllowed(
-	value: number,
-	entries: AllowedConfigValue[],
-): boolean {
-	for (const entry of entries) {
-		if ("value" in entry) {
-			if (entry.value === value) return true;
-		} else {
-			if (value >= entry.from && value <= entry.to) {
-				const step = entry.step ?? 1;
-				if ((value - entry.from) % step === 0) return true;
-			}
-		}
-	}
-	return false;
-}
-
-/**
- * Computes the min and max values from parsed allowed entries.
- */
-export function inferMinMaxValueFromAllowed(
-	entries: AllowedConfigValue[],
-): { min: number; max: number } | undefined {
-	let min = Infinity;
-	let max = -Infinity;
-
-	for (const entry of entries) {
-		if ("value" in entry) {
-			min = Math.min(min, entry.value);
-			max = Math.max(max, entry.value);
-		} else {
-			min = Math.min(min, entry.from);
-			max = Math.max(max, entry.to);
-		}
-	}
-
-	if (min === Infinity || max === -Infinity) {
-		return undefined;
-	}
-
-	return { min, max };
-}
+// isValueAllowed and inferMinMaxStepsFromAllowed are re-exported from @zwave-js/core
+export { inferMinMaxStepsFromAllowed, isValueAllowed };

--- a/packages/zwave-js/src/Values.ts
+++ b/packages/zwave-js/src/Values.ts
@@ -12,6 +12,7 @@ export type {
 	ValueMetadataNumeric,
 	ValueMetadataString,
 	ValueType,
+	AllowedValue,
 } from "@zwave-js/core";
 export type {
 	ZWaveNodeMetadataUpdatedArgs,

--- a/packages/zwave-js/src/Values.ts
+++ b/packages/zwave-js/src/Values.ts
@@ -4,6 +4,7 @@ export type { SetbackState, Switchpoint } from "@zwave-js/cc";
 export type { Scale, Sensor } from "@zwave-js/core";
 export { Duration, ValueMetadata } from "@zwave-js/core";
 export type {
+	AllowedValue,
 	DurationUnit,
 	TranslatedValueID,
 	ValueID,
@@ -12,7 +13,6 @@ export type {
 	ValueMetadataNumeric,
 	ValueMetadataString,
 	ValueType,
-	AllowedValue,
 } from "@zwave-js/core";
 export type {
 	ZWaveNodeMetadataUpdatedArgs,


### PR DESCRIPTION
Certain CC values, especially the wakeup interval, have gaps in their value ranges (0 = off, plus a stepped range). Until now this was not modeled properly. This PR adds support for a new `allowed` property for `ValueMetadata`, which is modeled after the solution for config parameters introduced in #8547.

For backwards compatibility, the `min` and `max` are still provided and define the envelope of all allowed values. This value range may have gaps of disallowed values though.

Applications should prefer the new `allowed` property where it exists if they need to do client-side validation.