### PR TITLE
fix(thermostat): correct operating state report by masking reserved bits

### DIFF
--- a/packages/cc/src/cc/ThermostatOperatingStateCC.ts
+++ b/packages/cc/src/cc/ThermostatOperatingStateCC.ts
@@ -185,7 +185,7 @@ export class ThermostatOperatingStateCCReport
 		ctx: CCParsingContext,
 	): ThermostatOperatingStateCCReport {
 		validatePayload(raw.payload.length >= 1);
-		const state: ThermostatOperatingState = raw.payload[0];
+		const state: ThermostatOperatingState = raw.payload[0] & 0x0f;
 
 		return new this({
 			nodeId: ctx.sourceNodeId,


### PR DESCRIPTION
`ThermostatOperatingStateCCReport.from()` assigned the full first payload byte as the operating state. The Z-Wave spec defines only bits 0–3 as the Operating State field; bits 4–7 are reserved. If a device sets any reserved bits, the parsed state would be an invalid enum value.

Fixed by masking the byte with `& 0x0f`.