### PR TITLE
fix: expose failed locking attempts for Door Lock CC through setValue API

### DIFF
--- a/packages/cc/src/cc/DoorLockCC.ts
+++ b/packages/cc/src/cc/DoorLockCC.ts
@@ -12,6 +12,7 @@ import {
 	type WithAddress,
 	ZWaveError,
 	ZWaveErrorCodes,
+	encodeBitMask,
 	enumValuesToMetadataStates,
 	parseBitMask,
 	supervisedCommandSucceeded,
@@ -920,18 +921,16 @@ export class DoorLockCCOperationSet extends DoorLockCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): DoorLockCCOperationSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
+		validatePayload(raw.payload.length >= 1);
+		const mode: DoorLockMode = raw.payload[0];
 
-		// return new DoorLockCCOperationSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			mode,
+		});
 	}
 
 	public mode: DoorLockMode;
@@ -1050,6 +1049,44 @@ export class DoorLockCCOperationReport extends DoorLockCC {
 			targetMode,
 			duration,
 		});
+	}
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const handles = [
+			...this.insideHandlesCanOpenDoor,
+			...this.outsideHandlesCanOpenDoor,
+		]
+			.map((val, i) => (val ? 1 << i : 0))
+			.reduce((acc, cur) => acc | cur, 0);
+
+		const doorCondition = (this.doorStatus === "closed" ? 0b1 : 0)
+			| (this.boltStatus === "unlocked" ? 0b10 : 0)
+			| (this.latchStatus === "closed" ? 0b100 : 0);
+
+		let lockTimeoutMinutes = 0xfe;
+		let lockTimeoutSeconds = 0xfe;
+		if (this.lockTimeout != undefined) {
+			lockTimeoutMinutes = Math.floor(this.lockTimeout / 60);
+			lockTimeoutSeconds = this.lockTimeout % 60;
+		}
+
+		const payload = [
+			this.currentMode,
+			handles,
+			doorCondition,
+			lockTimeoutMinutes,
+			lockTimeoutSeconds,
+		];
+
+		if (this.targetMode != undefined) {
+			payload.push(this.targetMode);
+			payload.push(
+				(this.duration ?? Duration.default()).serializeReport(),
+			);
+		}
+
+		this.payload = Bytes.from(payload);
+		return super.serialize(ctx);
 	}
 
 	public persistValues(ctx: PersistValuesContext): boolean {
@@ -1248,6 +1285,57 @@ export class DoorLockCCConfigurationReport extends DoorLockCC {
 		});
 	}
 
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		const handles = [
+			...this.insideHandlesCanOpenDoorConfiguration,
+			...this.outsideHandlesCanOpenDoorConfiguration,
+		]
+			.map((val, i) => (val ? 1 << i : 0))
+			.reduce((acc, cur) => acc | cur, 0);
+
+		let lockTimeoutMinutes: number;
+		let lockTimeoutSeconds: number;
+		if (
+			this.operationType === DoorLockOperationType.Timed
+			&& this.lockTimeoutConfiguration != undefined
+		) {
+			lockTimeoutMinutes = Math.floor(
+				this.lockTimeoutConfiguration / 60,
+			);
+			lockTimeoutSeconds = this.lockTimeoutConfiguration % 60;
+		} else {
+			lockTimeoutMinutes = lockTimeoutSeconds = 0xfe;
+		}
+
+		const flags = (this.twistAssist ? 0b1 : 0)
+			| (this.blockToBlock ? 0b10 : 0);
+
+		this.payload = Bytes.from([
+			this.operationType,
+			handles,
+			lockTimeoutMinutes,
+			lockTimeoutSeconds,
+		]);
+
+		if (
+			this.autoRelockTime != undefined
+			|| this.holdAndReleaseTime != undefined
+			|| this.twistAssist != undefined
+			|| this.blockToBlock != undefined
+		) {
+			const extended = Bytes.alloc(5);
+			extended.writeUInt16BE((this.autoRelockTime ?? 0) & 0xffff, 0);
+			extended.writeUInt16BE(
+				(this.holdAndReleaseTime ?? 0) & 0xffff,
+				2,
+			);
+			extended[4] = flags;
+			this.payload = Bytes.concat([this.payload, extended]);
+		}
+
+		return super.serialize(ctx);
+	}
+
 	public readonly operationType: DoorLockOperationType;
 
 	public readonly outsideHandlesCanOpenDoorConfiguration: DoorHandleStatus;
@@ -1398,18 +1486,57 @@ export class DoorLockCCConfigurationSet extends DoorLockCC {
 	}
 
 	public static from(
-		_raw: CCRaw,
-		_ctx: CCParsingContext,
+		raw: CCRaw,
+		ctx: CCParsingContext,
 	): DoorLockCCConfigurationSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
+		validatePayload(raw.payload.length >= 4);
+		const operationType: DoorLockOperationType = raw.payload[0];
+		const outsideHandlesCanOpenDoorConfiguration: DoorHandleStatus = [
+			!!(raw.payload[1] & 0b0001_0000),
+			!!(raw.payload[1] & 0b0010_0000),
+			!!(raw.payload[1] & 0b0100_0000),
+			!!(raw.payload[1] & 0b1000_0000),
+		];
+		const insideHandlesCanOpenDoorConfiguration: DoorHandleStatus = [
+			!!(raw.payload[1] & 0b0001),
+			!!(raw.payload[1] & 0b0010),
+			!!(raw.payload[1] & 0b0100),
+			!!(raw.payload[1] & 0b1000),
+		];
 
-		// return new DoorLockCCConfigurationSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		let lockTimeoutConfiguration: number | undefined;
+		if (operationType === DoorLockOperationType.Timed) {
+			const lockTimeoutMinutes = raw.payload[2];
+			const lockTimeoutSeconds = raw.payload[3];
+			if (lockTimeoutMinutes <= 0xfd && lockTimeoutSeconds <= 59) {
+				lockTimeoutConfiguration = lockTimeoutSeconds
+					+ lockTimeoutMinutes * 60;
+			}
+		}
+
+		let autoRelockTime: number | undefined;
+		let holdAndReleaseTime: number | undefined;
+		let twistAssist: boolean | undefined;
+		let blockToBlock: boolean | undefined;
+		if (raw.payload.length >= 9) {
+			autoRelockTime = raw.payload.readUInt16BE(4);
+			holdAndReleaseTime = raw.payload.readUInt16BE(6);
+			const flags = raw.payload[8];
+			twistAssist = !!(flags & 0b1);
+			blockToBlock = !!(flags & 0b10);
+		}
+
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			operationType,
+			outsideHandlesCanOpenDoorConfiguration,
+			insideHandlesCanOpenDoorConfiguration,
+			lockTimeoutConfiguration,
+			autoRelockTime,
+			holdAndReleaseTime,
+			twistAssist,
+			blockToBlock,
+		} as WithAddress<DoorLockCCConfigurationSetOptions>);
 	}
 
 	public operationType: DoorLockOperationType;
@@ -1652,6 +1779,44 @@ export class DoorLockCCCapabilitiesReport extends DoorLockCC {
 	public readonly twistAssistSupported: boolean;
 
 	public readonly blockToBlockSupported: boolean;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		// Operation type bitmask (variable length)
+		const operationTypeMask = encodeBitMask(
+			this.supportedOperationTypes,
+			undefined,
+			0,
+		);
+
+		// Door lock mode list
+		const modeList = Bytes.from(this.supportedDoorLockModes as number[]);
+
+		const handles = [
+			...this.supportedInsideHandles,
+			...this.supportedOutsideHandles,
+		]
+			.map((val, i) => (val ? 1 << i : 0))
+			.reduce((acc, cur) => acc | cur, 0);
+
+		const componentStatus = (this.doorSupported ? 0b1 : 0)
+			| (this.boltSupported ? 0b10 : 0)
+			| (this.latchSupported ? 0b100 : 0);
+
+		const featureFlags = (this.blockToBlockSupported ? 0b1 : 0)
+			| (this.twistAssistSupported ? 0b10 : 0)
+			| (this.holdAndReleaseSupported ? 0b100 : 0)
+			| (this.autoRelockSupported ? 0b1000 : 0);
+
+		this.payload = Bytes.concat([
+			[operationTypeMask.length & 0b11111],
+			operationTypeMask,
+			[modeList.length],
+			modeList,
+			[handles, componentStatus, featureFlags],
+		]);
+
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {

--- a/packages/cc/src/cc/DoorLockCC.ts
+++ b/packages/cc/src/cc/DoorLockCC.ts
@@ -8,6 +8,7 @@ import {
 	MessagePriority,
 	type MessageRecord,
 	type SupervisionResult,
+	SupervisionStatus,
 	ValueMetadata,
 	type WithAddress,
 	ZWaveError,
@@ -27,7 +28,9 @@ import {
 	PhysicalCCAPI,
 	type PollValueImplementation,
 	SET_VALUE,
+	SET_VALUE_HOOKS,
 	type SetValueImplementation,
+	type SetValueImplementationHooksFactory,
 	throwUnsupportedProperty,
 	throwWrongValueType,
 } from "../lib/API.js";
@@ -350,21 +353,7 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 						typeof value,
 					);
 				}
-				const result = await this.set(value);
-
-				// Verify the current value after a delay, unless the command was supervised and successful
-				if (supervisedCommandSucceeded(result)) {
-					this.getValueDB().setValue(
-						DoorLockCCValues.currentMode.endpoint(
-							this.endpoint.index,
-						),
-						value,
-					);
-				} else {
-					this.schedulePoll({ property }, value);
-				}
-
-				return result;
+				return this.set(value);
 			} else if (
 				typeof property === "string"
 				&& configurationSetParameters.includes(property as any)
@@ -409,6 +398,64 @@ export class DoorLockCCAPI extends PhysicalCCAPI {
 			}
 		};
 	}
+
+	protected [SET_VALUE_HOOKS]: SetValueImplementationHooksFactory = (
+		{ property },
+		value,
+	) => {
+		if (property === "targetMode" && typeof value === "number") {
+			const targetMode = value;
+			const currentModeValueId = DoorLockCCValues.currentMode.endpoint(
+				this.endpoint.index,
+			);
+
+			return {
+				isSplitStateTargetValue: true,
+				supervisionDelayedUpdates: true,
+				optimisticallyUpdateRelatedValues: (
+					_supervisedAndSuccessful,
+				) => {
+					this.tryGetValueDB()?.setValue(
+						currentModeValueId,
+						targetMode,
+					);
+				},
+				supervisionOnSuccess: () => {
+					this.tryGetValueDB()?.setValue(
+						currentModeValueId,
+						targetMode,
+					);
+				},
+				supervisionOnFailure: async () => {
+					try {
+						await this.get();
+					} catch {
+						// ignore
+					}
+				},
+				verifyChanges: async (result) => {
+					switch (result?.status) {
+						case SupervisionStatus.Success:
+						case SupervisionStatus.Working:
+							return;
+						case SupervisionStatus.Fail:
+						case SupervisionStatus.NoSupport:
+							try {
+								await this.get();
+							} catch {
+								// ignore
+							}
+							return;
+						default:
+							this.schedulePoll(
+								{ property: "currentMode" },
+								targetMode,
+							);
+					}
+				},
+			};
+		}
+	};
 
 	protected get [POLL_VALUE](): PollValueImplementation {
 		return async function(this: DoorLockCCAPI, { property }) {

--- a/packages/cc/src/cc/LockCC.ts
+++ b/packages/cc/src/cc/LockCC.ts
@@ -7,8 +7,6 @@ import {
 	type SupervisionResult,
 	ValueMetadata,
 	type WithAddress,
-	ZWaveError,
-	ZWaveErrorCodes,
 	supervisedCommandSucceeded,
 	validatePayload,
 } from "@zwave-js/core";
@@ -194,16 +192,14 @@ export class LockCCSet extends LockCC {
 		this.locked = options.locked;
 	}
 
-	public static from(_raw: CCRaw, _ctx: CCParsingContext): LockCCSet {
-		// TODO: Deserialize payload
-		throw new ZWaveError(
-			`${this.name}: deserialization not implemented`,
-			ZWaveErrorCodes.Deserialization_NotImplemented,
-		);
+	public static from(raw: CCRaw, ctx: CCParsingContext): LockCCSet {
+		validatePayload(raw.payload.length >= 1);
+		const locked = raw.payload[0] === 1;
 
-		// return new LockCCSet({
-		// 	nodeId: ctx.sourceNodeId,
-		// });
+		return new this({
+			nodeId: ctx.sourceNodeId,
+			locked,
+		});
 	}
 
 	public locked: boolean;
@@ -249,6 +245,11 @@ export class LockCCReport extends LockCC {
 	}
 
 	public readonly locked: boolean;
+
+	public serialize(ctx: CCEncodingContext): Promise<Bytes> {
+		this.payload = Bytes.from([this.locked ? 1 : 0]);
+		return super.serialize(ctx);
+	}
 
 	public toLogEntry(ctx?: GetValueDB): MessageOrCCLogEntry {
 		return {

--- a/packages/testing/src/CCSpecificCapabilities.ts
+++ b/packages/testing/src/CCSpecificCapabilities.ts
@@ -1,5 +1,8 @@
 import type {
 	ColorComponent,
+	DoorHandleStatus,
+	DoorLockMode,
+	DoorLockOperationType,
 	KeypadMode,
 	SwitchType,
 	ThermostatMode,
@@ -47,6 +50,35 @@ export interface ConfigurationCCCapabilities {
 		isAdvanced?: boolean;
 		altersCapabilities?: boolean;
 	}[];
+}
+
+export interface LockCCCapabilities {
+	/**
+	 * Time in milliseconds for the lock to travel.
+	 * Set to 0 to lock/unlock instantly.
+	 * Default: 0
+	 */
+	travelTime?: number;
+}
+
+export interface DoorLockCCCapabilities {
+	supportedOperationTypes: DoorLockOperationType[];
+	supportedDoorLockModes: DoorLockMode[];
+	supportedOutsideHandles?: DoorHandleStatus;
+	supportedInsideHandles?: DoorHandleStatus;
+	doorSupported?: boolean;
+	boltSupported?: boolean;
+	latchSupported?: boolean;
+	blockToBlockSupported?: boolean;
+	twistAssistSupported?: boolean;
+	holdAndReleaseSupported?: boolean;
+	autoRelockSupported?: boolean;
+	/**
+	 * Time in milliseconds for the lock to travel.
+	 * Set to 0 to lock/unlock instantly.
+	 * Default: 0
+	 */
+	travelTime?: number;
 }
 
 export interface ColorSwitchCCCapabilities {
@@ -215,6 +247,8 @@ export type CCSpecificCapabilities = {
 	[0x77 /* Node Naming and Location */]: NodeNamingAndLocationCCCapabilities;
 	[48 /* Binary Sensor */]: BinarySensorCCCapabilities;
 	[0x25 /* Binary Switch */]: BinarySwitchCCCapabilities;
+	[0x62 /* Door Lock */]: DoorLockCCCapabilities;
+	[0x76 /* Lock */]: LockCCCapabilities;
 	[49 /* Multilevel Sensor */]: MultilevelSensorCCCapabilities;
 	[0x26 /* Multilevel Switch */]: MultilevelSwitchCCCapabilities;
 	[51 /* Color Switch */]: ColorSwitchCCCapabilities;

--- a/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
+++ b/packages/zwave-js/src/lib/node/MockNodeBehaviors.ts
@@ -24,8 +24,10 @@ import { BinarySensorCCBehaviors } from "./mockCCBehaviors/BinarySensor.js";
 import { BinarySwitchCCBehaviors } from "./mockCCBehaviors/BinarySwitch.js";
 import { ColorSwitchCCBehaviors } from "./mockCCBehaviors/ColorSwitch.js";
 import { ConfigurationCCBehaviors } from "./mockCCBehaviors/Configuration.js";
+import { DoorLockCCBehaviors } from "./mockCCBehaviors/DoorLock.js";
 import { EnergyProductionCCBehaviors } from "./mockCCBehaviors/EnergyProduction.js";
 import { IndicatorCCBehaviors } from "./mockCCBehaviors/Indicator.js";
+import { LockCCBehaviors } from "./mockCCBehaviors/Lock.js";
 import { ManufacturerSpecificCCBehaviors } from "./mockCCBehaviors/ManufacturerSpecific.js";
 import { MeterCCBehaviors } from "./mockCCBehaviors/Meter.js";
 import {
@@ -214,7 +216,9 @@ export function createDefaultBehaviors(): MockNodeBehavior[] {
 		...BinarySwitchCCBehaviors,
 		...ColorSwitchCCBehaviors,
 		...ConfigurationCCBehaviors,
+		...DoorLockCCBehaviors,
 		...EnergyProductionCCBehaviors,
+		...LockCCBehaviors,
 		...IndicatorCCBehaviors,
 		...ManufacturerSpecificCCBehaviors,
 		...MeterCCBehaviors,

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/DoorLock.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/DoorLock.ts
@@ -1,0 +1,342 @@
+import {
+	type CommandClass,
+	DoorLockMode,
+	DoorLockOperationType,
+} from "@zwave-js/cc";
+import {
+	DoorLockCCCapabilitiesGet,
+	DoorLockCCCapabilitiesReport,
+	DoorLockCCConfigurationGet,
+	DoorLockCCConfigurationReport,
+	DoorLockCCConfigurationSet,
+	DoorLockCCOperationGet,
+	DoorLockCCOperationReport,
+	DoorLockCCOperationSet,
+} from "@zwave-js/cc/DoorLockCC";
+import { CommandClasses, Duration } from "@zwave-js/core";
+import { type Timer, setTimer } from "@zwave-js/shared";
+import type {
+	DoorLockCCCapabilities,
+	MockController,
+	MockNode,
+	MockNodeBehavior,
+} from "@zwave-js/testing";
+
+const defaultCapabilities: Required<DoorLockCCCapabilities> = {
+	supportedOperationTypes: [DoorLockOperationType.Constant],
+	supportedDoorLockModes: [DoorLockMode.Unsecured, DoorLockMode.Secured],
+	supportedOutsideHandles: [true, true, true, true],
+	supportedInsideHandles: [true, true, true, true],
+	doorSupported: true,
+	boltSupported: true,
+	latchSupported: true,
+	blockToBlockSupported: false,
+	twistAssistSupported: false,
+	holdAndReleaseSupported: false,
+	autoRelockSupported: false,
+	travelTime: 0,
+};
+
+const STATE_KEY_PREFIX = "DoorLock_";
+const StateKeys = {
+	currentMode: `${STATE_KEY_PREFIX}currentMode`,
+	transition: `${STATE_KEY_PREFIX}transition`,
+	operationType: `${STATE_KEY_PREFIX}operationType`,
+	outsideHandlesCanOpenDoorConfiguration:
+		`${STATE_KEY_PREFIX}outsideHandlesCanOpenDoorConfiguration`,
+	insideHandlesCanOpenDoorConfiguration:
+		`${STATE_KEY_PREFIX}insideHandlesCanOpenDoorConfiguration`,
+	lockTimeoutConfiguration: `${STATE_KEY_PREFIX}lockTimeoutConfiguration`,
+	autoRelockTime: `${STATE_KEY_PREFIX}autoRelockTime`,
+	holdAndReleaseTime: `${STATE_KEY_PREFIX}holdAndReleaseTime`,
+	twistAssist: `${STATE_KEY_PREFIX}twistAssist`,
+	blockToBlock: `${STATE_KEY_PREFIX}blockToBlock`,
+} as const;
+
+interface DoorLockTransition {
+	targetMode: DoorLockMode;
+	startTime: number;
+	durationMs: number;
+	timer: Timer;
+	supervised: boolean;
+}
+
+function getTransitionRemainingDuration(
+	transition: DoorLockTransition,
+): Duration {
+	const remaining = Math.max(
+		0,
+		transition.durationMs - (Date.now() - transition.startTime),
+	);
+	return new Duration(Math.ceil(remaining / 1000), "seconds");
+}
+
+/** Stops any running transition and snaps state to the target. */
+function stopCurrentTransition(
+	self: MockNode,
+): { wasSupervised: boolean } | undefined {
+	const existing = self.state.get(
+		StateKeys.transition,
+	) as DoorLockTransition | undefined;
+	if (existing) {
+		existing.timer.clear();
+		self.state.set(StateKeys.currentMode, existing.targetMode);
+		self.state.delete(StateKeys.transition);
+		return { wasSupervised: existing.supervised };
+	}
+}
+
+/**
+ * Stops any existing transition, then starts a new one.
+ * Returns the transition duration in milliseconds (0 = instant).
+ */
+function beginTransition(
+	controller: MockController,
+	self: MockNode,
+	receivedCC: CommandClass,
+	targetMode: DoorLockMode,
+	travelTime: number,
+	supervised: boolean,
+	onCompleteSupervised?: () => Promise<void>,
+): number {
+	stopCurrentTransition(self);
+
+	const currentMode = (
+		self.state.get(StateKeys.currentMode) ?? DoorLockMode.Unsecured
+	) as DoorLockMode;
+
+	if (currentMode === targetMode || travelTime === 0) {
+		self.state.set(StateKeys.currentMode, targetMode);
+		return 0;
+	}
+
+	const timer = setTimer(async () => {
+		self.state.set(StateKeys.currentMode, targetMode);
+		self.state.delete(StateKeys.transition);
+
+		if (supervised) {
+			await onCompleteSupervised?.();
+			return;
+		}
+
+		const cc = new DoorLockCCOperationReport({
+			nodeId: controller.ownNodeId,
+			currentMode: targetMode,
+			outsideHandlesCanOpenDoor: [true, true, true, true],
+			insideHandlesCanOpenDoor: [true, true, true, true],
+			targetMode,
+			duration: new Duration(0, "seconds"),
+		});
+		await self.sendResponse(receivedCC, {
+			action: "sendCC",
+			cc,
+		});
+	}, travelTime).unref();
+
+	const transition: DoorLockTransition = {
+		targetMode,
+		startTime: Date.now(),
+		durationMs: travelTime,
+		timer,
+		supervised,
+	};
+	self.state.set(StateKeys.transition, transition);
+	return travelTime;
+}
+
+const respondToDoorLockCapabilitiesGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof DoorLockCCCapabilitiesGet) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses["Door Lock"],
+					receivedCC.endpointIndex,
+				),
+			};
+			const cc = new DoorLockCCCapabilitiesReport({
+				nodeId: controller.ownNodeId,
+				supportedOperationTypes: capabilities.supportedOperationTypes,
+				supportedDoorLockModes: capabilities.supportedDoorLockModes,
+				supportedOutsideHandles: capabilities.supportedOutsideHandles,
+				supportedInsideHandles: capabilities.supportedInsideHandles,
+				doorSupported: capabilities.doorSupported,
+				boltSupported: capabilities.boltSupported,
+				latchSupported: capabilities.latchSupported,
+				blockToBlockSupported: capabilities.blockToBlockSupported,
+				twistAssistSupported: capabilities.twistAssistSupported,
+				holdAndReleaseSupported: capabilities.holdAndReleaseSupported,
+				autoRelockSupported: capabilities.autoRelockSupported,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToDoorLockOperationGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof DoorLockCCOperationGet) {
+			const transition = self.state.get(
+				StateKeys.transition,
+			) as DoorLockTransition | undefined;
+
+			let currentMode: DoorLockMode;
+			let targetMode: DoorLockMode | undefined;
+			let duration: Duration | undefined;
+
+			if (transition) {
+				// Lock is still moving - report the mode before the transition
+				currentMode = (
+					self.state.get(StateKeys.currentMode)
+						?? DoorLockMode.Unsecured
+				) as DoorLockMode;
+				targetMode = transition.targetMode;
+				duration = getTransitionRemainingDuration(transition);
+			} else {
+				currentMode = (
+					self.state.get(StateKeys.currentMode)
+						?? DoorLockMode.Unsecured
+				) as DoorLockMode;
+				targetMode = currentMode;
+				duration = new Duration(0, "seconds");
+			}
+
+			const cc = new DoorLockCCOperationReport({
+				nodeId: controller.ownNodeId,
+				currentMode,
+				outsideHandlesCanOpenDoor: [true, true, true, true],
+				insideHandlesCanOpenDoor: [true, true, true, true],
+				targetMode,
+				duration,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToDoorLockOperationSet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof DoorLockCCOperationSet) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses["Door Lock"],
+					receivedCC.endpointIndex,
+				),
+			};
+			const supervised = receivedCC.isEncapsulatedWith(
+				CommandClasses.Supervision,
+			);
+			const durationMs = beginTransition(
+				controller,
+				self,
+				receivedCC,
+				receivedCC.mode,
+				capabilities.travelTime,
+				supervised,
+				async () =>
+					self.sendResponse(receivedCC, {
+						action: "ok",
+					}),
+			);
+			return {
+				action: "ok",
+				durationMs,
+			};
+		}
+	},
+};
+
+const respondToDoorLockConfigurationGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof DoorLockCCConfigurationGet) {
+			const operationType = (
+				self.state.get(StateKeys.operationType)
+					?? DoorLockOperationType.Constant
+			) as DoorLockOperationType;
+			const outsideHandlesCanOpenDoorConfiguration = (self.state.get(
+				StateKeys.outsideHandlesCanOpenDoorConfiguration,
+			) ?? [true, true, true, true]) as [
+				boolean,
+				boolean,
+				boolean,
+				boolean,
+			];
+			const insideHandlesCanOpenDoorConfiguration = (self.state.get(
+				StateKeys.insideHandlesCanOpenDoorConfiguration,
+			) ?? [true, true, true, true]) as [
+				boolean,
+				boolean,
+				boolean,
+				boolean,
+			];
+			const lockTimeoutConfiguration = self.state.get(
+				StateKeys.lockTimeoutConfiguration,
+			) as number | undefined;
+			const autoRelockTime = self.state.get(
+				StateKeys.autoRelockTime,
+			) as number | undefined;
+			const holdAndReleaseTime = self.state.get(
+				StateKeys.holdAndReleaseTime,
+			) as number | undefined;
+			const twistAssist = self.state.get(
+				StateKeys.twistAssist,
+			) as boolean | undefined;
+			const blockToBlock = self.state.get(
+				StateKeys.blockToBlock,
+			) as boolean | undefined;
+
+			const cc = new DoorLockCCConfigurationReport({
+				nodeId: controller.ownNodeId,
+				operationType,
+				outsideHandlesCanOpenDoorConfiguration,
+				insideHandlesCanOpenDoorConfiguration,
+				lockTimeoutConfiguration,
+				autoRelockTime,
+				holdAndReleaseTime,
+				twistAssist,
+				blockToBlock,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToDoorLockConfigurationSet: MockNodeBehavior = {
+	handleCC(_controller, self, receivedCC) {
+		if (receivedCC instanceof DoorLockCCConfigurationSet) {
+			self.state.set(StateKeys.operationType, receivedCC.operationType);
+			self.state.set(
+				StateKeys.outsideHandlesCanOpenDoorConfiguration,
+				receivedCC.outsideHandlesCanOpenDoorConfiguration,
+			);
+			self.state.set(
+				StateKeys.insideHandlesCanOpenDoorConfiguration,
+				receivedCC.insideHandlesCanOpenDoorConfiguration,
+			);
+			self.state.set(
+				StateKeys.lockTimeoutConfiguration,
+				receivedCC.lockTimeoutConfiguration,
+			);
+			self.state.set(
+				StateKeys.autoRelockTime,
+				receivedCC.autoRelockTime,
+			);
+			self.state.set(
+				StateKeys.holdAndReleaseTime,
+				receivedCC.holdAndReleaseTime,
+			);
+			self.state.set(StateKeys.twistAssist, receivedCC.twistAssist);
+			self.state.set(StateKeys.blockToBlock, receivedCC.blockToBlock);
+			return { action: "ok" };
+		}
+	},
+};
+
+export const DoorLockCCBehaviors = [
+	respondToDoorLockCapabilitiesGet,
+	respondToDoorLockOperationGet,
+	respondToDoorLockOperationSet,
+	respondToDoorLockConfigurationGet,
+	respondToDoorLockConfigurationSet,
+];

--- a/packages/zwave-js/src/lib/node/mockCCBehaviors/Lock.ts
+++ b/packages/zwave-js/src/lib/node/mockCCBehaviors/Lock.ts
@@ -1,0 +1,147 @@
+import { type CommandClass } from "@zwave-js/cc";
+import { LockCCGet, LockCCReport, LockCCSet } from "@zwave-js/cc/LockCC";
+import { CommandClasses } from "@zwave-js/core";
+import { type Timer, setTimer } from "@zwave-js/shared";
+import type {
+	LockCCCapabilities,
+	MockController,
+	MockNode,
+	MockNodeBehavior,
+} from "@zwave-js/testing";
+
+const defaultCapabilities: Required<LockCCCapabilities> = {
+	travelTime: 0,
+};
+
+const STATE_KEY_PREFIX = "Lock_";
+const StateKeys = {
+	locked: `${STATE_KEY_PREFIX}locked`,
+	transition: `${STATE_KEY_PREFIX}transition`,
+} as const;
+
+interface LockTransition {
+	targetLocked: boolean;
+	timer: Timer;
+	supervised: boolean;
+}
+
+/** Stops any running transition and snaps state to the target. */
+function stopCurrentTransition(
+	self: MockNode,
+): { wasSupervised: boolean } | undefined {
+	const existing = self.state.get(
+		StateKeys.transition,
+	) as LockTransition | undefined;
+	if (existing) {
+		existing.timer.clear();
+		self.state.set(StateKeys.locked, existing.targetLocked);
+		self.state.delete(StateKeys.transition);
+		return { wasSupervised: existing.supervised };
+	}
+}
+
+/**
+ * Stops any existing transition, then starts a new one.
+ * Returns the transition duration in milliseconds (0 = instant).
+ */
+function beginTransition(
+	controller: MockController,
+	self: MockNode,
+	receivedCC: CommandClass,
+	targetLocked: boolean,
+	travelTime: number,
+	supervised: boolean,
+	onCompleteSupervised?: () => Promise<void>,
+): number {
+	stopCurrentTransition(self);
+
+	const currentLocked = (
+		self.state.get(StateKeys.locked) ?? false
+	) as boolean;
+
+	if (currentLocked === targetLocked || travelTime === 0) {
+		self.state.set(StateKeys.locked, targetLocked);
+		return 0;
+	}
+
+	const timer = setTimer(async () => {
+		self.state.set(StateKeys.locked, targetLocked);
+		self.state.delete(StateKeys.transition);
+
+		if (supervised) {
+			await onCompleteSupervised?.();
+			return;
+		}
+
+		const cc = new LockCCReport({
+			nodeId: controller.ownNodeId,
+			locked: targetLocked,
+		});
+		await self.sendResponse(receivedCC, {
+			action: "sendCC",
+			cc,
+		});
+	}, travelTime).unref();
+
+	const transition: LockTransition = {
+		targetLocked,
+		timer,
+		supervised,
+	};
+	self.state.set(StateKeys.transition, transition);
+	return travelTime;
+}
+
+const respondToLockGet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof LockCCGet) {
+			const locked = (
+				self.state.get(StateKeys.locked) ?? false
+			) as boolean;
+
+			const cc = new LockCCReport({
+				nodeId: controller.ownNodeId,
+				locked,
+			});
+			return { action: "sendCC", cc };
+		}
+	},
+};
+
+const respondToLockSet: MockNodeBehavior = {
+	handleCC(controller, self, receivedCC) {
+		if (receivedCC instanceof LockCCSet) {
+			const capabilities = {
+				...defaultCapabilities,
+				...self.getCCCapabilities(
+					CommandClasses.Lock,
+					receivedCC.endpointIndex,
+				),
+			};
+			const supervised = receivedCC.isEncapsulatedWith(
+				CommandClasses.Supervision,
+			);
+			const durationMs = beginTransition(
+				controller,
+				self,
+				receivedCC,
+				receivedCC.locked,
+				capabilities.travelTime,
+				supervised,
+				async () =>
+					self.sendResponse(receivedCC, {
+						action: "ok",
+					}),
+			);
+			return {
+				action: "ok",
+				durationMs,
+			};
+		}
+	},
+};
+
+export const LockCCBehaviors = [
+	respondToLockGet,
+	respondToLockSet,
+];

--- a/packages/zwave-js/src/lib/test/driver/setValueDoorLockSupervisionFailVerify.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueDoorLockSupervisionFailVerify.test.ts
@@ -1,0 +1,150 @@
+import {
+	DoorLockCCOperationGet,
+	DoorLockCCOperationReport,
+	DoorLockCCOperationSet,
+	DoorLockMode,
+	DoorLockOperationType,
+	SupervisionCCGet,
+	SupervisionCCReport,
+} from "@zwave-js/cc";
+import { DoorLockCCValues } from "@zwave-js/cc/DoorLockCC";
+import { CommandClasses, Duration, SupervisionStatus } from "@zwave-js/core";
+import {
+	type MockNodeBehavior,
+	MockZWaveFrameType,
+	createMockZWaveRequestFrame,
+} from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Door Lock setValue: targetMode optimistic, verify on final supervision Fail",
+	{
+		debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				{
+					ccId: CommandClasses["Door Lock"],
+					isSupported: true,
+					version: 4,
+				},
+				CommandClasses.Supervision,
+				CommandClasses.Version,
+			],
+		},
+
+		customSetup: async (_driver, _controller, mockNode) => {
+			// Generic handler for Door Lock Gets
+			const respondToDoorLockGets: MockNodeBehavior = {
+				handleCC(controller, _self, receivedCC) {
+					if (receivedCC instanceof DoorLockCCOperationGet) {
+						const cc = new DoorLockCCOperationReport({
+							nodeId: controller.ownNodeId,
+							currentMode: DoorLockMode.Unsecured,
+							targetMode: DoorLockMode.Unsecured,
+							duration: new Duration(0, "seconds"),
+							outsideHandlesCanOpenDoor: [
+								true,
+								true,
+								true,
+								true,
+							],
+							insideHandlesCanOpenDoor: [
+								true,
+								true,
+								true,
+								true,
+							],
+						});
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+
+			// When receiving any supervised command, fail after a delay
+			const respondToSupervisionGet: MockNodeBehavior = {
+				async handleCC(controller, self, receivedCC) {
+					if (
+						receivedCC instanceof DoorLockCCOperationSet
+						&& receivedCC.encapsulatingCC
+							instanceof SupervisionCCGet
+					) {
+						const sessionId = receivedCC.encapsulatingCC.sessionId;
+						const cc = new SupervisionCCReport({
+							nodeId: controller.ownNodeId,
+							sessionId,
+							moreUpdatesFollow: true,
+							status: SupervisionStatus.Working,
+							duration: new Duration(2, "seconds"),
+						});
+
+						setTimeout(async () => {
+							const delayedCC = new SupervisionCCReport({
+								nodeId: controller.ownNodeId,
+								sessionId,
+								moreUpdatesFollow: false,
+								status: SupervisionStatus.Fail,
+							});
+							await self.sendToController(
+								createMockZWaveRequestFrame(delayedCC, {
+									ackRequested: false,
+								}),
+							);
+						}, 500);
+
+						return { action: "sendCC", cc };
+					}
+				},
+			};
+
+			mockNode.defineBehavior(
+				respondToDoorLockGets,
+				respondToSupervisionGet,
+			);
+		},
+
+		testBody: async (t, _driver, node, _mockController, mockNode) => {
+			const targetModeValueId = DoorLockCCValues.targetMode.id;
+			const currentModeValueId = DoorLockCCValues.currentMode.id;
+			const initialCurrentMode = node.getValue(currentModeValueId);
+
+			t.expect(initialCurrentMode === DoorLockMode.Unsecured).toBe(true);
+
+			// Set targetMode to Secured
+			await node.setValue(
+				targetModeValueId,
+				DoorLockMode.Secured,
+			);
+
+			// After the Working report and setValue completion, targetMode updates optimistically
+			t.expect(node.getValue(targetModeValueId)).toBe(
+				DoorLockMode.Secured,
+			);
+
+			// Current mode should not update yet
+			t.expect(node.getValue(currentModeValueId)).toBe(
+				initialCurrentMode,
+			);
+
+			// Wait for Supervision Fail to trigger verification GET
+			await wait(1000);
+
+			// After the GET completes, current mode should be reported as Unsecured (from OperationReport)
+			t.expect(node.getValue(currentModeValueId)).toBe(
+				DoorLockMode.Unsecured,
+			);
+
+			// Assert that the GET was actually sent
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof DoorLockCCOperationGet,
+				{
+					errorMessage:
+						"Node should have received a DoorLockCCOperationGet after final supervision Fail",
+				},
+			);
+		},
+	},
+);

--- a/packages/zwave-js/src/lib/test/driver/setValueDoorLockSupervisionFailVerify.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueDoorLockSupervisionFailVerify.test.ts
@@ -3,7 +3,6 @@ import {
 	DoorLockCCOperationReport,
 	DoorLockCCOperationSet,
 	DoorLockMode,
-	DoorLockOperationType,
 	SupervisionCCGet,
 	SupervisionCCReport,
 } from "@zwave-js/cc";
@@ -20,7 +19,7 @@ import { integrationTest } from "../integrationTestSuite.js";
 integrationTest(
 	"Door Lock setValue: targetMode optimistic, verify on final supervision Fail",
 	{
-		debug: true,
+		// debug: true,
 
 		nodeCapabilities: {
 			commandClasses: [

--- a/packages/zwave-js/src/lib/test/driver/setValueDoorLockSupervisionSuccess.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueDoorLockSupervisionSuccess.test.ts
@@ -13,7 +13,6 @@ import { integrationTest } from "../integrationTestSuite.js";
 integrationTest(
 	"Door Lock setValue: immediate supervised Success updates currentMode without verification",
 	{
-
 		// debug: true,
 
 		nodeCapabilities: {

--- a/packages/zwave-js/src/lib/test/driver/setValueDoorLockSupervisionSuccess.test.ts
+++ b/packages/zwave-js/src/lib/test/driver/setValueDoorLockSupervisionSuccess.test.ts
@@ -1,0 +1,121 @@
+import {
+	DoorLockCCOperationGet,
+	DoorLockCCOperationSet,
+	DoorLockMode,
+	SupervisionCCGet,
+} from "@zwave-js/cc";
+import { DoorLockCCValues } from "@zwave-js/cc/DoorLockCC";
+import { CommandClasses } from "@zwave-js/core";
+import { MockZWaveFrameType } from "@zwave-js/testing";
+import { wait } from "alcalzone-shared/async";
+import { integrationTest } from "../integrationTestSuite.js";
+
+integrationTest(
+	"Door Lock setValue: immediate supervised Success updates currentMode without verification",
+	{
+
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				{
+					ccId: CommandClasses["Door Lock"],
+					isSupported: true,
+					version: 4,
+					travelTime: 0,
+				},
+				CommandClasses.Supervision,
+				CommandClasses.Version,
+			],
+		},
+
+		testBody: async (t, _driver, node, _mockController, mockNode) => {
+			const targetModeValueId = DoorLockCCValues.targetMode.id;
+			const currentModeValueId = DoorLockCCValues.currentMode.id;
+
+			await node.setValue(targetModeValueId, DoorLockMode.Secured);
+			await wait(500);
+
+			t.expect(node.getValue(targetModeValueId)).toBe(
+				DoorLockMode.Secured,
+			);
+			t.expect(node.getValue(currentModeValueId)).toBe(
+				DoorLockMode.Secured,
+			);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof SupervisionCCGet
+					&& frame.payload.encapsulated
+						instanceof DoorLockCCOperationSet,
+				{
+					errorMessage:
+						"Node should have received a supervised DoorLockCCOperationSet",
+				},
+			);
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof DoorLockCCOperationGet,
+				{
+					noMatch: true,
+					errorMessage:
+						"Node should NOT have received a DoorLockCCOperationGet",
+				},
+			);
+		},
+	},
+);
+
+integrationTest(
+	"Door Lock setValue: delayed supervised Success updates currentMode without verification",
+	{
+		// debug: true,
+
+		nodeCapabilities: {
+			commandClasses: [
+				{
+					ccId: CommandClasses["Door Lock"],
+					isSupported: true,
+					version: 4,
+					travelTime: 500,
+				},
+				CommandClasses.Supervision,
+				CommandClasses.Version,
+			],
+		},
+
+		testBody: async (t, _driver, node, _mockController, mockNode) => {
+			const targetModeValueId = DoorLockCCValues.targetMode.id;
+			const currentModeValueId = DoorLockCCValues.currentMode.id;
+			const initialCurrentMode = node.getValue(currentModeValueId);
+
+			await node.setValue(targetModeValueId, DoorLockMode.Secured);
+
+			t.expect(node.getValue(targetModeValueId)).toBe(
+				DoorLockMode.Secured,
+			);
+			t.expect(node.getValue(currentModeValueId)).toBe(
+				initialCurrentMode,
+			);
+
+			await wait(750);
+
+			t.expect(node.getValue(currentModeValueId)).toBe(
+				DoorLockMode.Secured,
+			);
+
+			mockNode.assertReceivedControllerFrame(
+				(frame) =>
+					frame.type === MockZWaveFrameType.Request
+					&& frame.payload instanceof DoorLockCCOperationGet,
+				{
+					noMatch: true,
+					errorMessage:
+						"Node should NOT have received a DoorLockCCOperationGet",
+				},
+			);
+		},
+	},
+);


### PR DESCRIPTION
Reported in https://github.com/home-assistant/core/issues/167814
The issue was that a delayed Supervision status of `Fail` was silently swallowed instead of verifying the current lock state. This PR streamlines the handling to be more in line with other CCs that have been migrated to SET_VALUE_HOOKS.