### PR TITLE
ci: limit Dependabot to direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       timezone: Europe/Berlin
     open-pull-requests-limit: 5
     versioning-strategy: increase
+    allow:
+      # Z-Wave JS is a library. We have no control over which transient dependencies
+      # get installed when Z-Wave JS is used elsewhere.
+      - dependency-type: "direct"
     ignore:
       # Typescript should not be updated automatically, except patch updates
       # it does not follow semver and minor updates are usually breaking

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     allow:
       # Z-Wave JS is a library. We have no control over which transient dependencies
       # get installed when Z-Wave JS is used elsewhere.
-      - dependency-type: "direct"
+      - dependency-type: 'direct'
     ignore:
       # Typescript should not be updated automatically, except patch updates
       # it does not follow semver and minor updates are usually breaking


### PR DESCRIPTION
This should prevent Dependabot from updating transient dependencies in yarn.lock which only affect the dev environment.