### PR TITLE
test: extend Window Covering mocks, support transitioning

### DIFF
--- a/packages/testing/src/CCSpecificCapabilities.ts
+++ b/packages/testing/src/CCSpecificCapabilities.ts
@@ -98,6 +98,8 @@ export interface MultilevelSensorCCCapabilities {
 export interface MultilevelSwitchCCCapabilities {
 	defaultValue?: MaybeUnknown<number>;
 	primarySwitchType: SwitchType;
+	/** Full travel time from 0 to 99 in milliseconds. Default: 0 (instant) */
+	travelTime?: number;
 }
 
 export interface SoundSwitchCCCapabilities {
@@ -111,6 +113,8 @@ export interface SoundSwitchCCCapabilities {
 
 export interface WindowCoveringCCCapabilities {
 	supportedParameters: WindowCoveringParameter[];
+	/** Full travel time from 0 to 99 in milliseconds. Default: 5000 */
+	travelTime?: number;
 }
 
 export interface EnergyProductionCCCapabilities {

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/MockTransition.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/MockTransition.ts
@@ -1,0 +1,72 @@
+import { Duration } from "@zwave-js/core";
+import { type Timer, setTimer } from "@zwave-js/shared";
+
+export interface MockTransition {
+	startValue: number;
+	targetValue: number;
+	startTime: number;
+	durationMs: number;
+	timer: Timer;
+}
+
+/** Computes the interpolated current value from a running transition. */
+export function getTransitionCurrentValue(
+	transition: MockTransition,
+): number {
+	const elapsed = Date.now() - transition.startTime;
+	const progress = Math.min(elapsed / transition.durationMs, 1);
+	return Math.round(
+		transition.startValue
+			+ (transition.targetValue - transition.startValue) * progress,
+	);
+}
+
+/** Returns the remaining duration of a running transition. */
+export function getTransitionRemainingDuration(
+	transition: MockTransition,
+): Duration {
+	const remaining = Math.max(
+		0,
+		transition.durationMs - (Date.now() - transition.startTime),
+	);
+	return new Duration(Math.ceil(remaining / 1000), "seconds");
+}
+
+/**
+ * Stops a running transition and returns the interpolated value at
+ * the time of stopping.
+ */
+export function stopTransition(transition: MockTransition): number {
+	transition.timer.clear();
+	return getTransitionCurrentValue(transition);
+}
+
+/**
+ * Starts a value transition with proportional duration based on distance.
+ * Returns the new {@link MockTransition}, or `undefined` when the
+ * transition completes instantly (travelTime is 0 or current equals target).
+ */
+export function startTransition(options: {
+	currentValue: number;
+	targetValue: number;
+	duration: number;
+	onComplete: () => void | Promise<void>;
+}): MockTransition | undefined {
+	const { currentValue, targetValue, duration, onComplete } = options;
+
+	if (currentValue === targetValue || duration === 0) {
+		return undefined;
+	}
+
+	const durationMs = Math.round(
+		duration * (Math.abs(targetValue - currentValue) / 99),
+	);
+
+	return {
+		startValue: currentValue,
+		targetValue,
+		startTime: Date.now(),
+		durationMs,
+		timer: setTimer(onComplete, durationMs).unref(),
+	};
+}

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/MultilevelSwitch.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/MultilevelSwitch.ts
@@ -10,23 +10,99 @@ import {
 } from "@zwave-js/cc/MultilevelSwitchCC";
 import {
 	CommandClasses,
+	Duration,
 	type MaybeUnknown,
 	UNKNOWN_STATE,
 } from "@zwave-js/core";
-import type {
-	MockNodeBehavior,
-	MultilevelSwitchCCCapabilities,
+import { setTimer } from "@zwave-js/shared";
+import {
+	type MockController,
+	type MockNode,
+	type MockNodeBehavior,
+	type MultilevelSwitchCCCapabilities,
+	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
+import {
+	type MockTransition,
+	getTransitionCurrentValue,
+	getTransitionRemainingDuration,
+	startTransition,
+	stopTransition,
+} from "./MockTransition.js";
 
-const defaultCapabilities: MultilevelSwitchCCCapabilities = {
+const defaultCapabilities: Required<MultilevelSwitchCCCapabilities> = {
 	defaultValue: 0,
 	primarySwitchType: SwitchType["Down/Up"],
+	travelTime: 0,
 };
 
 const STATE_KEY_PREFIX = "MultilevelSwitch_";
 const StateKeys = {
 	currentValue: `${STATE_KEY_PREFIX}currentValue`,
+	transition: `${STATE_KEY_PREFIX}transition`,
 } as const;
+
+/** Stops any running transition and snaps state. */
+function stopCurrentTransition(
+	self: Parameters<NonNullable<MockNodeBehavior["handleCC"]>>[1],
+): void {
+	const existing = self.state.get(
+		StateKeys.transition,
+	) as MockTransition | undefined;
+	if (existing) {
+		const value = stopTransition(existing);
+		self.state.set(StateKeys.currentValue, value);
+		self.state.delete(StateKeys.transition);
+	}
+}
+
+/**
+ * Stops any existing transition, then starts a new one.
+ * Manages all state reads/writes.
+ */
+function beginTransition(
+	controller: MockController,
+	self: MockNode,
+	targetValue: number,
+	travelTime: number,
+	defaultValue: MaybeUnknown<number> | undefined,
+): void {
+	stopCurrentTransition(self);
+
+	const currentValue = (
+		self.state.get(StateKeys.currentValue)
+			?? defaultValue
+			?? 0
+	) as number;
+
+	const transition = startTransition({
+		currentValue,
+		targetValue,
+		duration: travelTime,
+		onComplete: async () => {
+			self.state.set(StateKeys.currentValue, targetValue);
+			self.state.delete(StateKeys.transition);
+
+			const cc = new MultilevelSwitchCCReport({
+				nodeId: controller.ownNodeId,
+				currentValue: targetValue,
+				targetValue,
+				duration: new Duration(0, "seconds"),
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+		},
+	});
+
+	if (transition) {
+		self.state.set(StateKeys.transition, transition);
+	} else {
+		self.state.set(StateKeys.currentValue, targetValue);
+	}
+}
 
 const respondToMultilevelSwitchGet: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
@@ -38,16 +114,33 @@ const respondToMultilevelSwitchGet: MockNodeBehavior = {
 					receivedCC.endpointIndex,
 				),
 			};
-			const currentValue = (
-				self.state.get(StateKeys.currentValue)
-					?? capabilities.defaultValue
-					?? UNKNOWN_STATE
-			) as MaybeUnknown<number>;
+			const transition = self.state.get(
+				StateKeys.transition,
+			) as MockTransition | undefined;
+
+			let currentValue: MaybeUnknown<number>;
+			let targetValue: MaybeUnknown<number>;
+			let duration: Duration | undefined;
+
+			if (transition) {
+				currentValue = getTransitionCurrentValue(transition);
+				targetValue = transition.targetValue;
+				duration = getTransitionRemainingDuration(transition);
+			} else {
+				currentValue = (
+					self.state.get(StateKeys.currentValue)
+						?? capabilities.defaultValue
+						?? UNKNOWN_STATE
+				) as MaybeUnknown<number>;
+				targetValue = currentValue;
+				duration = new Duration(0, "seconds");
+			}
+
 			const cc = new MultilevelSwitchCCReport({
 				nodeId: controller.ownNodeId,
 				currentValue,
-				// We don't support transitioning yet
-				targetValue: currentValue,
+				targetValue,
+				duration,
 			});
 			return { action: "sendCC", cc };
 		}
@@ -57,7 +150,20 @@ const respondToMultilevelSwitchGet: MockNodeBehavior = {
 const respondToMultilevelSwitchSet: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
 		if (receivedCC instanceof MultilevelSwitchCCSet) {
-			self.state.set(StateKeys.currentValue, receivedCC.targetValue);
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses["Multilevel Switch"],
+					receivedCC.endpointIndex,
+				),
+			};
+			beginTransition(
+				controller,
+				self,
+				receivedCC.targetValue,
+				capabilities.travelTime,
+				capabilities.defaultValue,
+			);
 			return { action: "ok" };
 		}
 	},
@@ -85,12 +191,21 @@ const respondToMultilevelSwitchSupportedGet: MockNodeBehavior = {
 const respondToMultilevelSwitchStartLevelChange: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
 		if (receivedCC instanceof MultilevelSwitchCCStartLevelChange) {
-			// TODO: A proper simulation should gradually transition the value. We just set it to the target value.
-			self.state.set(
-				StateKeys.currentValue,
-				receivedCC.direction === "up" ? 99 : 0,
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses["Multilevel Switch"],
+					receivedCC.endpointIndex,
+				),
+			};
+			const targetValue = receivedCC.direction === "up" ? 99 : 0;
+			beginTransition(
+				controller,
+				self,
+				targetValue,
+				capabilities.travelTime,
+				capabilities.defaultValue,
 			);
-
 			return { action: "ok" };
 		}
 	},
@@ -99,6 +214,27 @@ const respondToMultilevelSwitchStartLevelChange: MockNodeBehavior = {
 const respondToMultilevelSwitchStopLevelChange: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
 		if (receivedCC instanceof MultilevelSwitchCCStopLevelChange) {
+			stopCurrentTransition(self);
+
+			const currentValue = (
+				self.state.get(StateKeys.currentValue) ?? 0
+			) as number;
+
+			// Send a delayed report with the final state
+			setTimer(async () => {
+				const cc = new MultilevelSwitchCCReport({
+					nodeId: controller.ownNodeId,
+					currentValue,
+					targetValue: currentValue,
+					duration: new Duration(0, "seconds"),
+				});
+				await self.sendToController(
+					createMockZWaveRequestFrame(cc, {
+						ackRequested: false,
+					}),
+				);
+			}, 100).unref();
+
 			return { action: "ok" };
 		}
 	},

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/WindowCovering.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/WindowCovering.ts
@@ -1,16 +1,100 @@
 import {
+	WindowCoveringCCGet,
+	WindowCoveringCCReport,
+	WindowCoveringCCSet,
+	WindowCoveringCCStartLevelChange,
+	WindowCoveringCCStopLevelChange,
 	WindowCoveringCCSupportedGet,
 	WindowCoveringCCSupportedReport,
 } from "@zwave-js/cc/WindowCoveringCC";
-import { CommandClasses } from "@zwave-js/core";
-import type {
-	MockNodeBehavior,
-	WindowCoveringCCCapabilities,
+import { CommandClasses, Duration } from "@zwave-js/core";
+import { setTimer } from "@zwave-js/shared";
+import {
+	type MockNodeBehavior,
+	type WindowCoveringCCCapabilities,
+	createMockZWaveRequestFrame,
 } from "@zwave-js/testing";
+import {
+	type MockTransition,
+	getTransitionCurrentValue,
+	getTransitionRemainingDuration,
+	startTransition,
+	stopTransition,
+} from "./MockTransition.js";
 
-const defaultCapabilities: WindowCoveringCCCapabilities = {
+const defaultCapabilities: Required<WindowCoveringCCCapabilities> = {
 	supportedParameters: [],
+	travelTime: 5000,
 };
+
+const STATE_KEY_PREFIX = "WindowCovering_";
+function currentValueKey(param: number): string {
+	return `${STATE_KEY_PREFIX}currentValue_${param}`;
+}
+function transitionKey(param: number): string {
+	return `${STATE_KEY_PREFIX}transition_${param}`;
+}
+
+/** Stops any running transition for the given parameter and snaps state. */
+function stopParameterTransition(
+	self: Parameters<NonNullable<MockNodeBehavior["handleCC"]>>[1],
+	param: number,
+): void {
+	const existing = self.state.get(
+		transitionKey(param),
+	) as MockTransition | undefined;
+	if (existing) {
+		const value = stopTransition(existing);
+		self.state.set(currentValueKey(param), value);
+		self.state.delete(transitionKey(param));
+	}
+}
+
+/**
+ * Stops any existing transition for a parameter, then starts a new one.
+ * Manages all state reads/writes.
+ */
+function beginTransition(
+	controller: Parameters<NonNullable<MockNodeBehavior["handleCC"]>>[0],
+	self: Parameters<NonNullable<MockNodeBehavior["handleCC"]>>[1],
+	param: number,
+	targetValue: number,
+	travelTime: number,
+): void {
+	stopParameterTransition(self, param);
+
+	const currentValue =
+		(self.state.get(currentValueKey(param)) as number | undefined) ?? 0;
+
+	const transition = startTransition({
+		currentValue,
+		targetValue,
+		duration: travelTime,
+		onComplete: async () => {
+			self.state.set(currentValueKey(param), targetValue);
+			self.state.delete(transitionKey(param));
+
+			const cc = new WindowCoveringCCReport({
+				nodeId: controller.ownNodeId,
+				parameter: param,
+				currentValue: targetValue,
+				targetValue,
+				duration: new Duration(0, "seconds"),
+			});
+			await self.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+		},
+	});
+
+	if (transition) {
+		self.state.set(transitionKey(param), transition);
+	} else {
+		self.state.set(currentValueKey(param), targetValue);
+	}
+}
 
 const respondToWindowCoveringSupportedGet: MockNodeBehavior = {
 	handleCC(controller, self, receivedCC) {
@@ -31,4 +115,124 @@ const respondToWindowCoveringSupportedGet: MockNodeBehavior = {
 	},
 };
 
-export const WindowCoveringCCBehaviors = [respondToWindowCoveringSupportedGet];
+const respondToWindowCoveringGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof WindowCoveringCCGet) {
+			const param = receivedCC.parameter;
+			const transition = self.state.get(
+				transitionKey(param),
+			) as MockTransition | undefined;
+
+			let currentValue: number;
+			let targetValue: number;
+			let duration: Duration;
+
+			if (transition) {
+				currentValue = getTransitionCurrentValue(transition);
+				targetValue = transition.targetValue;
+				duration = getTransitionRemainingDuration(transition);
+			} else {
+				currentValue = (self.state.get(currentValueKey(param)) as
+					| number
+					| undefined) ?? 0;
+				targetValue = currentValue;
+				duration = new Duration(0, "seconds");
+			}
+
+			const cc = new WindowCoveringCCReport({
+				nodeId: controller.ownNodeId,
+				parameter: param,
+				currentValue,
+				targetValue,
+				duration,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToWindowCoveringSet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof WindowCoveringCCSet) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses["Window Covering"],
+					receivedCC.endpointIndex,
+				),
+			};
+			for (const { parameter, value } of receivedCC.targetValues) {
+				beginTransition(
+					controller,
+					self,
+					parameter,
+					value,
+					capabilities.travelTime,
+				);
+			}
+			return { action: "ok" };
+		}
+	},
+};
+
+const respondToWindowCoveringStartLevelChange: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof WindowCoveringCCStartLevelChange) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses["Window Covering"],
+					receivedCC.endpointIndex,
+				),
+			};
+			const targetValue = receivedCC.direction === "up" ? 99 : 0;
+			beginTransition(
+				controller,
+				self,
+				receivedCC.parameter,
+				targetValue,
+				capabilities.travelTime,
+			);
+			return { action: "ok" };
+		}
+	},
+};
+
+const respondToWindowCoveringStopLevelChange: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof WindowCoveringCCStopLevelChange) {
+			const param = receivedCC.parameter;
+			stopParameterTransition(self, param);
+
+			const currentValue = (self.state.get(currentValueKey(param)) as
+				| number
+				| undefined) ?? 0;
+
+			// Send a delayed report with the final state
+			setTimer(async () => {
+				const cc = new WindowCoveringCCReport({
+					nodeId: controller.ownNodeId,
+					parameter: param,
+					currentValue,
+					targetValue: currentValue,
+					duration: new Duration(0, "seconds"),
+				});
+				await self.sendToController(
+					createMockZWaveRequestFrame(cc, {
+						ackRequested: false,
+					}),
+				);
+			}, 100).unref();
+
+			return { action: "ok" };
+		}
+	},
+};
+
+export const WindowCoveringCCBehaviors = [
+	respondToWindowCoveringSupportedGet,
+	respondToWindowCoveringGet,
+	respondToWindowCoveringSet,
+	respondToWindowCoveringStartLevelChange,
+	respondToWindowCoveringStopLevelChange,
+];


### PR DESCRIPTION
This PR adds better support for mocking Window Covering CC and adds generic transition support to Window Covering CC and Multilevel Switch CC mocks.