### PR TITLE
fix(cc): disable optimistic updates for User Code CC

### DIFF
--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -15,7 +15,6 @@ import {
 	encodeBitMask,
 	enumValuesToMetadataStates,
 	parseBitMask,
-	supervisedCommandSucceeded,
 	validatePayload,
 } from "@zwave-js/core";
 import {
@@ -36,7 +35,9 @@ import {
 	PhysicalCCAPI,
 	type PollValueImplementation,
 	SET_VALUE,
+	SET_VALUE_HOOKS,
 	type SetValueImplementation,
+	type SetValueImplementationHooksFactory,
 	throwMissingPropertyKey,
 	throwUnsupportedProperty,
 	throwUnsupportedPropertyKey,
@@ -398,16 +399,102 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				throwUnsupportedProperty(this.ccId, property);
 			}
 
-			// Verify the change after a short delay, unless the command was supervised and successful
-			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-				this.schedulePoll({ property, propertyKey }, value, {
-					transition: "fast",
-				});
-			}
-
 			return result;
 		};
 	}
+
+	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
+		{ property, propertyKey },
+		value,
+	) => {
+		if (
+			property === "keypadMode"
+			|| property === "adminCode"
+			|| property === "masterCode"
+		) {
+			return {
+				verifyChanges: () => {
+					if (this.isSinglecast()) {
+						this.schedulePoll({ property }, value, {
+							transition: "fast",
+						});
+					}
+				},
+			};
+		} else if (property === "userIdStatus") {
+			if (typeof propertyKey !== "number") return;
+
+			const userIdStatusValueId = UserCodeCCValues.userIdStatus(
+				propertyKey,
+			).endpoint(this.endpoint.index);
+			const userCodeValueId = UserCodeCCValues.userCode(propertyKey)
+				.endpoint(this.endpoint.index);
+
+			return {
+				optimisticallyUpdateRelatedValues: (
+					_supervisedAndSuccessful,
+				) => {
+					if (!this.isSinglecast()) return;
+					const valueDB = this.tryGetValueDB();
+					if (!valueDB) return;
+
+					valueDB.setValue(userIdStatusValueId, value);
+					if (value === UserIDStatus.Available) {
+						valueDB.setValue(userCodeValueId, "");
+					}
+				},
+
+				verifyChanges: () => {
+					if (this.isSinglecast()) {
+						this.schedulePoll(userIdStatusValueId, value, {
+							transition: "fast",
+						});
+					}
+				},
+			};
+		} else if (property === "userCode") {
+			if (typeof propertyKey !== "number") return;
+
+			const userIdStatusValueId = UserCodeCCValues.userIdStatus(
+				propertyKey,
+			).endpoint(this.endpoint.index);
+			const userCodeValueId = UserCodeCCValues.userCode(propertyKey)
+				.endpoint(this.endpoint.index);
+
+			return {
+				optimisticallyUpdateRelatedValues: (
+					_supervisedAndSuccessful,
+				) => {
+					if (!this.isSinglecast()) return;
+					const valueDB = this.tryGetValueDB();
+					if (!valueDB) return;
+
+					valueDB.setValue(userCodeValueId, value);
+
+					const currentStatus = valueDB.getValue<UserIDStatus>(
+						userIdStatusValueId,
+					);
+					if (
+						currentStatus === UserIDStatus.Available
+						|| currentStatus == undefined
+					) {
+						valueDB.setValue(
+							userIdStatusValueId,
+							UserIDStatus.Enabled,
+						);
+					}
+				},
+
+				verifyChanges: () => {
+					if (this.isSinglecast()) {
+						this.schedulePoll(userCodeValueId, value, {
+							transition: "fast",
+						});
+					}
+				},
+			};
+		}
+	};
 
 	protected get [POLL_VALUE](): PollValueImplementation {
 		return async function(this: UserCodeCCAPI, { property, propertyKey }) {

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -412,12 +412,17 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			|| property === "adminCode"
 			|| property === "masterCode"
 		) {
+			const pollProperty = property === "masterCode"
+				? "adminCode"
+				: property;
 			return {
 				verifyChanges: () => {
 					if (this.isSinglecast()) {
-						this.schedulePoll({ property }, value, {
-							transition: "fast",
-						});
+						this.schedulePoll(
+							{ property: pollProperty },
+							value,
+							{ transition: "fast" },
+						);
 					}
 				},
 			};
@@ -452,6 +457,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			};
 		} else if (property === "userCode") {
 			if (typeof propertyKey !== "number") return;
+			if (propertyKey === 0) return;
 
 			const userIdStatusValueId = UserCodeCCValues.userIdStatus(
 				propertyKey,

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -423,6 +423,8 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 			};
 		} else if (property === "userIdStatus") {
 			if (typeof propertyKey !== "number") return;
+			// userId 0 clears all codes, skip optimistic updates
+			if (propertyKey === 0) return;
 
 			const userIdStatusValueId = UserCodeCCValues.userIdStatus(
 				propertyKey,
@@ -435,12 +437,8 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 					_supervisedAndSuccessful,
 				) => {
 					if (!this.isSinglecast()) return;
-					const valueDB = this.tryGetValueDB();
-					if (!valueDB) return;
-
-					valueDB.setValue(userIdStatusValueId, value);
 					if (value === UserIDStatus.Available) {
-						valueDB.setValue(userCodeValueId, "");
+						this.tryGetValueDB()?.setValue(userCodeValueId, "");
 					}
 				},
 
@@ -468,8 +466,6 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 					if (!this.isSinglecast()) return;
 					const valueDB = this.tryGetValueDB();
 					if (!valueDB) return;
-
-					valueDB.setValue(userCodeValueId, value);
 
 					const currentStatus = valueDB.getValue<UserIDStatus>(
 						userIdStatusValueId,

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -406,6 +406,7 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
 		{ property, propertyKey },
 		value,
+		_options,
 	) => {
 		if (
 			property === "keypadMode"

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -8,6 +8,7 @@ import {
 	MessagePriority,
 	type MessageRecord,
 	type SupervisionResult,
+	type ValueID,
 	ValueMetadata,
 	type WithAddress,
 	ZWaveError,
@@ -15,6 +16,7 @@ import {
 	encodeBitMask,
 	enumValuesToMetadataStates,
 	parseBitMask,
+	supervisedCommandSucceeded,
 	validatePayload,
 } from "@zwave-js/core";
 import {
@@ -35,9 +37,7 @@ import {
 	PhysicalCCAPI,
 	type PollValueImplementation,
 	SET_VALUE,
-	SET_VALUE_HOOKS,
 	type SetValueImplementation,
-	type SetValueImplementationHooksFactory,
 	throwMissingPropertyKey,
 	throwUnsupportedProperty,
 	throwUnsupportedPropertyKey,
@@ -399,105 +399,20 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				throwUnsupportedProperty(this.ccId, property);
 			}
 
+			// Verify the change after a short delay, unless the command was supervised and successful
+			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
+				this.schedulePoll({ property, propertyKey }, value, {
+					transition: "fast",
+				});
+			}
+
 			return result;
 		};
 	}
 
-	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
-		{ property, propertyKey },
-		value,
-		_options,
-	) => {
-		if (
-			property === "keypadMode"
-			|| property === "adminCode"
-			|| property === "masterCode"
-		) {
-			const pollProperty = property === "masterCode"
-				? "adminCode"
-				: property;
-			return {
-				verifyChanges: () => {
-					if (this.isSinglecast()) {
-						this.schedulePoll(
-							{ property: pollProperty },
-							value,
-							{ transition: "fast" },
-						);
-					}
-				},
-			};
-		} else if (property === "userIdStatus") {
-			if (typeof propertyKey !== "number") return;
-			// userId 0 clears all codes, skip optimistic updates
-			if (propertyKey === 0) return;
-
-			const userIdStatusValueId = UserCodeCCValues.userIdStatus(
-				propertyKey,
-			).endpoint(this.endpoint.index);
-			const userCodeValueId = UserCodeCCValues.userCode(propertyKey)
-				.endpoint(this.endpoint.index);
-
-			return {
-				optimisticallyUpdateRelatedValues: (
-					_supervisedAndSuccessful,
-				) => {
-					if (!this.isSinglecast()) return;
-					if (value === UserIDStatus.Available) {
-						this.tryGetValueDB()?.setValue(userCodeValueId, "");
-					}
-				},
-
-				verifyChanges: () => {
-					if (this.isSinglecast()) {
-						this.schedulePoll(userIdStatusValueId, value, {
-							transition: "fast",
-						});
-					}
-				},
-			};
-		} else if (property === "userCode") {
-			if (typeof propertyKey !== "number") return;
-			if (propertyKey === 0) return;
-
-			const userIdStatusValueId = UserCodeCCValues.userIdStatus(
-				propertyKey,
-			).endpoint(this.endpoint.index);
-			const userCodeValueId = UserCodeCCValues.userCode(propertyKey)
-				.endpoint(this.endpoint.index);
-
-			return {
-				optimisticallyUpdateRelatedValues: (
-					_supervisedAndSuccessful,
-				) => {
-					if (!this.isSinglecast()) return;
-					const valueDB = this.tryGetValueDB();
-					if (!valueDB) return;
-
-					const currentStatus = valueDB.getValue<UserIDStatus>(
-						userIdStatusValueId,
-					);
-					if (
-						currentStatus === UserIDStatus.Available
-						|| currentStatus == undefined
-					) {
-						valueDB.setValue(
-							userIdStatusValueId,
-							UserIDStatus.Enabled,
-						);
-					}
-				},
-
-				verifyChanges: () => {
-					if (this.isSinglecast()) {
-						this.schedulePoll(userCodeValueId, value, {
-							transition: "fast",
-						});
-					}
-				},
-			};
-		}
-	};
+	public isSetValueOptimistic(_valueId: ValueID): boolean {
+		return false; // Always verify changes, do not assume changes were applied
+	}
 
 	protected get [POLL_VALUE](): PollValueImplementation {
 		return async function(this: UserCodeCCAPI, { property, propertyKey }) {

--- a/packages/cc/src/cc/UserCodeCC.ts
+++ b/packages/cc/src/cc/UserCodeCC.ts
@@ -37,7 +37,9 @@ import {
 	PhysicalCCAPI,
 	type PollValueImplementation,
 	SET_VALUE,
+	SET_VALUE_HOOKS,
 	type SetValueImplementation,
+	type SetValueImplementationHooksFactory,
 	throwMissingPropertyKey,
 	throwUnsupportedProperty,
 	throwUnsupportedPropertyKey,
@@ -129,6 +131,15 @@ export const UserCodeCCValues = V.defineCCValues(CommandClasses["User Code"], {
 			minVersion: 2,
 			secret: true,
 		} as const,
+	),
+	...V.staticPropertyWithName(
+		"_deprecated_masterCode",
+		"masterCode",
+		undefined,
+		{
+			internal: true,
+			autoCreate: false,
+		},
 	),
 	...V.dynamicPropertyAndKeyWithName(
 		"userIdStatus",
@@ -399,16 +410,59 @@ export class UserCodeCCAPI extends PhysicalCCAPI {
 				throwUnsupportedProperty(this.ccId, property);
 			}
 
-			// Verify the change after a short delay, unless the command was supervised and successful
-			if (this.isSinglecast() && !supervisedCommandSucceeded(result)) {
-				this.schedulePoll({ property, propertyKey }, value, {
-					transition: "fast",
-				});
-			}
-
 			return result;
 		};
 	}
+
+	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
+		{ property, propertyKey },
+		value,
+	) => {
+		const valueId = {
+			commandClass: this.ccId,
+			endpoint: this.endpoint.index,
+			property,
+			propertyKey,
+		};
+
+		if (
+			UserCodeCCValues.keypadMode.is(valueId)
+			|| UserCodeCCValues.adminCode.is(valueId)
+			// Support devices that were interviewed before the rename to adminCode
+			|| UserCodeCCValues._deprecated_masterCode.is(valueId)
+		) {
+			// Keypad mode, admin/master code should update immediately.
+			// Optimistically update when supervised successfully, otherwise verify
+			// For the deprecated masterCode, the canonical target is adminCode
+			return {
+				forceVerifyChanges: () => true,
+				verifyChanges: (result) => {
+					if (supervisedCommandSucceeded(result)) {
+						this.tryGetValueDB()?.setValue(valueId, value);
+					} else if (this.isSinglecast()) {
+						this.schedulePoll(valueId, value, {
+							transition: "fast",
+						});
+					}
+				},
+			};
+		} else if (
+			UserCodeCCValues.userCode.is(valueId)
+			|| UserCodeCCValues.userIdStatus.is(valueId)
+		) {
+			// Simply verify the change in any case
+			return {
+				forceVerifyChanges: () => true,
+				verifyChanges: (_result) => {
+					if (this.isSinglecast()) {
+						this.schedulePoll(valueId, value, {
+							transition: "fast",
+						});
+					}
+				},
+			};
+		}
+	};
 
 	public isSetValueOptimistic(_valueId: ValueID): boolean {
 		return false; // Always verify changes, do not assume changes were applied

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -8863,6 +8863,33 @@ export const UserCodeCCValues = Object.freeze({
 			autoCreate: true,
 		} as const satisfies CCValueOptions,
 	},
+	_deprecated_masterCode: {
+		id: {
+			commandClass: CommandClasses["User Code"],
+			property: "masterCode",
+		} as const,
+		endpoint: (endpoint: number = 0) => ({
+			commandClass: CommandClasses["User Code"],
+			endpoint,
+			property: "masterCode",
+		} as const),
+		is: (valueId: ValueID): boolean => {
+			return valueId.commandClass === CommandClasses["User Code"]
+				&& valueId.property === "masterCode"
+				&& valueId.propertyKey == undefined;
+		},
+		get meta() {
+			return ValueMetadata.Any;
+		},
+		options: {
+			internal: true,
+			minVersion: 1,
+			secret: false,
+			stateful: true,
+			supportsEndpoints: true,
+			autoCreate: false,
+		} as const satisfies CCValueOptions,
+	},
 	userIdStatus: Object.assign(
 		(userId: number) => {
 			const property = "userIdStatus";

--- a/packages/cc/tsconfig.build.json
+++ b/packages/cc/tsconfig.build.json
@@ -19,8 +19,13 @@
 		},
 		{
 			"path": "../maintenance/tsconfig.build.json"
+		},
+		{
+			"path": "../transformers/tsconfig.build.json"
 		}
 	],
-	"include": ["src_gen/**/*.ts"],
+	"include": [
+		"src_gen/**/*.ts"
+	],
 	"exclude": []
 }

--- a/packages/cc/tsconfig.build.json
+++ b/packages/cc/tsconfig.build.json
@@ -19,13 +19,8 @@
 		},
 		{
 			"path": "../maintenance/tsconfig.build.json"
-		},
-		{
-			"path": "../transformers/tsconfig.build.json"
 		}
 	],
-	"include": [
-		"src_gen/**/*.ts"
-	],
+	"include": ["src_gen/**/*.ts"],
 	"exclude": []
 }


### PR DESCRIPTION
## Summary
- Adds `isSetValueOptimistic` override returning `false` to `UserCodeCCAPI`, so user code changes are always verified against the device rather than optimistically cached
- This prevents the driver from temporarily storing unconfirmed values for security-sensitive user code slots

## Test plan
- [ ] Verify that setting a user code does not optimistically update the cached value
- [ ] Verify that the value is updated only after the device confirms the change via a report

🤖 Generated with [Claude Code](https://claude.com/claude-code)