### PR TITLE
fix: add missing transformers project reference to cc package

### DIFF
--- a/packages/cc/tsconfig.build.json
+++ b/packages/cc/tsconfig.build.json
@@ -19,8 +19,13 @@
 		},
 		{
 			"path": "../maintenance/tsconfig.build.json"
+		},
+		{
+			"path": "../transformers/tsconfig.build.json"
 		}
 	],
-	"include": ["src_gen/**/*.ts"],
+	"include": [
+		"src_gen/**/*.ts"
+	],
 	"exclude": []
 }


### PR DESCRIPTION
## Summary
- The `@zwave-js/cc` package imports `validateArgs` from `@zwave-js/transformers` but was missing the corresponding TypeScript project reference in `tsconfig.build.json`
- Detected by `yarn run sync-references`

🤖 Generated with [Claude Code](https://claude.com/claude-code)