### PR TITLE
fix: emit value update with `UNKNOWN_STATE` when clearing notification variable

### DIFF
--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -626,7 +626,7 @@ This property has the following shape:
 The `from` object specifies which incoming notification event should be remapped.
 
 - With `to`: the incoming notification is treated as if the device sent the target notification event instead.
-- With `clear`: receiving the source notification causes each listed target notification value to be set to `undefined` (unknown state).
+- With `clear`: receiving the source notification causes each listed target notification value to be set to unknown state (`UNKNOWN_STATE`).
 - With `idle`: receiving the source notification causes each listed target notification value to be set to idle (0).
 
 When a notification is remapped, the original notification event is removed from the list of supported events and the mapping target is added instead. Mappings with `clear` or `idle` do not add to the list of supported notification events.

--- a/docs/config-files/file-format.md
+++ b/docs/config-files/file-format.md
@@ -626,7 +626,7 @@ This property has the following shape:
 The `from` object specifies which incoming notification event should be remapped.
 
 - With `to`: the incoming notification is treated as if the device sent the target notification event instead.
-- With `clear`: receiving the source notification causes each listed target notification value to be removed.
+- With `clear`: receiving the source notification causes each listed target notification value to be set to `undefined` (unknown state).
 - With `idle`: receiving the source notification causes each listed target notification value to be set to idle (0).
 
 When a notification is remapped, the original notification event is removed from the list of supported events and the mapping target is added instead. Mappings with `clear` or `idle` do not add to the list of supported notification events.

--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -21,9 +21,11 @@ import {
 	type GetSupportedCCVersion,
 	type GetValueDB,
 	type LogNode,
+	NOT_KNOWN,
 	type NodeId,
 	type Notification,
 	type NotificationState,
+	UNKNOWN_STATE,
 	type ValueID,
 	type ValueMetadataNumeric,
 	getNotification,
@@ -109,7 +111,7 @@ export function handleNotificationReport(
 						).endpoint(command.endpointIndex);
 
 					if (match.action.type === "clear") {
-						node.valueDB.removeValue(valueId);
+						node.valueDB.setValue(valueId, UNKNOWN_STATE);
 					} else {
 						node.valueDB.setValue(valueId, 0 /* idle */);
 					}

--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -21,7 +21,6 @@ import {
 	type GetSupportedCCVersion,
 	type GetValueDB,
 	type LogNode,
-	NOT_KNOWN,
 	type NodeId,
 	type Notification,
 	type NotificationState,
@@ -111,14 +110,43 @@ export function handleNotificationReport(
 						).endpoint(command.endpointIndex);
 
 					if (match.action.type === "clear") {
-						node.valueDB.setValue(valueId, UNKNOWN_STATE);
+						// Only clear if the variable currently reflects this specific event,
+						// to avoid spurious updates when multiple targets share the same variable.
+						if (
+							node.valueDB.getValue(valueId)
+								=== target.notificationEvent
+						) {
+							node.valueDB.setValue(valueId, UNKNOWN_STATE);
+						}
+
+						// Special case for doorStateSimple. If the parent value
+						// gets cleared, this also needs to get cleared.
+						if (
+							target.notificationType === 0x06
+							&& (target.notificationEvent === 0x16
+								|| target.notificationEvent === 0x17)
+						) {
+							const simpleDoorStateId = NotificationCCValues
+								.doorStateSimple
+								.endpoint(command.endpointIndex);
+							if (
+								node.valueDB.getValue(simpleDoorStateId)
+									=== target.notificationEvent
+							) {
+								node.valueDB.setValue(
+									simpleDoorStateId,
+									UNKNOWN_STATE,
+								);
+							}
+						}
 					} else {
 						node.valueDB.setValue(valueId, 0 /* idle */);
 					}
 				}
 				return;
 			} else {
-				// Normal remap: overwrite notification type and event
+				// Normal remap: overwrite notification type and event, then fall through
+				// to normal handling.
 				const to = match.action.to;
 				command.notificationType = to.notificationType;
 				command.notificationEvent = to.notificationEvent;

--- a/packages/zwave-js/src/lib/test/compat/fixtures/remapNotificationsDoorState/deviceConfig.json
+++ b/packages/zwave-js/src/lib/test/compat/fixtures/remapNotificationsDoorState/deviceConfig.json
@@ -1,0 +1,56 @@
+{
+	"manufacturer": "Test Manufacturer",
+	"manufacturerId": "0xdead",
+	"label": "Test Door Sensor",
+	"description": "With notification remapping to simple door state",
+	"devices": [
+		{
+			"productType": "0xbeef",
+			"productId": "0xcaff"
+		}
+	],
+	"firmwareVersion": {
+		"min": "0.0",
+		"max": "255.255"
+	},
+	"compat": {
+		"remapNotifications": [
+			{
+				"from": {
+					"notificationType": 6,
+					"notificationEvent": 1
+				},
+				"to": {
+					"notificationType": 6,
+					"notificationEvent": 22
+				}
+			},
+			{
+				"from": {
+					"notificationType": 6,
+					"notificationEvent": 2
+				},
+				"to": {
+					"notificationType": 6,
+					"notificationEvent": 23
+				}
+			},
+			{
+				"from": {
+					"notificationType": 6,
+					"notificationEvent": 254
+				},
+				"clear": [
+					{
+						"notificationType": 6,
+						"notificationEvent": 22
+					},
+					{
+						"notificationType": 6,
+						"notificationEvent": 23
+					}
+				]
+			}
+		]
+	}
+}

--- a/packages/zwave-js/src/lib/test/compat/notificationRemapping.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemapping.test.ts
@@ -2,7 +2,11 @@ import {
 	NotificationCCReport,
 	NotificationCCValues,
 } from "@zwave-js/cc/NotificationCC";
-import { CommandClasses, UNKNOWN_STATE, type ValueMetadataNumeric } from "@zwave-js/core";
+import {
+	CommandClasses,
+	UNKNOWN_STATE,
+	type ValueMetadataNumeric,
+} from "@zwave-js/core";
 import { createMockZWaveRequestFrame } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import path from "node:path";
@@ -154,9 +158,9 @@ integrationTest(
 			await wait(100);
 
 			doorHandleValue = node.getValue(doorHandleStateId);
-			t.expect(doorHandleValue).toBeUndefined();
+			t.expect(doorHandleValue).toBe(UNKNOWN_STATE);
 
-			// Verify that "clear" action emits "value updated" with undefined, NOT "value removed"
+			// Verify that "clear" action emits "value updated" with UNKNOWN_STATE, NOT "value removed"
 			t.expect(valueRemovedEvents).toHaveLength(0);
 			t.expect(valueUpdatedEvents.length).toBeGreaterThan(0);
 			const clearEvent = valueUpdatedEvents.find(

--- a/packages/zwave-js/src/lib/test/compat/notificationRemapping.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemapping.test.ts
@@ -2,7 +2,7 @@ import {
 	NotificationCCReport,
 	NotificationCCValues,
 } from "@zwave-js/cc/NotificationCC";
-import { CommandClasses, type ValueMetadataNumeric } from "@zwave-js/core";
+import { CommandClasses, UNKNOWN_STATE, type ValueMetadataNumeric } from "@zwave-js/core";
 import { createMockZWaveRequestFrame } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
 import path from "node:path";
@@ -44,6 +44,18 @@ integrationTest(
 		},
 
 		async testBody(t, driver, node, mockController, mockNode) {
+			// Track value events to ensure "clear" doesn't fire "value removed"
+			const valueRemovedEvents: any[] = [];
+			const valueUpdatedEvents: any[] = [];
+
+			node.on("value removed", (_, args) => {
+				valueRemovedEvents.push(args);
+			});
+
+			node.on("value updated", (_, args) => {
+				valueUpdatedEvents.push(args);
+			});
+
 			// Verify the compat flag is loaded
 			t.expect(node.deviceConfig?.compat?.remapNotifications)
 				.toBeDefined();
@@ -121,7 +133,11 @@ integrationTest(
 			// The "Door handle state" variable tracks the last event, but
 			// event 0x18 and 0x19 share the same variable, so only the
 			// last one persists. To properly test multi-clear, verify the
-			// value is removed after clearing.
+			// value is set to undefined after clearing.
+
+			// Clear the event trackers before the clear action
+			valueRemovedEvents.length = 0;
+			valueUpdatedEvents.length = 0;
 
 			// Send a "Manual not fully locked operation" (0x07) report - should clear both handle events
 			cc = new NotificationCCReport({
@@ -139,6 +155,17 @@ integrationTest(
 
 			doorHandleValue = node.getValue(doorHandleStateId);
 			t.expect(doorHandleValue).toBeUndefined();
+
+			// Verify that "clear" action emits "value updated" with undefined, NOT "value removed"
+			t.expect(valueRemovedEvents).toHaveLength(0);
+			t.expect(valueUpdatedEvents.length).toBeGreaterThan(0);
+			const clearEvent = valueUpdatedEvents.find(
+				(e) =>
+					e.property === "Access Control"
+					&& e.propertyKey === "Door handle state",
+			);
+			t.expect(clearEvent).toBeDefined();
+			t.expect(clearEvent.newValue).toBe(UNKNOWN_STATE);
 
 			// Send a "Manual lock operation" (0x01) again to set the value
 			cc = new NotificationCCReport({

--- a/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
@@ -11,7 +11,7 @@ import { integrationTest } from "../integrationTestSuite.js";
 integrationTest(
 	"remapNotifications compat flag syncs doorStateSimple when remapping to/clearing door open/closed events",
 	{
-		debug: true,
+		// debug: true,
 
 		nodeCapabilities: {
 			manufacturerId: 0xdead,

--- a/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
@@ -1,0 +1,99 @@
+import {
+	NotificationCCReport,
+	NotificationCCValues,
+} from "@zwave-js/cc/NotificationCC";
+import { CommandClasses, UNKNOWN_STATE } from "@zwave-js/core";
+import { createMockZWaveRequestFrame } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import path from "node:path";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"remapNotifications compat flag syncs doorStateSimple when remapping to/clearing door open/closed events",
+	{
+		debug: true,
+
+		nodeCapabilities: {
+			manufacturerId: 0xdead,
+			productType: 0xbeef,
+			productId: 0xcaff,
+
+			commandClasses: [
+				{
+					ccId: CommandClasses.Notification,
+					isSupported: true,
+					version: 8,
+					supportsV1Alarm: false,
+					notificationTypesAndEvents: {
+						// Access Control - Manual lock events remapped to door open/closed
+						[0x06]: [0x01, 0x02],
+					},
+				},
+				CommandClasses["Manufacturer Specific"],
+				CommandClasses.Version,
+			],
+		},
+
+		additionalDriverOptions: {
+			storage: {
+				deviceConfigPriorityDir: path.join(
+					__dirname,
+					"fixtures/remapNotificationsDoorState",
+				),
+			},
+		},
+
+		async testBody(t, driver, node, mockController, mockNode) {
+			const doorStateSimpleId = NotificationCCValues.doorStateSimple
+				.endpoint(0);
+
+			// Send event 0x01 - should be remapped to door open (0x16) and sync doorStateSimple
+			let cc = new NotificationCCReport({
+				nodeId: mockNode.id,
+				notificationType: 0x06,
+				notificationEvent: 0x01,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			t.expect(node.getValue(doorStateSimpleId)).toBe(0x16);
+
+			// Send event 0x02 - should be remapped to door closed (0x17) and sync doorStateSimple
+			cc = new NotificationCCReport({
+				nodeId: mockNode.id,
+				notificationType: 0x06,
+				notificationEvent: 0x02,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			t.expect(node.getValue(doorStateSimpleId)).toBe(0x17);
+
+			// Send event 0xfe - should clear door open/closed and set doorStateSimple to UNKNOWN_STATE
+			cc = new NotificationCCReport({
+				nodeId: mockNode.id,
+				notificationType: 0x06,
+				notificationEvent: 0xfe,
+			});
+
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
+
+			t.expect(node.getValue(doorStateSimpleId)).toBe(UNKNOWN_STATE);
+		},
+	},
+);


### PR DESCRIPTION
Removing the value was too much.