### PR TITLE
fix: deprecate all Door state variables, add new synthetic "Opening state"

### DIFF
--- a/packages/cc/maintenance/generateCCValueDefinitions.ts
+++ b/packages/cc/maintenance/generateCCValueDefinitions.ts
@@ -147,7 +147,20 @@ export async function generateCCValueDefinitionsFile(
 				}
 				return undefined;
 			})
-			.filter((decl) => decl != undefined);
+			.filter((decl): decl is Statement => decl != undefined)
+			// deduplicate top-level declarations that might be referenced multiple times
+			// in the value definitions
+			.filter((decl, index, declarations) => {
+				const key =
+					`${decl.getSourceFile().getFilePath()}:${decl.getPos()}`;
+				return (
+					declarations.findIndex(
+						(candidate) =>
+							`${candidate.getSourceFile().getFilePath()}:${candidate.getPos()}`
+								=== key,
+					) === index
+				);
+			});
 
 		// Functions are hoisted and might need access to the CCValues definition
 		const localFunctionsToCopy = localDeclarationsToCopy.filter(

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -133,10 +133,10 @@ export const NotificationCCValues = V.defineCCValues(
 				ccSpecific: {
 					notificationType: 0x06,
 				},
-			} as const,
+			},
 			{
 				autoCreate: shouldAutoCreateSyntheticDoorSensorValue,
-			} as const,
+			},
 		),
 		// Previous attempts at fixing the door state mess, but only made things worse.
 		...V.staticPropertyAndKeyWithName(

--- a/packages/cc/src/cc/NotificationCC.ts
+++ b/packages/cc/src/cc/NotificationCC.ts
@@ -117,8 +117,30 @@ export const NotificationCCValues = V.defineCCValues(
 				label: "Alarm Level",
 			} as const,
 		),
+		// Synthetic notification variable to simplify working with Open/Close/Tilted states
 		...V.staticPropertyAndKeyWithName(
-			"doorStateSimple",
+			"openingState",
+			"Access Control",
+			"Opening state",
+			{
+				// Must be a number for compatibility reasons
+				...ValueMetadata.ReadOnlyUInt8,
+				label: "Opening state",
+				states: {
+					[0x00]: "Closed",
+					[0x01]: "Open",
+				},
+				ccSpecific: {
+					notificationType: 0x06,
+				},
+			} as const,
+			{
+				autoCreate: shouldAutoCreateSyntheticDoorSensorValue,
+			} as const,
+		),
+		// Previous attempts at fixing the door state mess, but only made things worse.
+		...V.staticPropertyAndKeyWithName(
+			"deprecated_doorStateSimple",
 			"Access Control",
 			"Door state (simple)",
 			{
@@ -134,11 +156,12 @@ export const NotificationCCValues = V.defineCCValues(
 				},
 			} as const,
 			{
-				autoCreate: shouldAutoCreateSimpleDoorSensorValue,
+				autoCreate: shouldAutoCreateSyntheticDoorSensorValue,
 			} as const,
 		),
+		// Previous attempts at fixing the door state mess, but only made things worse.
 		...V.staticPropertyAndKeyWithName(
-			"doorTiltState",
+			"deprecated_doorTiltState",
 			"Access Control",
 			"Door tilt state",
 			{
@@ -212,7 +235,7 @@ export const NotificationCCValues = V.defineCCValues(
 	},
 );
 
-export function shouldAutoCreateSimpleDoorSensorValue(
+export function shouldAutoCreateSyntheticDoorSensorValue(
 	ctx: GetValueDB,
 	endpoint: EndpointId,
 ): boolean {

--- a/packages/cc/src/cc/_CCValues.generated.ts
+++ b/packages/cc/src/cc/_CCValues.generated.ts
@@ -6919,7 +6919,47 @@ export const NotificationCCValues = Object.freeze({
 			autoCreate: true,
 		} as const satisfies CCValueOptions,
 	},
-	doorStateSimple: {
+	openingState: {
+		id: {
+			commandClass: CommandClasses.Notification,
+			property: "Access Control",
+			propertyKey: "Opening state",
+		} as const,
+		endpoint: (endpoint: number = 0) => ({
+			commandClass: CommandClasses.Notification,
+			endpoint,
+			property: "Access Control",
+			propertyKey: "Opening state",
+		} as const),
+		is: (valueId: ValueID): boolean => {
+			return valueId.commandClass === CommandClasses.Notification
+				&& valueId.property === "Access Control"
+				&& valueId.propertyKey == "Opening state";
+		},
+		get meta() {
+			return {
+				// Must be a number for compatibility reasons
+				...ValueMetadata.ReadOnlyUInt8,
+				label: "Opening state",
+				states: {
+					[0x00]: "Closed",
+					[0x01]: "Open",
+				},
+				ccSpecific: {
+					notificationType: 0x06,
+				},
+			} as const;
+		},
+		options: {
+			internal: false,
+			minVersion: 1,
+			secret: false,
+			stateful: true,
+			supportsEndpoints: true,
+			autoCreate: shouldAutoCreateSyntheticDoorSensorValue,
+		} as const satisfies CCValueOptions,
+	},
+	deprecated_doorStateSimple: {
 		id: {
 			commandClass: CommandClasses.Notification,
 			property: "Access Control",
@@ -6956,10 +6996,10 @@ export const NotificationCCValues = Object.freeze({
 			secret: false,
 			stateful: true,
 			supportsEndpoints: true,
-			autoCreate: shouldAutoCreateSimpleDoorSensorValue,
+			autoCreate: shouldAutoCreateSyntheticDoorSensorValue,
 		} as const satisfies CCValueOptions,
 	},
-	doorTiltState: {
+	deprecated_doorTiltState: {
 		id: {
 			commandClass: CommandClasses.Notification,
 			property: "Access Control",
@@ -7166,7 +7206,7 @@ export const NotificationCCValues = Object.freeze({
 	),
 });
 
-function shouldAutoCreateSimpleDoorSensorValue(
+function shouldAutoCreateSyntheticDoorSensorValue(
 	ctx: GetValueDB,
 	endpoint: EndpointId,
 ): boolean {

--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -440,7 +440,7 @@ function handleKnownNotification(
 		// Actual status
 		0x16,
 		0x17,
-		// Synthetic status with enum
+		// Synthetic status with enum (deprecated)
 		0x1600,
 		0x1601,
 	];
@@ -486,10 +486,38 @@ function handleKnownNotification(
 		// very cumbersome. Also, this is currently the only notification where the enum values
 		// extend the state value.
 
-		// To work around this, we hard-code a notification value for the door status
-		// which only includes the "legacy" states for open/closed.
+		// To work around this, we synthesize a stable door/window state that only
+		// exposes tilt after we've actually seen a tilted notification.
+		const isTilted = command.notificationEvent === 0x16
+			&& command.eventParameters === 0x01;
+		const openingStateValue = NotificationCCValues.openingState;
+		const openingStateValueId = openingStateValue.endpoint(
+			command.endpointIndex,
+		);
+		const openingStateTiltMetadata: ValueMetadataNumeric = {
+			...openingStateValue.meta,
+			states: {
+				...openingStateValue.meta.states,
+				[0x02]: "Tilted",
+			},
+		};
+		const openingStateMetadata = node.valueDB.getMetadata(
+			openingStateValueId,
+		) as ValueMetadataNumeric | undefined;
+		if (isTilted && !openingStateMetadata?.states?.[2]) {
+			node.valueDB.setMetadata(
+				openingStateValueId,
+				openingStateTiltMetadata,
+			);
+		}
 		node.valueDB.setValue(
-			NotificationCCValues.doorStateSimple.endpoint(
+			openingStateValueId,
+			command.notificationEvent === 0x17 ? 0x00 : isTilted ? 0x02 : 0x01,
+		);
+
+		// Keep the legacy compatibility value limited to the historic open/closed states.
+		node.valueDB.setValue(
+			NotificationCCValues.deprecated_doorStateSimple.endpoint(
 				command.endpointIndex,
 			),
 			command.notificationEvent === 0x17 ? 0x17 : 0x16,
@@ -499,17 +527,17 @@ function handleKnownNotification(
 		// This will only be created after receiving a notification for the tilted state.
 		// Only after it exists, it will be updated. Otherwise, we'd get phantom
 		// values, since some devices send the enum value, even when they don't support tilt.
-		const tiltValue = NotificationCCValues.doorTiltState;
+		const tiltValue = NotificationCCValues.deprecated_doorTiltState;
 		const tiltValueId = tiltValue.endpoint(command.endpointIndex);
 		let tiltValueWasCreated = node.valueDB.hasMetadata(tiltValueId);
-		if (command.eventParameters === 0x01 && !tiltValueWasCreated) {
+		if (isTilted && !tiltValueWasCreated) {
 			node.valueDB.setMetadata(tiltValueId, tiltValue.meta);
 			tiltValueWasCreated = true;
 		}
 		if (tiltValueWasCreated) {
 			node.valueDB.setValue(
 				tiltValueId,
-				command.eventParameters === 0x01 ? 0x01 : 0x00,
+				isTilted ? 0x01 : 0x00,
 			);
 		}
 	} else if (

--- a/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
+++ b/packages/zwave-js/src/lib/node/CCHandlers/NotificationCC.ts
@@ -127,7 +127,7 @@ export function handleNotificationReport(
 								|| target.notificationEvent === 0x17)
 						) {
 							const simpleDoorStateId = NotificationCCValues
-								.doorStateSimple
+								.deprecated_doorStateSimple
 								.endpoint(command.endpointIndex);
 							if (
 								node.valueDB.getValue(simpleDoorStateId)

--- a/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
+++ b/packages/zwave-js/src/lib/test/cc-specific/notificationEnums.test.ts
@@ -27,8 +27,6 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.commandClasses.Notification.getSupportedEvents(0x0f);
-
 			const valveOperationStatusId =
 				NotificationCCValues.notificationVariable(
 					"Water Valve",
@@ -105,8 +103,6 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.commandClasses.Notification.getSupportedEvents(0x06);
-
 			const doorStateValueId = NotificationCCValues.notificationVariable(
 				"Access Control",
 				"Door state",
@@ -210,8 +206,6 @@ integrationTest("The 'simple' Door state value works correctly", {
 	},
 
 	testBody: async (t, driver, node, mockController, mockNode) => {
-		await node.commandClasses.Notification.getSupportedEvents(0x06);
-
 		const valueIDs = node.getDefinedValueIDs();
 		const simpleVID = valueIDs.find(
 			(vid) =>
@@ -238,7 +232,7 @@ integrationTest("The 'simple' Door state value works correctly", {
 			"Access Control",
 			"Door state",
 		);
-		const valueSimple = NotificationCCValues.doorStateSimple;
+		const valueSimple = NotificationCCValues.deprecated_doorStateSimple;
 
 		let cc = new NotificationCCReport({
 			nodeId: mockController.ownNodeId,
@@ -314,170 +308,315 @@ integrationTest("The 'simple' Door state value works correctly", {
 	},
 });
 
-integrationTest("The synthetic 'Door tilt state' value works correctly", {
-	// debug: true,
+integrationTest(
+	"The synthetic 'Opening state' value works correctly",
+	{
+		// debug: true,
 
-	nodeCapabilities: {
-		commandClasses: [
-			CommandClasses.Version,
-			{
-				ccId: CommandClasses.Notification,
-				isSupported: true,
-				version: 8,
-				supportsV1Alarm: false,
-				notificationTypesAndEvents: {
-					// Access Control - Window open and Window closed
-					[0x06]: [0x16, 0x17],
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				{
+					ccId: CommandClasses.Notification,
+					isSupported: true,
+					version: 8,
+					supportsV1Alarm: false,
+					notificationTypesAndEvents: {
+						// Access Control - Window open and Window closed
+						[0x06]: [0x16, 0x17],
+					},
 				},
-			},
-		],
-	},
+			],
+		},
 
-	testBody: async (t, driver, node, mockController, mockNode) => {
-		await node.commandClasses.Notification.getSupportedEvents(0x06);
-
-		const tiltVID = NotificationCCValues.doorTiltState.id;
-
-		const hasTiltVID = () =>
-			node.getDefinedValueIDs().some(
-				(vid) => NotificationCCValues.doorTiltState.is(vid),
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const valueIDs = node.getDefinedValueIDs();
+			const openingStateVID = valueIDs.find(
+				(vid) =>
+					vid.commandClass === CommandClasses.Notification
+					&& vid.propertyKey === "Opening state",
 			);
-		// Before receiving any notifications with the tilt enum, the synthetic value should not exist
-		t.expect(hasTiltVID()).toBe(false);
+			t.expect(openingStateVID).toBeTruthy();
 
-		// Send a notification to the node where the window is not tilted
-		let cc = new NotificationCCReport({
-			nodeId: mockController.ownNodeId,
-			notificationType: 0x06,
-			notificationEvent: 0x16, // Window/door is open
-			eventParameters: Uint8Array.from([0x00]), // ... in regular position
-		});
-		await mockNode.sendToController(
-			createMockZWaveRequestFrame(cc, {
-				ackRequested: false,
-			}),
-		);
-		// wait a bit for the value to be updated
-		await wait(100);
+			const getOpeningStateMeta = () =>
+				node.getValueMetadata(openingStateVID!) as ValueMetadataNumeric;
 
-		// The value should still not exist
-		t.expect(hasTiltVID()).toBe(false);
+			t.expect(getOpeningStateMeta()).toMatchObject({
+				ccSpecific: { notificationType: 6 },
+				label: "Opening state",
+				readable: true,
+				states: {
+					[0x00]: "Closed",
+					[0x01]: "Open",
+				},
+				type: "number",
+				writeable: false,
+			});
 
-		// ===
+			let cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
 
-		// Again with tilt
-		cc = new NotificationCCReport({
-			nodeId: mockController.ownNodeId,
-			notificationType: 0x06,
-			notificationEvent: 0x16, // Window/door is open
-			eventParameters: Uint8Array.from([0x01]), // ... in tilt position
-		});
-		await mockNode.sendToController(
-			createMockZWaveRequestFrame(cc, {
-				ackRequested: false,
-			}),
-		);
-		// wait a bit for the value to be updated
-		await wait(100);
+			t.expect(node.getValue(openingStateVID!)).toBe(0x01);
+			t.expect(getOpeningStateMeta().states).toStrictEqual({
+				[0x00]: "Closed",
+				[0x01]: "Open",
+			});
 
-		// The value should now exist
-		t.expect(hasTiltVID()).toBe(true);
-		t.expect(node.getValue(tiltVID)).toBe(0x01);
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+				eventParameters: Uint8Array.from([0x00]), // ... in regular position
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
 
-		// ===
+			t.expect(node.getValue(openingStateVID!)).toBe(0x01);
+			t.expect(getOpeningStateMeta().states).toStrictEqual({
+				[0x00]: "Closed",
+				[0x01]: "Open",
+			});
 
-		// Again without tilt
-		cc = new NotificationCCReport({
-			nodeId: mockController.ownNodeId,
-			notificationType: 0x06,
-			notificationEvent: 0x16, // Window/door is open
-			eventParameters: Uint8Array.from([0x00]), // ... in regular position
-		});
-		await mockNode.sendToController(
-			createMockZWaveRequestFrame(cc, {
-				ackRequested: false,
-			}),
-		);
-		// wait a bit for the value to be updated
-		await wait(100);
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+				eventParameters: Uint8Array.from([0x01]), // ... in tilt position
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
 
-		t.expect(node.getValue(tiltVID)).toBe(0x00);
+			t.expect(node.getValue(openingStateVID!)).toBe(0x02);
+			t.expect(getOpeningStateMeta().states).toStrictEqual({
+				[0x00]: "Closed",
+				[0x01]: "Open",
+				[0x02]: "Tilted",
+			});
 
-		// ===
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x17, // Window/door is closed
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
 
-		// Again with tilt to be able to detect changes
-		cc = new NotificationCCReport({
-			nodeId: mockController.ownNodeId,
-			notificationType: 0x06,
-			notificationEvent: 0x16, // Window/door is open
-			eventParameters: Uint8Array.from([0x01]), // ... in tilt position
-		});
-		await mockNode.sendToController(
-			createMockZWaveRequestFrame(cc, {
-				ackRequested: false,
-			}),
-		);
-		// wait a bit for the value to be updated
-		await wait(100);
+			t.expect(node.getValue(openingStateVID!)).toBe(0x00);
+			t.expect(getOpeningStateMeta().states).toStrictEqual({
+				[0x00]: "Closed",
+				[0x01]: "Open",
+				[0x02]: "Tilted",
+			});
 
-		t.expect(node.getValue(tiltVID)).toBe(0x01);
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			await wait(100);
 
-		// ===
-
-		// And now without the enum
-		cc = new NotificationCCReport({
-			nodeId: mockController.ownNodeId,
-			notificationType: 0x06,
-			notificationEvent: 0x17, // Window/door is closed
-		});
-		await mockNode.sendToController(
-			createMockZWaveRequestFrame(cc, {
-				ackRequested: false,
-			}),
-		);
-		// wait a bit for the value to be updated
-		await wait(100);
-
-		t.expect(node.getValue(tiltVID)).toBe(0x00);
-
-		// ===
-
-		// Again with tilt to be able to detect changes
-		cc = new NotificationCCReport({
-			nodeId: mockController.ownNodeId,
-			notificationType: 0x06,
-			notificationEvent: 0x16, // Window/door is open
-			eventParameters: Uint8Array.from([0x01]), // ... in tilt position
-		});
-		await mockNode.sendToController(
-			createMockZWaveRequestFrame(cc, {
-				ackRequested: false,
-			}),
-		);
-		// wait a bit for the value to be updated
-		await wait(100);
-
-		t.expect(node.getValue(tiltVID)).toBe(0x01);
-
-		// ===
-
-		// And again without the enum
-		cc = new NotificationCCReport({
-			nodeId: mockController.ownNodeId,
-			notificationType: 0x06,
-			notificationEvent: 0x16, // Window/door is open
-		});
-		await mockNode.sendToController(
-			createMockZWaveRequestFrame(cc, {
-				ackRequested: false,
-			}),
-		);
-		// wait a bit for the value to be updated
-		await wait(100);
-
-		t.expect(node.getValue(tiltVID)).toBe(0x00);
+			t.expect(node.getValue(openingStateVID!)).toBe(0x01);
+			t.expect(getOpeningStateMeta().states).toStrictEqual({
+				[0x00]: "Closed",
+				[0x01]: "Open",
+				[0x02]: "Tilted",
+			});
+		},
 	},
-});
+);
+
+integrationTest(
+	"The synthetic 'Door tilt state' value works correctly",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				CommandClasses.Version,
+				{
+					ccId: CommandClasses.Notification,
+					isSupported: true,
+					version: 8,
+					supportsV1Alarm: false,
+					notificationTypesAndEvents: {
+						// Access Control - Window open and Window closed
+						[0x06]: [0x16, 0x17],
+					},
+				},
+			],
+		},
+
+		testBody: async (t, driver, node, mockController, mockNode) => {
+			const tiltVID = NotificationCCValues.deprecated_doorTiltState.id;
+
+			const hasTiltVID = () =>
+				node.getDefinedValueIDs().some(
+					(vid) =>
+						NotificationCCValues.deprecated_doorTiltState.is(vid),
+				);
+			// Before receiving any notifications with the tilt enum, the synthetic value should not exist
+			t.expect(hasTiltVID()).toBe(false);
+
+			// Send a notification to the node where the window is not tilted
+			let cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+				eventParameters: Uint8Array.from([0x00]), // ... in regular position
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			// The value should still not exist
+			t.expect(hasTiltVID()).toBe(false);
+
+			// ===
+
+			// Again with tilt
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+				eventParameters: Uint8Array.from([0x01]), // ... in tilt position
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			// The value should now exist
+			t.expect(hasTiltVID()).toBe(true);
+			t.expect(node.getValue(tiltVID)).toBe(0x01);
+
+			// ===
+
+			// Again without tilt
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+				eventParameters: Uint8Array.from([0x00]), // ... in regular position
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			t.expect(node.getValue(tiltVID)).toBe(0x00);
+
+			// ===
+
+			// Again with tilt to be able to detect changes
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+				eventParameters: Uint8Array.from([0x01]), // ... in tilt position
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			t.expect(node.getValue(tiltVID)).toBe(0x01);
+
+			// ===
+
+			// And now without the enum
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x17, // Window/door is closed
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			t.expect(node.getValue(tiltVID)).toBe(0x00);
+
+			// ===
+
+			// Again with tilt to be able to detect changes
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+				eventParameters: Uint8Array.from([0x01]), // ... in tilt position
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			t.expect(node.getValue(tiltVID)).toBe(0x01);
+
+			// ===
+
+			// And again without the enum
+			cc = new NotificationCCReport({
+				nodeId: mockController.ownNodeId,
+				notificationType: 0x06,
+				notificationEvent: 0x16, // Window/door is open
+			});
+			await mockNode.sendToController(
+				createMockZWaveRequestFrame(cc, {
+					ackRequested: false,
+				}),
+			);
+			// wait a bit for the value to be updated
+			await wait(100);
+
+			t.expect(node.getValue(tiltVID)).toBe(0x00);
+		},
+	},
+);
 
 integrationTest(
 	"Notification types with 'replace'-type enums fall back to the default value if the event parameter is not contained in the CC",

--- a/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
@@ -44,8 +44,7 @@ integrationTest(
 		},
 
 		async testBody(t, driver, node, mockController, mockNode) {
-			const doorStateSimpleId = NotificationCCValues.doorStateSimple
-				.endpoint(0);
+			const doorStateSimpleId = NotificationCCValues.deprecated_doorStateSimple.id;
 
 			// Send event 0x01 - should be remapped to door open (0x16) and sync doorStateSimple
 			let cc = new NotificationCCReport({

--- a/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
+++ b/packages/zwave-js/src/lib/test/compat/notificationRemappingDoorState.test.ts
@@ -44,7 +44,8 @@ integrationTest(
 		},
 
 		async testBody(t, driver, node, mockController, mockNode) {
-			const doorStateSimpleId = NotificationCCValues.deprecated_doorStateSimple.id;
+			const doorStateSimpleId =
+				NotificationCCValues.deprecated_doorStateSimple.id;
 
 			// Send event 0x01 - should be remapped to door open (0x16) and sync doorStateSimple
 			let cc = new NotificationCCReport({


### PR DESCRIPTION
The notification variables for "Door state" are a mess. We tried to fix this in the past with the "Door state (simple)" and later the "Door tilt state", but this causes even more of a mess in applications.

This PR deprecates all of those state variables in favor of a new, synthetic "Opening state" variable with 3 states: Closed, Open, Tilted.
Since there is no way to query support, the Tilted state is only added dynamically at runtime, once it has been observed.

For: zwave-js/backlog#23