### PR TITLE
feat(compat): support remapping notifications

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -589,6 +589,48 @@ Many devices unnecessarily use endpoints when they could (or do) provide all fun
 
 The Z-Wave+ specs mandate that the root endpoint must **mirror** the application functionality of endpoint 1 (and potentially others). For this reason, `zwave-js` hides these superfluous values. However, some legacy devices offer additional functionality through the root endpoint, which should not be hidden. To achieve this, set `preserveRootApplicationCCValueIDs` to `true`.
 
+### `remapNotifications`
+
+This option is used to remap notification events to different notification events or variables. This is useful for devices that use suboptimal notification events for specific behaviors, e.g. sending "Manual lock operation" when they should be reporting a "Door handle state" variable.
+
+This property has the following shape:
+
+```json
+"compat": {
+	"remapNotifications": [
+		{
+			"from": {
+				"notificationType": 6, // The notification type to remap
+				"notificationEvent": 1, // The notification event to remap
+			},
+			"to": {
+				"notificationType": 6, // The target notification type
+				"notificationEvent": 25, // The target notification event
+			}
+		},
+		// Example with action: clear/idle multiple target variables
+		{
+			"from": {
+				"notificationType": 6,
+				"notificationEvent": 7,
+			},
+			"clear": [
+				{ "notificationType": 6, "notificationEvent": 24 },
+				{ "notificationType": 6, "notificationEvent": 25 }
+			]
+		}
+	]
+}
+```
+
+The `from` object specifies which incoming notification event should be remapped.
+
+- With `to`: the incoming notification is treated as if the device sent the target notification event instead.
+- With `clear`: receiving the source notification causes each listed target notification value to be removed.
+- With `idle`: receiving the source notification causes each listed target notification value to be set to idle (0).
+
+When a notification is remapped, the original notification event is removed from the list of supported events and the mapping target is added instead. Mappings with `clear` or `idle` do not add to the list of supported notification events.
+
 ### `removeEndpoints`
 
 Some devices expose endpoints which are not needed or don't behave correctly. Using this flag, they can be ignored/hidden from applications. Example:

--- a/maintenance/schemas/device-config.json
+++ b/maintenance/schemas/device-config.json
@@ -162,6 +162,26 @@
 			"description": "Used to import another config file or parts thereof",
 			"pattern": "^((?<dir>((?:~/)?[\\w\\d_\\.-]+/)+)?(?<filename>[\\w\\d_-]+\\.json))?(?<selector>#([\\w\\d\\[\\]_-]+/)*[\\w\\d\\[\\]_-]+)?$"
 		},
+		"remapNotificationsTarget": {
+			"type": "object",
+			"properties": {
+				"notificationType": {
+					"type": "integer",
+					"minimum": 0,
+					"maximum": 255
+				},
+				"notificationEvent": {
+					"type": "integer",
+					"minimum": 0,
+					"maximum": 255
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"notificationType",
+				"notificationEvent"
+			]
+		},
 		"condition": {
 			"type": "string",
 			"description": "A condition that must be fulfilled for this entry to exit."
@@ -662,6 +682,70 @@
 							},
 							{
 								"required": ["$import"]
+							}
+						]
+					},
+					"minItems": 1,
+					"additionalItems": false
+				},
+				"remapNotifications": {
+					"description": "Is used to remap notification events to different notification events or variables",
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"$import": { "$ref": "#/definitions/import" },
+							"from": {
+								"type": "object",
+								"properties": {
+									"notificationType": {
+										"type": "integer",
+										"minimum": 0,
+										"maximum": 255
+									},
+									"notificationEvent": {
+										"type": "integer",
+										"minimum": 0,
+										"maximum": 255
+									}
+								},
+								"additionalProperties": false,
+								"required": [
+									"notificationType",
+									"notificationEvent"
+								]
+							},
+							"to": {
+								"$ref": "#/definitions/remapNotificationsTarget"
+							},
+							"clear": {
+								"type": "array",
+								"items": {
+									"$ref": "#/definitions/remapNotificationsTarget"
+								},
+								"minItems": 1
+							},
+							"idle": {
+								"type": "array",
+								"items": {
+									"$ref": "#/definitions/remapNotificationsTarget"
+								},
+								"minItems": 1
+							}
+						},
+						"additionalProperties": false,
+						"oneOf": [
+							{
+								"required": ["$import"]
+							},
+							{
+								"required": ["from", "to"]
+							},
+							{
+								"required": ["from", "clear"]
+							},
+							{
+								"required": ["from", "idle"]
 							}
 						]
 					},

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -558,6 +558,19 @@ export class NotificationCC extends CommandClass {
 			.getValue(NotificationCCValues.notificationMode.id);
 	}
 
+	/** Returns the supported notification events for a given notification type */
+	public static getSupportedNotificationEvents(
+		ctx: GetValueDB,
+		node: NodeId,
+		type: number,
+	): MaybeNotKnown<readonly number[]> {
+		return ctx
+			.getValueDB(node.id)
+			.getValue(
+				NotificationCCValues.supportedNotificationEvents(type).id,
+			);
+	}
+
 	public async interview(
 		ctx: InterviewContext,
 	): Promise<void> {
@@ -694,7 +707,6 @@ export class NotificationCC extends CommandClass {
 				for (let i = 0; i < supportedNotificationTypes.length; i++) {
 					const type = supportedNotificationTypes[i];
 					const name = supportedNotificationNames[i];
-					const notification = getNotification(type);
 
 					// Enable reports for each notification type
 					ctx.logNode(node.id, {
@@ -703,45 +715,6 @@ export class NotificationCC extends CommandClass {
 						direction: "outbound",
 					});
 					await api.set(type, true);
-
-					// Set the value to idle if possible and there is no value yet
-					if (notification) {
-						const events = supportedNotificationEvents.get(type);
-						if (events) {
-							// Find all variables that are supported by this node and have an idle state
-							for (
-								const variable of notification.variables
-									.filter((v) => !!v.idle)
-							) {
-								if (
-									[...variable.states.keys()].some((key) =>
-										events.includes(key)
-									)
-								) {
-									const value = NotificationCCValues
-										.notificationVariable(
-											notification.name,
-											variable.name,
-										);
-
-									// Set the value to idle if it has no value yet
-									// TODO: GH#1028
-									// * do this only if the last update was more than 5 minutes ago
-									// * schedule an auto-idle if the last update was less than 5 minutes ago but before the current applHost start
-									if (
-										this.getValue(ctx, value)
-											== undefined
-									) {
-										this.setValue(
-											ctx,
-											value,
-											0, /* idle */
-										);
-									}
-								}
-							}
-						}
-					}
 				}
 			}
 		}
@@ -752,31 +725,169 @@ export class NotificationCC extends CommandClass {
 			this.ensureMetadata(ctx, NotificationCCValues.alarmLevel);
 		}
 
-		// Also create metadata for values mapped through compat config
+		// Create metadata and internal values for alarm mappings
+		this.applyAlarmMappingCompat(ctx);
+
+		// Apply notification remappings
+		this.applyNotificationRemappings(ctx);
+
+		// Set idle values from (potentially remapped) supported events
+		this.initNotificationIdleValues(ctx);
+
+		// Remember that the interview is complete
+		this.setInterviewComplete(ctx, true);
+	}
+
+	/**
+	 * Applies the `alarmMapping` compat flag by adding metadata and supported notification
+	 * types/events for the alarm mapping targets.
+	 */
+	private applyAlarmMappingCompat(
+		ctx: InterviewContext,
+	): void {
 		const mappings = ctx.getDeviceConfig?.(this.nodeId as number)
 			?.compat?.alarmMapping;
-		if (mappings) {
-			// Find all mappings to a valid notification variable
-			const supportedNotifications = new Map<number, Set<number>>();
-			for (const { to } of mappings) {
-				const notification = getNotification(to.notificationType);
-				if (!notification) continue;
-				const valueConfig = getNotificationValue(
-					notification,
-					to.notificationEvent,
+		if (!mappings) return;
+
+		// Find all mappings to a valid notification variable
+		const supportedNotifications = new Map<number, Set<number>>();
+		for (const { to } of mappings) {
+			const notification = getNotification(to.notificationType);
+			if (!notification) continue;
+			const valueConfig = getNotificationValue(
+				notification,
+				to.notificationEvent,
+			);
+
+			// Remember supported notification types and events to create the internal values later
+			if (!supportedNotifications.has(to.notificationType)) {
+				supportedNotifications.set(
+					to.notificationType,
+					new Set(),
+				);
+			}
+			const supportedNotificationTypesSet = supportedNotifications
+				.get(to.notificationType)!;
+			supportedNotificationTypesSet.add(to.notificationEvent);
+
+			if (valueConfig?.type !== "state") continue;
+
+			const notificationValue = NotificationCCValues
+				.notificationVariable(
+					notification.name,
+					valueConfig.variableName,
 				);
 
-				// Remember supported notification types and events to create the internal values later
-				if (!supportedNotifications.has(to.notificationType)) {
-					supportedNotifications.set(
-						to.notificationType,
-						new Set(),
-					);
-				}
-				const supportedNotificationTypesSet = supportedNotifications
-					.get(to.notificationType)!;
-				supportedNotificationTypesSet.add(to.notificationEvent);
+			// Create or update the metadata
+			const metadata = getNotificationValueMetadata(
+				this.getMetadata(ctx, notificationValue),
+				notification,
+				valueConfig,
+			);
+			this.setMetadata(ctx, notificationValue, metadata);
+		}
 
+		// Remember supported notification types and events in the cache
+		this.setValue(
+			ctx,
+			NotificationCCValues.supportedNotificationTypes,
+			[...supportedNotifications.keys()],
+		);
+		for (const [type, events] of supportedNotifications) {
+			this.setValue(
+				ctx,
+				NotificationCCValues.supportedNotificationEvents(type),
+				[...events],
+			);
+		}
+	}
+
+	/**
+	 * Applies the `remapNotifications` compat flag by modifying the supported notification
+	 * types/events in cache and creating metadata for remapping targets.
+	 */
+	private applyNotificationRemappings(
+		ctx: InterviewContext,
+	): void {
+		const remappings = ctx.getDeviceConfig?.(this.nodeId as number)
+			?.compat?.remapNotifications;
+		if (!remappings?.length) return;
+
+		ctx.logNode(this.nodeId as number, {
+			message: `Applying notification remapping compat flag...`,
+			direction: "none",
+			level: "verbose",
+		});
+
+		// Load current supported types and events from cache
+		const supportedTypes = new Set<number>(
+			this.getValue<readonly number[]>(
+				ctx,
+				NotificationCCValues.supportedNotificationTypes,
+			) ?? [],
+		);
+
+		const supportedEvents = new Map<number, Set<number>>();
+		for (const type of supportedTypes) {
+			const events = NotificationCC.getSupportedNotificationEvents(
+				ctx,
+				this.getNode(ctx)!,
+				type,
+			);
+			if (events) {
+				supportedEvents.set(type, new Set(events));
+			}
+		}
+
+		for (const mapping of remappings) {
+			// Remove the original event from supported events
+			const fromEvents = supportedEvents.get(
+				mapping.from.notificationType,
+			);
+			if (fromEvents) {
+				fromEvents.delete(mapping.from.notificationEvent);
+				if (fromEvents.size === 0) {
+					supportedEvents.delete(mapping.from.notificationType);
+					supportedTypes.delete(mapping.from.notificationType);
+				}
+			}
+
+			// Only add target events for normal remaps
+			if (mapping.action.type === "remap") {
+				const to = mapping.action.to;
+				supportedTypes.add(to.notificationType);
+				if (!supportedEvents.has(to.notificationType)) {
+					supportedEvents.set(to.notificationType, new Set());
+				}
+				supportedEvents.get(to.notificationType)!.add(
+					to.notificationEvent,
+				);
+			}
+		}
+
+		// Persist updated supported types and events
+		this.setValue(
+			ctx,
+			NotificationCCValues.supportedNotificationTypes,
+			[...supportedTypes],
+		);
+		for (const [type, events] of supportedEvents) {
+			this.setValue(
+				ctx,
+				NotificationCCValues.supportedNotificationEvents(type),
+				[...events],
+			);
+		}
+
+		// Rebuild metadata for all supported events (since we may have removed
+		// some events and added others, the previous metadata may be stale)
+		for (const [type, events] of supportedEvents) {
+			const notification = getNotification(type);
+			if (!notification) continue;
+
+			let isFirst = true;
+			for (const value of events) {
+				const valueConfig = getNotificationValue(notification, value);
 				if (valueConfig?.type !== "state") continue;
 
 				const notificationValue = NotificationCCValues
@@ -785,48 +896,77 @@ export class NotificationCC extends CommandClass {
 						valueConfig.variableName,
 					);
 
-				// Create or update the metadata
 				const metadata = getNotificationValueMetadata(
-					this.getMetadata(ctx, notificationValue),
+					isFirst
+						? undefined
+						: this.getMetadata(ctx, notificationValue),
 					notification,
 					valueConfig,
 				);
 				this.setMetadata(ctx, notificationValue, metadata);
 
-				// Set the value to idle if it has no value yet
-				if (valueConfig.idle) {
+				isFirst = false;
+			}
+		}
+	}
+
+	/**
+	 * Sets idle values for all supported notification variables that have an idle state
+	 * and don't have a value yet.
+	 */
+	private initNotificationIdleValues(
+		ctx: InterviewContext,
+	): void {
+		const supportedTypes = this.getValue<readonly number[]>(
+			ctx,
+			NotificationCCValues.supportedNotificationTypes,
+		) ?? [];
+
+		for (const type of supportedTypes) {
+			const notification = getNotification(type);
+			if (!notification) continue;
+
+			// Reads supported events from cache so it works correctly
+			// after compat remappings have been applied.
+			const events = NotificationCC.getSupportedNotificationEvents(
+				ctx,
+				this.getNode(ctx)!,
+				type,
+			);
+			if (!events) continue;
+
+			// Find all variables that are supported by this node and have an idle state
+			for (
+				const variable of notification.variables
+					.filter((v) => !!v.idle)
+			) {
+				if (
+					[...variable.states.keys()].some((key) =>
+						events.includes(key)
+					)
+				) {
+					const value = NotificationCCValues
+						.notificationVariable(
+							notification.name,
+							variable.name,
+						);
+
+					// Set the value to idle if it has no value yet
 					// TODO: GH#1028
 					// * do this only if the last update was more than 5 minutes ago
 					// * schedule an auto-idle if the last update was less than 5 minutes ago but before the current applHost start
 					if (
-						this.getValue(ctx, notificationValue) == undefined
+						this.getValue(ctx, value) == undefined
 					) {
 						this.setValue(
 							ctx,
-							notificationValue,
+							value,
 							0, /* idle */
 						);
 					}
 				}
 			}
-
-			// Remember supported notification types and events in the cache
-			this.setValue(
-				ctx,
-				NotificationCCValues.supportedNotificationTypes,
-				[...supportedNotifications.keys()],
-			);
-			for (const [type, events] of supportedNotifications) {
-				this.setValue(
-					ctx,
-					NotificationCCValues.supportedNotificationEvents(type),
-					[...events],
-				);
-			}
 		}
-
-		// Remember that the interview is complete
-		this.setInterviewComplete(ctx, true);
 	}
 
 	public async refreshValues(
@@ -1092,14 +1232,12 @@ export class NotificationCCReport extends NotificationCC {
 					isArray(supportedNotificationTypes)
 					&& supportedNotificationTypes.includes(this.alarmType)
 				) {
-					const supportedNotificationEvents = this.getValue<
-						readonly number[]
-					>(
-						ctx,
-						NotificationCCValues.supportedNotificationEvents(
+					const supportedNotificationEvents = NotificationCC
+						.getSupportedNotificationEvents(
+							ctx,
+							this.getNode(ctx)!,
 							this.alarmType,
-						),
-					);
+						);
 					if (
 						isArray(supportedNotificationEvents)
 						&& supportedNotificationEvents.includes(this.alarmLevel)

--- a/packages/config/src/devices/CompatConfig.ts
+++ b/packages/config/src/devices/CompatConfig.ts
@@ -590,6 +590,23 @@ compat option alarmMapping must be an array where all items are objects!`,
 			);
 		}
 
+		if (definition.remapNotifications != undefined) {
+			if (
+				!isArray(definition.remapNotifications)
+				|| !definition.remapNotifications.every((m: any) => isObject(m))
+			) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+compat option remapNotifications must be an array where all items are objects!`,
+				);
+			}
+			this.remapNotifications = (definition.remapNotifications as any[])
+				.map(
+					(m, i) => new CompatRemapNotification(filename, m, i + 1),
+				);
+		}
+
 		if (definition.overrideQueries != undefined) {
 			if (!isObject(definition.overrideQueries)) {
 				throwInvalidConfig(
@@ -606,6 +623,7 @@ compat option overrideQueries must be an object!`,
 	}
 
 	public readonly alarmMapping?: readonly CompatMapAlarm[];
+	public readonly remapNotifications?: readonly CompatRemapNotification[];
 	public readonly addCCs?: ReadonlyMap<CommandClasses, CompatAddCC>;
 	public readonly removeCCs?: ReadonlyMap<
 		CommandClasses,
@@ -654,6 +672,7 @@ compat option overrideQueries must be an object!`,
 		if (!conditionApplies(this, deviceId)) return;
 		const ret = pick(this, [
 			"alarmMapping",
+			"remapNotifications",
 			"addCCs",
 			"removeCCs",
 			"disableAutoRefresh",
@@ -872,6 +891,133 @@ error in compat option alarmMapping, mapping #${index}: property "to.eventParame
 
 	public readonly from: CompatMapAlarmFrom;
 	public readonly to: CompatMapAlarmTo;
+}
+
+export interface CompatRemapNotificationFrom {
+	notificationType: number;
+	notificationEvent: number;
+}
+
+export interface CompatRemapNotificationTo {
+	notificationType: number;
+	notificationEvent: number;
+}
+
+export type CompatRemapNotificationAction =
+	| { type: "remap"; to: CompatRemapNotificationTo }
+	| { type: "clear"; targets: CompatRemapNotificationTo[] }
+	| { type: "idle"; targets: CompatRemapNotificationTo[] };
+
+export class CompatRemapNotification {
+	public constructor(
+		filename: string,
+		definition: JSONObject,
+		index: number,
+	) {
+		if (!isObject(definition.from)) {
+			throwInvalidConfig(
+				"devices",
+				`config/devices/${filename}:
+error in compat option remapNotifications, mapping #${index}: property "from" must be an object!`,
+			);
+		} else {
+			if (typeof definition.from.notificationType !== "number") {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option remapNotifications, mapping #${index}: property "from.notificationType" must be a number!`,
+				);
+			}
+			if (typeof definition.from.notificationEvent !== "number") {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option remapNotifications, mapping #${index}: property "from.notificationEvent" must be a number!`,
+				);
+			}
+		}
+
+		this.from = pick(definition.from, [
+			"notificationType",
+			"notificationEvent",
+		]);
+
+		const validateToObject = (obj: any, label: string) => {
+			if (!isObject(obj)) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option remapNotifications, mapping #${index}: ${label} must be an object!`,
+				);
+			}
+			if (typeof obj.notificationType !== "number") {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option remapNotifications, mapping #${index}: ${label} must have a numeric "notificationType"!`,
+				);
+			}
+			if (typeof obj.notificationEvent !== "number") {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option remapNotifications, mapping #${index}: ${label} must have a numeric "notificationEvent"!`,
+				);
+			}
+		};
+
+		const validateTargetArray = (arr: any, label: string): void => {
+			if (!isArray(arr) || arr.length === 0) {
+				throwInvalidConfig(
+					"devices",
+					`config/devices/${filename}:
+error in compat option remapNotifications, mapping #${index}: property "${label}" must be a non-empty array of objects!`,
+				);
+			}
+			for (let j = 0; j < arr.length; j++) {
+				validateToObject(
+					arr[j],
+					`"${label}[${j}]"`,
+				);
+			}
+		};
+
+		if (definition.to != undefined) {
+			validateToObject(definition.to, `property "to"`);
+			this.action = {
+				type: "remap",
+				to: pick(definition.to, [
+					"notificationType",
+					"notificationEvent",
+				]),
+			};
+		} else if (definition.clear != undefined) {
+			validateTargetArray(definition.clear, "clear");
+			this.action = {
+				type: "clear",
+				targets: (definition.clear as any[]).map((target) =>
+					pick(target, ["notificationType", "notificationEvent"])
+				),
+			};
+		} else if (definition.idle != undefined) {
+			validateTargetArray(definition.idle, "idle");
+			this.action = {
+				type: "idle",
+				targets: (definition.idle as any[]).map((target) =>
+					pick(target, ["notificationType", "notificationEvent"])
+				),
+			};
+		} else {
+			throwInvalidConfig(
+				"devices",
+				`config/devices/${filename}:
+error in compat option remapNotifications, mapping #${index}: exactly one of "to", "clear", or "idle" must be defined!`,
+			);
+		}
+	}
+
+	public readonly from: CompatRemapNotificationFrom;
+	public readonly action: CompatRemapNotificationAction;
 }
 
 export class CompatOverrideQueries {

--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -74,6 +74,56 @@ export function handleNotificationReport(
 		return;
 	}
 
+	// Apply notification remapping from compat config
+	const remappings = node.deviceConfig?.compat?.remapNotifications;
+	if (remappings?.length) {
+		const match = remappings.find(
+			(m) =>
+				m.from.notificationType === command.notificationType
+				&& m.from.notificationEvent === command.notificationEvent,
+		);
+		if (match) {
+			ctx.logNode(node.id, {
+				message: `Notification remapped via compat flag`,
+				direction: "inbound",
+				level: "verbose",
+			});
+
+			if (match.action.type === "clear" || match.action.type === "idle") {
+				for (const target of match.action.targets) {
+					const targetNotification = getNotification(
+						target.notificationType,
+					);
+					if (!targetNotification) continue;
+
+					const targetValueConfig = getNotificationValue(
+						targetNotification,
+						target.notificationEvent,
+					);
+					if (targetValueConfig?.type !== "state") continue;
+
+					const valueId = NotificationCCValues
+						.notificationVariable(
+							targetNotification.name,
+							targetValueConfig.variableName,
+						).endpoint(command.endpointIndex);
+
+					if (match.action.type === "clear") {
+						node.valueDB.removeValue(valueId);
+					} else {
+						node.valueDB.setValue(valueId, 0 /* idle */);
+					}
+				}
+				return;
+			} else {
+				// Normal remap: overwrite notification type and event
+				const to = match.action.to;
+				command.notificationType = to.notificationType;
+				command.notificationEvent = to.notificationEvent;
+			}
+		}
+	}
+
 	const ccVersion = getEffectiveCCVersion(ctx, command);
 
 	// Look up the received notification in the config

--- a/packages/zwave-js/src/lib/test/compat/fixtures/remapNotifications/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/compat/fixtures/remapNotifications/deviceConfig.json
@@ -1,0 +1,72 @@
+{
+	"manufacturer": "Test Manufacturer",
+	"manufacturerId": "0xdead",
+	"label": "Test Lock",
+	"description": "With notification remapping",
+	"devices": [
+		{
+			"productType": "0xbeef",
+			"productId": "0xcafe"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"compat": {
+		"remapNotifications": [
+			{
+				"from": {
+					"notificationType": 6,
+					"notificationEvent": 1
+				},
+				"to": {
+					"notificationType": 6,
+					"notificationEvent": 25
+				}
+			},
+			{
+				"from": {
+					"notificationType": 6,
+					"notificationEvent": 2
+				},
+				"to": {
+					"notificationType": 6,
+					"notificationEvent": 24
+				}
+			},
+			{
+				"from": {
+					"notificationType": 6,
+					"notificationEvent": 7
+				},
+				"clear": [
+					{
+						"notificationType": 6,
+						"notificationEvent": 24
+					},
+					{
+						"notificationType": 6,
+						"notificationEvent": 25
+					}
+				]
+			},
+			{
+				"from": {
+					"notificationType": 6,
+					"notificationEvent": 9
+				},
+				"idle": [
+					{
+						"notificationType": 6,
+						"notificationEvent": 24
+					},
+					{
+						"notificationType": 6,
+						"notificationEvent": 25
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/zwave-js/src/lib/test/compat/notificationRemapping.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemapping.test.ts
@@ -1,0 +1,178 @@
+import {
+	NotificationCCReport,
+	NotificationCCValues,
+} from "@zwave-js/cc/NotificationCC";
+import { CommandClasses, type ValueMetadataNumeric } from "@zwave-js/core";
+import { createMockZWaveRequestFrame } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"remapNotifications compat flag remaps supported events and metadata during interview",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			manufacturerId: 0xdead,
+			productType: 0xbeef,
+			productId: 0xcafe,
+
+			commandClasses: [
+				{
+					ccId: CommandClasses.Notification,
+					isSupported: true,
+					version: 8,
+					supportsV1Alarm: false,
+					notificationTypesAndEvents: {
+						// Access Control - Manual lock, Manual unlock, Manual not fully locked, Auto lock
+						[0x06]: [0x01, 0x02, 0x07, 0x09],
+					},
+				},
+				CommandClasses["Manufacturer Specific"],
+				CommandClasses.Version,
+			],
+		},
+
+		additionalDriverOptions: {
+			storage: {
+				deviceConfigPriorityDir: path.join(
+					__dirname,
+					"fixtures/remapNotifications",
+				),
+			},
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			// Verify the compat flag is loaded
+			t.expect(node.deviceConfig?.compat?.remapNotifications)
+				.toBeDefined();
+
+			// The supported notification events should be remapped:
+			// 0x01, 0x02, 0x07, 0x09 should be replaced by 0x18, 0x19
+			// (0x07 maps with "clear" and 0x09 with "idle", so they don't add target events)
+			const supportedAccessControlEvents: number[] | undefined = node
+				.getValue(
+					NotificationCCValues.supportedNotificationEvents(0x06).id,
+				);
+
+			t.expect(supportedAccessControlEvents).toBeDefined();
+			// Should contain the remapped targets
+			t.expect(supportedAccessControlEvents).toContain(0x18);
+			t.expect(supportedAccessControlEvents).toContain(0x19);
+			// Should NOT contain the original events
+			t.expect(supportedAccessControlEvents).not.toContain(0x01);
+			t.expect(supportedAccessControlEvents).not.toContain(0x02);
+			t.expect(supportedAccessControlEvents).not.toContain(0x09);
+			t.expect(supportedAccessControlEvents).not.toContain(0x07);
+
+			// Metadata should be created for "Door handle state" variable
+			const doorHandleStateId = NotificationCCValues
+				.notificationVariable(
+					"Access Control",
+					"Door handle state",
+				).id;
+			const metadata = node.getValueMetadata(
+				doorHandleStateId,
+			) as ValueMetadataNumeric;
+			t.expect(metadata).toBeDefined();
+			t.expect(metadata.states?.[0x18]).toBe(
+				"Window/door handle is open",
+			);
+			t.expect(metadata.states?.[0x19]).toBe(
+				"Window/door handle is closed",
+			);
+
+			// Send a "Manual lock operation" (0x01) report - should be remapped to 0x19 (handle closed)
+			let cc = new NotificationCCReport({
+				nodeId: mockNode.id,
+				notificationType: 0x06,
+				notificationEvent: 0x01,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			let doorHandleValue = node.getValue(doorHandleStateId);
+			t.expect(doorHandleValue).toBe(0x19);
+
+			// Send a "Manual unlock operation" (0x02) report - should be remapped to 0x18 (handle open)
+			cc = new NotificationCCReport({
+				nodeId: mockNode.id,
+				notificationType: 0x06,
+				notificationEvent: 0x02,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			doorHandleValue = node.getValue(doorHandleStateId);
+			t.expect(doorHandleValue).toBe(0x18);
+
+			// Now both handle states are set (0x19 from lock, 0x18 from unlock).
+			// The "Door handle state" variable tracks the last event, but
+			// event 0x18 and 0x19 share the same variable, so only the
+			// last one persists. To properly test multi-clear, verify the
+			// value is removed after clearing.
+
+			// Send a "Manual not fully locked operation" (0x07) report - should clear both handle events
+			cc = new NotificationCCReport({
+				nodeId: mockNode.id,
+				notificationType: 0x06,
+				notificationEvent: 0x07,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			doorHandleValue = node.getValue(doorHandleStateId);
+			t.expect(doorHandleValue).toBeUndefined();
+
+			// Send a "Manual lock operation" (0x01) again to set the value
+			cc = new NotificationCCReport({
+				nodeId: mockNode.id,
+				notificationType: 0x06,
+				notificationEvent: 0x01,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			doorHandleValue = node.getValue(doorHandleStateId);
+			t.expect(doorHandleValue).toBe(0x19);
+
+			// Send a "Auto lock operation" (0x09) report - should set both handle events to idle (0)
+			cc = new NotificationCCReport({
+				nodeId: mockNode.id,
+				notificationType: 0x06,
+				notificationEvent: 0x09,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			doorHandleValue = node.getValue(doorHandleStateId);
+			t.expect(doorHandleValue).toBe(0);
+		},
+	},
+);


### PR DESCRIPTION
This PR adds the new compat flag `remapNotifications` that allows mapping notifications from one notification type/event to another, as well as clearing or idling notifications on receipt of another one. This includes remapping standalone events to related notification variables.