### PR TITLE
refactor: move credential API behind the `accessControl` namespace

### DIFF
--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -295,6 +295,15 @@ Retrieves the version of the given CommandClass this endpoint implements.
 
 Z-Wave JS provides a unified API for managing users and credentials on access control devices such as door locks. This API transparently supports both the **User Credential CC** and the legacy **User Code CC**, abstracting away the differences between the two.
 
+The credential management API is accessed via the `accessControl` property on endpoints and nodes. Before accessing it, use `endpoint.supportsFeature` to check for support:
+
+```ts
+// Check if the endpoint supports access control
+if (endpoint.supportsFeature(DeviceFeatures.AccessControl)) {
+	const user = await endpoint.accessControl.getUser(1);
+}
+```
+
 > [!NOTE] For nodes using the **User Code CC**, only a subset of the functionality is available. Each user supports a single credential in slot 1, user names and credential rules are not supported, and credential learning is unavailable.
 
 > [!NOTE] Methods that read data return `undefined` when the endpoint does not support access control. Methods that write data will throw if neither the **User Credential CC** nor the **User Code CC** is supported.
@@ -579,7 +588,7 @@ Cancels an ongoing credential learn process.
 Devices that support an admin code allow configuring a code that can be used for administrative functions. Whether this is supported can be determined using `getCredentialCapabilitiesCached()`:
 
 ```ts
-const caps = endpoint.getCredentialCapabilitiesCached();
+const caps = endpoint.accessControl.getCredentialCapabilitiesCached();
 if (caps?.supportsAdminCode) {
 	// Admin code is supported
 }

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -19,10 +19,13 @@ export { VirtualEndpoint } from "./lib/node/VirtualEndpoint.js";
 export { VirtualNode } from "./lib/node/VirtualNode.js";
 export type { VirtualValueID } from "./lib/node/VirtualNode.js";
 export * from "./lib/node/_Types.js";
+export { AccessControlAPI } from "./lib/node/feature-apis/AccessControl.js";
 export type {
 	CredentialCapabilities,
 	CredentialData,
 	SetUserOptions,
 	UserCapabilities,
 	UserData,
-} from "./lib/node/endpoint-mixins/05_AccessControl.js";
+} from "./lib/node/feature-apis/AccessControl.js";
+export { DeviceFeatures } from "./lib/node/feature-apis/DeviceFeatures.js";
+export { FeatureAPI } from "./lib/node/feature-apis/FeatureAPI.js";

--- a/packages/zwave-js/src/lib/node/_Types.ts
+++ b/packages/zwave-js/src/lib/node/_Types.ts
@@ -26,7 +26,7 @@ import type { AllOrNone, BytesView } from "@zwave-js/shared";
 import type { Endpoint } from "./Endpoint.js";
 import type { ZWaveNode } from "./Node.js";
 import type { RouteStatistics } from "./NodeStatistics.js";
-import type { UserData } from "./endpoint-mixins/05_AccessControl.js";
+import type { UserData } from "./feature-apis/AccessControl.js";
 
 export {
 	EntryControlDataTypes,

--- a/packages/zwave-js/src/lib/node/endpoint-mixins/index.ts
+++ b/packages/zwave-js/src/lib/node/endpoint-mixins/index.ts
@@ -1,3 +1,23 @@
-import { AccessControlMixin } from "./05_AccessControl.js";
+import { CommandClasses } from "@zwave-js/core";
+import { AccessControlAPI } from "../feature-apis/AccessControl.js";
+import { DeviceFeatures } from "../feature-apis/DeviceFeatures.js";
+import { EndpointBase } from "./00_Base.js";
 
-export class EndpointMixins extends AccessControlMixin {}
+export class FeatureAPIsMixin extends EndpointBase {
+	private _accessControl?: AccessControlAPI;
+
+	public get accessControl(): AccessControlAPI {
+		return this._accessControl ??= new AccessControlAPI(this);
+	}
+
+	/** Tests whether this endpoint supports the given high-level device feature */
+	public supportsFeature(feature: DeviceFeatures): boolean {
+		switch (feature) {
+			case DeviceFeatures.AccessControl:
+				return this.supportsCC(CommandClasses["User Credential"])
+					|| this.supportsCC(CommandClasses["User Code"]);
+		}
+	}
+}
+
+export class EndpointMixins extends FeatureAPIsMixin {}

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -13,16 +13,14 @@ import {
 } from "@zwave-js/cc/UserCredentialCC";
 import {
 	CommandClasses,
-	type MaybeNotKnown,
 	type SupervisionResult,
-	type ValueID,
 	ZWaveError,
 	ZWaveErrorCodes,
 	isUnsupervisedOrSucceeded,
 	supervisedCommandSucceeded,
 } from "@zwave-js/core";
 import { Bytes, getEnumMemberName } from "@zwave-js/shared";
-import { EndpointBase } from "./00_Base.js";
+import { FeatureAPI } from "./FeatureAPI.js";
 
 export interface UserCapabilities {
 	maxUsers: number;
@@ -64,151 +62,6 @@ export interface SetUserOptions {
 	expiringTimeoutMinutes?: number;
 }
 
-/** Defines functionality of Z-Wave endpoints related to managing users and credentials for access control */
-export interface EndpointAccessControl {
-	/**
-	 * Returns the user-related capabilities of this endpoint.
-	 * This method uses cached information from the most recent interview.
-	 */
-	getUserCapabilitiesCached(): UserCapabilities | undefined;
-
-	/**
-	 * Returns the credential-related capabilities of this endpoint.
-	 * This method uses cached information from the most recent interview.
-	 */
-	getCredentialCapabilitiesCached(): CredentialCapabilities | undefined;
-
-	/**
-	 * Returns the data for the user with the given ID.
-	 * This communicates with the node to retrieve fresh information.
-	 */
-	getUser(userId: number): Promise<UserData | undefined>;
-
-	/**
-	 * Returns the data for the user with the given ID.
-	 * This method uses cached information from the most recent interview.
-	 */
-	getUserCached(userId: number): UserData | undefined;
-
-	/**
-	 * Returns the data for all configured users.
-	 * This communicates with the node to retrieve fresh information.
-	 */
-	getUsers(): Promise<UserData[]>;
-
-	/**
-	 * Returns the data for all configured users.
-	 * This method uses cached information from the most recent interview.
-	 */
-	getUsersCached(): UserData[];
-
-	/**
-	 * Creates or updates the user with the given ID.
-	 * This communicates with the node.
-	 */
-	setUser(
-		userId: number,
-		options: SetUserOptions,
-	): Promise<SupervisionResult | undefined>;
-
-	/**
-	 * Deletes the user with the given ID and all of their credentials.
-	 * This communicates with the node.
-	 */
-	deleteUser(userId: number): Promise<SupervisionResult | undefined>;
-
-	/**
-	 * Deletes all users and their credentials.
-	 * This communicates with the node.
-	 */
-	deleteAllUsers(): Promise<SupervisionResult | undefined>;
-
-	/**
-	 * Returns the data for a specific credential.
-	 * This communicates with the node to retrieve fresh information.
-	 */
-	getCredential(
-		userId: number,
-		type: UserCredentialType,
-		slot: number,
-	): Promise<CredentialData | undefined>;
-
-	/**
-	 * Returns the data for a specific credential.
-	 * This method uses cached information from the most recent interview.
-	 */
-	getCredentialCached(
-		userId: number,
-		type: UserCredentialType,
-		slot: number,
-	): CredentialData | undefined;
-
-	/**
-	 * Returns all credentials for the given user.
-	 * This communicates with the node to retrieve fresh information.
-	 */
-	getCredentials(userId: number): Promise<CredentialData[]>;
-
-	/**
-	 * Returns all credentials for the given user.
-	 * This method uses cached information from the most recent interview.
-	 */
-	getCredentialsCached(userId: number): CredentialData[];
-
-	/**
-	 * Creates or updates a credential for the given user.
-	 * This communicates with the node.
-	 */
-	setCredential(
-		userId: number,
-		type: UserCredentialType,
-		slot: number,
-		data: string | Uint8Array,
-	): Promise<SupervisionResult | undefined>;
-
-	/**
-	 * Deletes the given credential.
-	 * This communicates with the node.
-	 */
-	deleteCredential(
-		userId: number,
-		type: UserCredentialType,
-		slot: number,
-	): Promise<SupervisionResult | undefined>;
-
-	/**
-	 * Starts a learn process for the given credential slot, allowing a user
-	 * to input a credential directly on the device.
-	 * Only supported on nodes using the User Credential CC.
-	 * This communicates with the node.
-	 */
-	startCredentialLearn(
-		userId: number,
-		type: UserCredentialType,
-		slot: number,
-		timeout?: number,
-	): Promise<SupervisionResult | undefined>;
-
-	/**
-	 * Cancels an ongoing credential learn process.
-	 * Only supported on nodes using the User Credential CC.
-	 * This communicates with the node.
-	 */
-	cancelCredentialLearn(): Promise<SupervisionResult | undefined>;
-
-	/**
-	 * Retrieves the admin code from the node.
-	 * This communicates with the node to retrieve fresh information.
-	 */
-	getAdminCode(): Promise<string | undefined>;
-
-	/**
-	 * Sets the admin code on the node.
-	 * This communicates with the node.
-	 */
-	setAdminCode(code: string): Promise<SupervisionResult | undefined>;
-}
-
 const NON_PIN_CHARS = /[^0-9]/;
 
 /**
@@ -220,55 +73,57 @@ function supportsNonPINChars(supportedASCIIChars: string | undefined): boolean {
 		&& NON_PIN_CHARS.test(supportedASCIIChars);
 }
 
-export class AccessControlMixin extends EndpointBase
-	implements EndpointAccessControl
-{
-	/** Read a cached value from the node's value DB */
-	private _getValue<T = unknown>(valueId: ValueID): MaybeNotKnown<T> {
-		return this.tryGetNode()?.getValue(valueId);
-	}
-
+/** High-level API for managing users and credentials on access control devices */
+export class AccessControlAPI extends FeatureAPI {
 	// FIXME: This is technically not correct. A node could support both CCs,
 	// and we may have to decide which one to use, or switch between them on
 	// the fly using Version CC / migration.
 	// This is not implemented yet, so checking for U3C first is fine for now.
-	private get _usesUserCredentialCC(): boolean {
-		return this.supportsCC(CommandClasses["User Credential"]);
+	get #usesUserCredentialCC(): boolean {
+		return this.endpoint.supportsCC(CommandClasses["User Credential"]);
 	}
 
-	private get _usesUserCodeCC(): boolean {
-		return !this._usesUserCredentialCC
-			&& this.supportsCC(CommandClasses["User Code"]);
+	get #usesUserCodeCC(): boolean {
+		return !this.#usesUserCredentialCC
+			&& this.endpoint.supportsCC(CommandClasses["User Code"]);
 	}
 
+	/**
+	 * Returns the user-related capabilities of this endpoint.
+	 * This method uses cached information from the most recent interview.
+	 */
 	public getUserCapabilitiesCached():
 		| UserCapabilities
 		| undefined
 	{
-		if (this._usesUserCredentialCC) {
+		if (this.#usesUserCredentialCC) {
 			return {
-				maxUsers: this._getValue<number>(
-					UserCredentialCCValues.supportedUsers.endpoint(this.index),
+				maxUsers: this.getValue<number>(
+					UserCredentialCCValues.supportedUsers.endpoint(
+						this.endpoint.index,
+					),
 				) ?? 0,
-				supportedUserTypes: this._getValue<UserCredentialUserType[]>(
+				supportedUserTypes: this.getValue<UserCredentialUserType[]>(
 					UserCredentialCCValues.supportedUserTypes.endpoint(
-						this.index,
+						this.endpoint.index,
 					),
 				) ?? [],
-				maxUserNameLength: this._getValue<number>(
+				maxUserNameLength: this.getValue<number>(
 					UserCredentialCCValues.maxUserNameLength.endpoint(
-						this.index,
+						this.endpoint.index,
 					),
 				) ?? undefined,
-				supportedCredentialRules: this._getValue<UserCredentialRule[]>(
+				supportedCredentialRules: this.getValue<UserCredentialRule[]>(
 					UserCredentialCCValues.supportedCredentialRules.endpoint(
-						this.index,
+						this.endpoint.index,
 					),
 				) ?? [],
 			};
-		} else if (this._usesUserCodeCC) {
-			const supportedStatuses = this._getValue<UserIDStatus[]>(
-				UserCodeCCValues.supportedUserIDStatuses.endpoint(this.index),
+		} else if (this.#usesUserCodeCC) {
+			const supportedStatuses = this.getValue<UserIDStatus[]>(
+				UserCodeCCValues.supportedUserIDStatuses.endpoint(
+					this.endpoint.index,
+				),
 			) ?? [];
 			const supportedUserTypes: UserCredentialUserType[] = [
 				UserCredentialUserType.General,
@@ -280,8 +135,10 @@ export class AccessControlMixin extends EndpointBase
 			}
 
 			return {
-				maxUsers: this._getValue<number>(
-					UserCodeCCValues.supportedUsers.endpoint(this.index),
+				maxUsers: this.getValue<number>(
+					UserCodeCCValues.supportedUsers.endpoint(
+						this.endpoint.index,
+					),
 				) ?? 0,
 				supportedUserTypes,
 				// User Code CC does not support user names or credential rules
@@ -292,14 +149,18 @@ export class AccessControlMixin extends EndpointBase
 		return undefined;
 	}
 
+	/**
+	 * Returns the credential-related capabilities of this endpoint.
+	 * This method uses cached information from the most recent interview.
+	 */
 	public getCredentialCapabilitiesCached():
 		| CredentialCapabilities
 		| undefined
 	{
-		if (this._usesUserCredentialCC) {
-			const supportedTypes = this._getValue<UserCredentialType[]>(
+		if (this.#usesUserCredentialCC) {
+			const supportedTypes = this.getValue<UserCredentialType[]>(
 				UserCredentialCCValues.supportedCredentialTypes.endpoint(
-					this.index,
+					this.endpoint.index,
 				),
 			) ?? [];
 
@@ -308,10 +169,10 @@ export class AccessControlMixin extends EndpointBase
 				UserCredentialCapability
 			>();
 			for (const type of supportedTypes) {
-				const cap = this._getValue<UserCredentialCapability>(
+				const cap = this.getValue<UserCredentialCapability>(
 					UserCredentialCCValues.credentialCapabilities(type)
 						.endpoint(
-							this.index,
+							this.endpoint.index,
 						),
 				);
 				if (cap) credentialTypes.set(type, cap);
@@ -319,17 +180,17 @@ export class AccessControlMixin extends EndpointBase
 
 			return {
 				supportedCredentialTypes: credentialTypes,
-				supportsAdminCode: this._getValue<boolean>(
+				supportsAdminCode: this.getValue<boolean>(
 					UserCredentialCCValues.supportsAdminCode.endpoint(
-						this.index,
+						this.endpoint.index,
 					),
 				) ?? false,
-				supportsAdminCodeDeactivation: this._getValue<boolean>(
+				supportsAdminCodeDeactivation: this.getValue<boolean>(
 					UserCredentialCCValues.supportsAdminCodeDeactivation
-						.endpoint(this.index),
+						.endpoint(this.endpoint.index),
 				) ?? false,
 			};
-		} else if (this._usesUserCodeCC) {
+		} else if (this.#usesUserCodeCC) {
 			// User Code CC only supports a single credential per user
 			// with a length of 4-10 characters (CC:0063.01.01.11.006).
 			// Despite the spec calling them "PIN codes", v1 devices often
@@ -338,7 +199,7 @@ export class AccessControlMixin extends EndpointBase
 				UserCredentialType,
 				UserCredentialCapability
 			>();
-			credentialTypes.set(this._ucCredentialType, {
+			credentialTypes.set(this.#ucCredentialType, {
 				numberOfCredentialSlots: 1,
 				minCredentialLength: 4,
 				maxCredentialLength: 10,
@@ -348,12 +209,14 @@ export class AccessControlMixin extends EndpointBase
 
 			return {
 				supportedCredentialTypes: credentialTypes,
-				supportsAdminCode: this._getValue<boolean>(
-					UserCodeCCValues.supportsAdminCode.endpoint(this.index),
+				supportsAdminCode: this.getValue<boolean>(
+					UserCodeCCValues.supportsAdminCode.endpoint(
+						this.endpoint.index,
+					),
 				) ?? false,
-				supportsAdminCodeDeactivation: this._getValue<boolean>(
+				supportsAdminCodeDeactivation: this.getValue<boolean>(
 					UserCodeCCValues.supportsAdminCodeDeactivation.endpoint(
-						this.index,
+						this.endpoint.index,
 					),
 				) ?? false,
 			};
@@ -361,9 +224,13 @@ export class AccessControlMixin extends EndpointBase
 		return undefined;
 	}
 
+	/**
+	 * Returns the data for the user with the given ID.
+	 * This communicates with the node to retrieve fresh information.
+	 */
 	public async getUser(userId: number): Promise<UserData | undefined> {
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			const result = await api.getUser(userId);
 			if (!result?.userId) return undefined;
 			return {
@@ -375,11 +242,11 @@ export class AccessControlMixin extends EndpointBase
 				expiringTimeoutMinutes: result.expiringTimeoutMinutes
 					|| undefined,
 			};
-		} else if (this._usesUserCodeCC) {
-			const api = this._ucAPI();
+		} else if (this.#usesUserCodeCC) {
+			const api = this.#ucAPI();
 			const result = await api.get(userId);
 			if (!result) return undefined;
-			return this._mapUserCodeStatusToUserData(
+			return this.#mapUserCodeStatusToUserData(
 				userId,
 				result.userIdStatus,
 			);
@@ -387,18 +254,26 @@ export class AccessControlMixin extends EndpointBase
 		return undefined;
 	}
 
+	/**
+	 * Returns the data for the user with the given ID.
+	 * This method uses cached information from the most recent interview.
+	 */
 	public getUserCached(userId: number): UserData | undefined {
-		if (this._usesUserCredentialCC) {
-			return this._getUserCached_U3C(userId);
-		} else if (this._usesUserCodeCC) {
-			return this._getUserCached_UC(userId);
+		if (this.#usesUserCredentialCC) {
+			return this.#getUserCached_U3C(userId);
+		} else if (this.#usesUserCodeCC) {
+			return this.#getUserCached_UC(userId);
 		}
 		return undefined;
 	}
 
+	/**
+	 * Returns the data for all configured users.
+	 * This communicates with the node to retrieve fresh information.
+	 */
 	public async getUsers(): Promise<UserData[]> {
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			const users: UserData[] = [];
 			// Requesting userId 0 gives us the first user
 			let nextUserId = 0;
@@ -418,15 +293,15 @@ export class AccessControlMixin extends EndpointBase
 				nextUserId = result.nextUserId;
 			} while (nextUserId > 0);
 			return users;
-		} else if (this._usesUserCodeCC) {
-			const api = this._ucAPI();
+		} else if (this.#usesUserCodeCC) {
+			const api = this.#ucAPI();
 			const maxUsers = await api.getUsersCount();
 			if (!maxUsers) return [];
 
 			const users: UserData[] = [];
-			const supportsBulk = !!this._getValue<boolean>(
+			const supportsBulk = !!this.getValue<boolean>(
 				UserCodeCCValues.supportsMultipleUserCodeReport.endpoint(
-					this.index,
+					this.endpoint.index,
 				),
 			);
 
@@ -438,7 +313,7 @@ export class AccessControlMixin extends EndpointBase
 					users.push(
 						...response.userCodes
 							.map((entry) =>
-								this._mapUserCodeStatusToUserData(
+								this.#mapUserCodeStatusToUserData(
 									entry.userId,
 									entry.userIdStatus,
 								)
@@ -451,7 +326,7 @@ export class AccessControlMixin extends EndpointBase
 				for (let userId = 1; userId <= maxUsers; userId++) {
 					const result = await api.get(userId);
 					if (!result) continue;
-					const user = this._mapUserCodeStatusToUserData(
+					const user = this.#mapUserCodeStatusToUserData(
 						userId,
 						result.userIdStatus,
 					);
@@ -463,24 +338,30 @@ export class AccessControlMixin extends EndpointBase
 		return [];
 	}
 
+	/**
+	 * Returns the data for all configured users.
+	 * This method uses cached information from the most recent interview.
+	 */
 	public getUsersCached(): UserData[] {
-		if (this._usesUserCredentialCC) {
-			const maxUsers = this._getValue<number>(
-				UserCredentialCCValues.supportedUsers.endpoint(this.index),
+		if (this.#usesUserCredentialCC) {
+			const maxUsers = this.getValue<number>(
+				UserCredentialCCValues.supportedUsers.endpoint(
+					this.endpoint.index,
+				),
 			) ?? 0;
 			const users: UserData[] = [];
 			for (let userId = 1; userId <= maxUsers; userId++) {
-				const user = this._getUserCached_U3C(userId);
+				const user = this.#getUserCached_U3C(userId);
 				if (user) users.push(user);
 			}
 			return users;
-		} else if (this._usesUserCodeCC) {
-			const maxUsers = this._getValue<number>(
-				UserCodeCCValues.supportedUsers.endpoint(this.index),
+		} else if (this.#usesUserCodeCC) {
+			const maxUsers = this.getValue<number>(
+				UserCodeCCValues.supportedUsers.endpoint(this.endpoint.index),
 			) ?? 0;
 			const users: UserData[] = [];
 			for (let userId = 1; userId <= maxUsers; userId++) {
-				const user = this._getUserCached_UC(userId);
+				const user = this.#getUserCached_UC(userId);
 				if (user) users.push(user);
 			}
 			return users;
@@ -488,13 +369,17 @@ export class AccessControlMixin extends EndpointBase
 		return [];
 	}
 
+	/**
+	 * Creates or updates the user with the given ID.
+	 * This communicates with the node.
+	 */
 	public async setUser(
 		userId: number,
 		options: SetUserOptions,
 	): Promise<SupervisionResult | undefined> {
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
-			const existing = this._getUserCached_U3C(userId);
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
+			const existing = this.#getUserCached_U3C(userId);
 			const operationType = existing
 				? UserCredentialOperationType.Modify
 				: UserCredentialOperationType.Add;
@@ -527,11 +412,13 @@ export class AccessControlMixin extends EndpointBase
 					?? existing?.credentialRule,
 				userName: options.userName ?? existing?.userName,
 			});
-		} else if (this._usesUserCodeCC) {
-			const api = this._ucAPI();
-			const existing = this._getUserCached_UC(userId);
-			const existingStatus = this._getValue<UserIDStatus>(
-				UserCodeCCValues.userIdStatus(userId).endpoint(this.index),
+		} else if (this.#usesUserCodeCC) {
+			const api = this.#ucAPI();
+			const existing = this.#getUserCached_UC(userId);
+			const existingStatus = this.getValue<UserIDStatus>(
+				UserCodeCCValues.userIdStatus(userId).endpoint(
+					this.endpoint.index,
+				),
 			);
 
 			const active = options.active ?? existing?.active ?? true;
@@ -551,8 +438,10 @@ export class AccessControlMixin extends EndpointBase
 
 			// User Code CC requires sending the code along with every status
 			// change, so we re-send the existing code to preserve it
-			const existingCode = this._getValue<string>(
-				UserCodeCCValues.userCode(userId).endpoint(this.index),
+			const existingCode = this.getValue<string>(
+				UserCodeCCValues.userCode(userId).endpoint(
+					this.endpoint.index,
+				),
 			);
 			if (!existingCode) {
 				throw new ZWaveError(
@@ -578,39 +467,43 @@ export class AccessControlMixin extends EndpointBase
 				succeeded = supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
-				const node = this.tryGetNode();
+				const node = this.endpoint.tryGetNode();
 				if (node) {
 					const userData: UserData = { userId, active, userType };
 					node.emit(
 						existing ? "user modified" : "user added",
-						this,
+						this.endpoint as any,
 						userData,
 					);
 				}
 			}
 			return result;
 		}
-		this._throwNoAccessControl();
+		this.#throwNoAccessControl();
 	}
 
+	/**
+	 * Deletes the user with the given ID and all of their credentials.
+	 * This communicates with the node.
+	 */
 	public async deleteUser(
 		userId: number,
 	): Promise<SupervisionResult | undefined> {
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			const result = await api.setUser({
 				operationType: UserCredentialOperationType.Delete,
 				userId,
 			});
 			if (isUnsupervisedOrSucceeded(result)) {
-				this._purgeCachedCredentials(userId);
+				this.#purgeCachedCredentials(userId);
 			}
 			return result;
-		} else if (this._usesUserCodeCC) {
+		} else if (this.#usesUserCodeCC) {
 			// User Code CC ties each user to their code, so clearing
 			// the code implicitly deletes the user and vice versa
-			const existed = this._getUserCached_UC(userId) != undefined;
-			const api = this._ucAPI();
+			const existed = this.#getUserCached_UC(userId) != undefined;
+			const api = this.#ucAPI();
 			const result = await api.clear(userId);
 			let succeeded: boolean;
 			if (result == undefined) {
@@ -622,55 +515,63 @@ export class AccessControlMixin extends EndpointBase
 				succeeded = supervisedCommandSucceeded(result) && existed;
 			}
 			if (succeeded) {
-				const node = this.tryGetNode();
+				const node = this.endpoint.tryGetNode();
 				if (node) {
-					node.emit("user deleted", this, { userId });
-					node.emit("credential deleted", this, {
+					node.emit("user deleted", this.endpoint as any, { userId });
+					node.emit("credential deleted", this.endpoint as any, {
 						userId,
-						credentialType: this._ucCredentialType,
+						credentialType: this.#ucCredentialType,
 						credentialSlot: 1,
 					});
 				}
 			}
 			return result;
 		}
-		this._throwNoAccessControl();
+		this.#throwNoAccessControl();
 	}
 
+	/**
+	 * Deletes all users and their credentials.
+	 * This communicates with the node.
+	 */
 	public async deleteAllUsers(): Promise<SupervisionResult | undefined> {
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			const result = await api.setUser({
 				operationType: UserCredentialOperationType.Delete,
 				userId: 0,
 			});
 			if (isUnsupervisedOrSucceeded(result)) {
-				this._purgeAllCachedUsersAndCredentials();
+				this.#purgeAllCachedUsersAndCredentials();
 			}
 			return result;
-		} else if (this._usesUserCodeCC) {
-			const api = this._ucAPI();
+		} else if (this.#usesUserCodeCC) {
+			const api = this.#ucAPI();
 			const result = await api.clear(0);
 			// Verifying all users being deleted is unrealistic
 			// since there can be up to 65535 users. So we just
 			// assume it worked when the command was not supervised.
 			if (isUnsupervisedOrSucceeded(result)) {
-				this._purgeAllCachedUserCodes();
+				this.#purgeAllCachedUserCodes();
 			}
 			return result;
 		}
-		this._throwNoAccessControl();
+		this.#throwNoAccessControl();
 	}
 
+	/**
+	 * Returns the data for a specific credential.
+	 * This communicates with the node to retrieve fresh information.
+	 */
 	public async getCredential(
 		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): Promise<CredentialData | undefined> {
-		this._assertValidSlot(type, slot);
+		this.#assertValidSlot(type, slot);
 
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			const result = await api.getCredential(userId, type, slot);
 			if (!result?.credentialSlot) return undefined;
 			return {
@@ -679,8 +580,8 @@ export class AccessControlMixin extends EndpointBase
 				slot: result.credentialSlot,
 				data: result.credentialData,
 			};
-		} else if (this._usesUserCodeCC) {
-			const api = this._ucAPI();
+		} else if (this.#usesUserCodeCC) {
+			const api = this.#ucAPI();
 			const result = await api.get(userId);
 			if (!result) return undefined;
 			if (
@@ -694,24 +595,32 @@ export class AccessControlMixin extends EndpointBase
 		return undefined;
 	}
 
+	/**
+	 * Returns the data for a specific credential.
+	 * This method uses cached information from the most recent interview.
+	 */
 	public getCredentialCached(
 		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): CredentialData | undefined {
-		this._assertValidSlot(type, slot);
+		this.#assertValidSlot(type, slot);
 
-		if (this._usesUserCredentialCC) {
-			return this._getCredentialCached_U3C(userId, type, slot);
-		} else if (this._usesUserCodeCC) {
-			return this._getCredentialCached_UC(userId, type, slot);
+		if (this.#usesUserCredentialCC) {
+			return this.#getCredentialCached_U3C(userId, type, slot);
+		} else if (this.#usesUserCodeCC) {
+			return this.#getCredentialCached_UC(userId, type, slot);
 		}
 		return undefined;
 	}
 
+	/**
+	 * Returns all credentials for the given user.
+	 * This communicates with the node to retrieve fresh information.
+	 */
 	public async getCredentials(userId: number): Promise<CredentialData[]> {
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			const credentials: CredentialData[] = [];
 			// Starting from type 0 / slot 0 gives us the first credential for the user
 			let nextCredType: UserCredentialType = UserCredentialType.None;
@@ -736,10 +645,10 @@ export class AccessControlMixin extends EndpointBase
 				|| nextCredSlot !== 0
 			);
 			return credentials;
-		} else if (this._usesUserCodeCC) {
+		} else if (this.#usesUserCodeCC) {
 			const cred = await this.getCredential(
 				userId,
-				this._ucCredentialType,
+				this.#ucCredentialType,
 				1,
 			);
 			return cred ? [cred] : [];
@@ -747,20 +656,24 @@ export class AccessControlMixin extends EndpointBase
 		return [];
 	}
 
+	/**
+	 * Returns all credentials for the given user.
+	 * This method uses cached information from the most recent interview.
+	 */
 	public getCredentialsCached(userId: number): CredentialData[] {
-		if (this._usesUserCredentialCC) {
+		if (this.#usesUserCredentialCC) {
 			const credentials: CredentialData[] = [];
-			const supportedTypes = this._getValue<UserCredentialType[]>(
+			const supportedTypes = this.getValue<UserCredentialType[]>(
 				UserCredentialCCValues.supportedCredentialTypes.endpoint(
-					this.index,
+					this.endpoint.index,
 				),
 			) ?? [];
 
 			for (const type of supportedTypes) {
-				const cap = this._getValue<UserCredentialCapability>(
+				const cap = this.getValue<UserCredentialCapability>(
 					UserCredentialCCValues.credentialCapabilities(type)
 						.endpoint(
-							this.index,
+							this.endpoint.index,
 						),
 				);
 				if (!cap) continue;
@@ -769,7 +682,7 @@ export class AccessControlMixin extends EndpointBase
 					slot <= cap.numberOfCredentialSlots;
 					slot++
 				) {
-					const cred = this._getCredentialCached_U3C(
+					const cred = this.#getCredentialCached_U3C(
 						userId,
 						type,
 						slot,
@@ -778,10 +691,10 @@ export class AccessControlMixin extends EndpointBase
 				}
 			}
 			return credentials;
-		} else if (this._usesUserCodeCC) {
-			const cred = this._getCredentialCached_UC(
+		} else if (this.#usesUserCodeCC) {
+			const cred = this.#getCredentialCached_UC(
 				userId,
-				this._ucCredentialType,
+				this.#ucCredentialType,
 				1,
 			);
 			return cred ? [cred] : [];
@@ -789,17 +702,21 @@ export class AccessControlMixin extends EndpointBase
 		return [];
 	}
 
+	/**
+	 * Creates or updates a credential for the given user.
+	 * This communicates with the node.
+	 */
 	public async setCredential(
 		userId: number,
 		type: UserCredentialType,
 		slot: number,
 		data: string | Uint8Array,
 	): Promise<SupervisionResult | undefined> {
-		this._assertValidSlot(type, slot);
+		this.#assertValidSlot(type, slot);
 
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
-			const existing = this._getCredentialCached_U3C(userId, type, slot);
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
+			const existing = this.#getCredentialCached_U3C(userId, type, slot);
 			const credentialData = typeof data === "string"
 				? Bytes.from(data, "utf-8")
 				: Bytes.from(data);
@@ -812,12 +729,14 @@ export class AccessControlMixin extends EndpointBase
 				credentialSlot: slot,
 				credentialData,
 			});
-		} else if (this._usesUserCodeCC) {
-			const api = this._ucAPI();
+		} else if (this.#usesUserCodeCC) {
+			const api = this.#ucAPI();
 
 			// Determine the current status; default to Enabled for new users
-			const existingStatus = this._getValue<UserIDStatus>(
-				UserCodeCCValues.userIdStatus(userId).endpoint(this.index),
+			const existingStatus = this.getValue<UserIDStatus>(
+				UserCodeCCValues.userIdStatus(userId).endpoint(
+					this.endpoint.index,
+				),
 			);
 			const status = (
 					existingStatus == undefined
@@ -826,7 +745,7 @@ export class AccessControlMixin extends EndpointBase
 				? UserIDStatus.Enabled
 				: existingStatus;
 
-			const existingCred = this._getCredentialCached_UC(
+			const existingCred = this.#getCredentialCached_UC(
 				userId,
 				type,
 				slot,
@@ -848,13 +767,13 @@ export class AccessControlMixin extends EndpointBase
 				succeeded = supervisedCommandSucceeded(result);
 			}
 			if (succeeded) {
-				const node = this.tryGetNode();
+				const node = this.endpoint.tryGetNode();
 				if (node) {
 					node.emit(
 						existingCred
 							? "credential modified"
 							: "credential added",
-						this,
+						this.endpoint as any,
 						{
 							userId,
 							credentialType: type,
@@ -866,30 +785,34 @@ export class AccessControlMixin extends EndpointBase
 			}
 			return result;
 		}
-		this._throwNoAccessControl();
+		this.#throwNoAccessControl();
 	}
 
+	/**
+	 * Deletes the given credential.
+	 * This communicates with the node.
+	 */
 	public async deleteCredential(
 		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): Promise<SupervisionResult | undefined> {
-		this._assertValidSlot(type, slot);
+		this.#assertValidSlot(type, slot);
 
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			return api.setCredential({
 				operationType: UserCredentialOperationType.Delete,
 				userId,
 				credentialType: type,
 				credentialSlot: slot,
 			});
-		} else if (this._usesUserCodeCC) {
+		} else if (this.#usesUserCodeCC) {
 			// User Code CC ties each user to their code, so clearing
 			// the credential also deletes the user
-			const existed = this._getCredentialCached_UC(userId, type, slot)
+			const existed = this.#getCredentialCached_UC(userId, type, slot)
 				!= undefined;
-			const api = this._ucAPI();
+			const api = this.#ucAPI();
 			const result = await api.clear(userId);
 			let succeeded: boolean;
 			if (result == undefined) {
@@ -900,37 +823,43 @@ export class AccessControlMixin extends EndpointBase
 				succeeded = supervisedCommandSucceeded(result) && existed;
 			}
 			if (succeeded) {
-				const node = this.tryGetNode();
+				const node = this.endpoint.tryGetNode();
 				if (node) {
-					node.emit("credential deleted", this, {
+					node.emit("credential deleted", this.endpoint as any, {
 						userId,
 						credentialType: type,
 						credentialSlot: slot,
 					});
-					node.emit("user deleted", this, { userId });
+					node.emit("user deleted", this.endpoint as any, { userId });
 				}
 			}
 			return result;
 		}
-		this._throwNoAccessControl();
+		this.#throwNoAccessControl();
 	}
 
+	/**
+	 * Starts a learn process for the given credential slot, allowing a user
+	 * to input a credential directly on the device.
+	 * Only supported on nodes using the User Credential CC.
+	 * This communicates with the node.
+	 */
 	public async startCredentialLearn(
 		userId: number,
 		type: UserCredentialType,
 		slot: number,
 		timeout?: number,
 	): Promise<SupervisionResult | undefined> {
-		if (!this._usesUserCredentialCC) {
+		if (!this.#usesUserCredentialCC) {
 			throw new ZWaveError(
 				"This node does not support learning credentials",
 				ZWaveErrorCodes.CC_NotSupported,
 			);
 		}
 
-		this._assertValidSlot(type, slot);
+		this.#assertValidSlot(type, slot);
 
-		const existing = this._getCredentialCached_U3C(userId, type, slot);
+		const existing = this.#getCredentialCached_U3C(userId, type, slot);
 		const operationType = existing
 			? UserCredentialOperationType.Modify
 			: UserCredentialOperationType.Add;
@@ -948,7 +877,7 @@ export class AccessControlMixin extends EndpointBase
 			);
 		}
 
-		const api = this._u3cAPI();
+		const api = this.#u3cAPI();
 		return api.startCredentialLearn({
 			userId,
 			credentialType: type,
@@ -958,57 +887,71 @@ export class AccessControlMixin extends EndpointBase
 		});
 	}
 
+	/**
+	 * Cancels an ongoing credential learn process.
+	 * Only supported on nodes using the User Credential CC.
+	 * This communicates with the node.
+	 */
 	public async cancelCredentialLearn(): Promise<
 		SupervisionResult | undefined
 	> {
-		if (!this._usesUserCredentialCC) {
+		if (!this.#usesUserCredentialCC) {
 			throw new ZWaveError(
 				"This node does not support learning credentials",
 				ZWaveErrorCodes.CC_NotSupported,
 			);
 		}
-		const api = this._u3cAPI();
+		const api = this.#u3cAPI();
 		return api.cancelCredentialLearn();
 	}
 
+	/**
+	 * Retrieves the admin code from the node.
+	 * This communicates with the node to retrieve fresh information.
+	 */
 	public async getAdminCode(): Promise<string | undefined> {
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			return api.getAdminPinCode();
-		} else if (this._usesUserCodeCC) {
-			const api = this._ucAPI();
+		} else if (this.#usesUserCodeCC) {
+			const api = this.#ucAPI();
 			return api.getAdminCode();
 		}
 		return undefined;
 	}
 
+	/**
+	 * Sets the admin code on the node.
+	 * This communicates with the node.
+	 */
 	public async setAdminCode(
 		code: string,
 	): Promise<SupervisionResult | undefined> {
-		if (this._usesUserCredentialCC) {
-			const api = this._u3cAPI();
+		if (this.#usesUserCredentialCC) {
+			const api = this.#u3cAPI();
 			return api.setAdminPinCode({ pinCode: code });
-		} else if (this._usesUserCodeCC) {
-			const api = this._ucAPI();
+		} else if (this.#usesUserCodeCC) {
+			const api = this.#ucAPI();
 			return api.setAdminCode(code);
 		}
-		this._throwNoAccessControl();
+		this.#throwNoAccessControl();
 	}
 
-	private _ucAPI(): UserCodeCCAPI {
-		return this.commandClasses["User Code"] as unknown as UserCodeCCAPI;
+	#ucAPI(): UserCodeCCAPI {
+		return this.endpoint
+			.commandClasses["User Code"] as unknown as UserCodeCCAPI;
 	}
 
-	private _u3cAPI(): UserCredentialCCAPI {
-		return this.commandClasses[
+	#u3cAPI(): UserCredentialCCAPI {
+		return this.endpoint.commandClasses[
 			"User Credential"
 		] as unknown as UserCredentialCCAPI;
 	}
 
 	/** Returns the credential type to use for User Code CC based on supported characters */
-	private get _ucCredentialType(): UserCredentialType {
-		const supportedASCIIChars = this._getValue<string>(
-			UserCodeCCValues.supportedASCIIChars.endpoint(this.index),
+	get #ucCredentialType(): UserCredentialType {
+		const supportedASCIIChars = this.getValue<string>(
+			UserCodeCCValues.supportedASCIIChars.endpoint(this.endpoint.index),
 		);
 		return supportsNonPINChars(supportedASCIIChars)
 			? UserCredentialType.Password
@@ -1016,7 +959,7 @@ export class AccessControlMixin extends EndpointBase
 	}
 
 	/** Maps User Code CC's UserIDStatus to the unified active/userType model */
-	private _mapUserCodeStatusToUserData(
+	#mapUserCodeStatusToUserData(
 		userId: number,
 		status: UserIDStatus,
 	): UserData | undefined {
@@ -1055,8 +998,8 @@ export class AccessControlMixin extends EndpointBase
 	}
 
 	/** Removes cached credential values for a given user from the value DB */
-	private _purgeCachedCredentials(userId: number): void {
-		const valueDB = this.tryGetNode()?.valueDB;
+	#purgeCachedCredentials(userId: number): void {
+		const valueDB = this.endpoint.tryGetNode()?.valueDB;
 		if (!valueDB) return;
 		const credentialValues = valueDB.findValues(
 			(vid) =>
@@ -1071,12 +1014,14 @@ export class AccessControlMixin extends EndpointBase
 	}
 
 	/** Removes all cached user and credential values from the value DB */
-	private _purgeAllCachedUsersAndCredentials(): void {
-		const valueDB = this.tryGetNode()?.valueDB;
+	#purgeAllCachedUsersAndCredentials(): void {
+		const valueDB = this.endpoint.tryGetNode()?.valueDB;
 		if (!valueDB) return;
 
-		const maxUsers = this._getValue<number>(
-			UserCredentialCCValues.supportedUsers.endpoint(this.index),
+		const maxUsers = this.getValue<number>(
+			UserCredentialCCValues.supportedUsers.endpoint(
+				this.endpoint.index,
+			),
 		) ?? 0;
 		for (let userId = 1; userId <= maxUsers; userId++) {
 			for (
@@ -1091,7 +1036,7 @@ export class AccessControlMixin extends EndpointBase
 					UserCredentialCCValues.userChecksum(userId),
 				]
 			) {
-				valueDB.removeValue(value.endpoint(this.index));
+				valueDB.removeValue(value.endpoint(this.endpoint.index));
 			}
 		}
 
@@ -1108,8 +1053,8 @@ export class AccessControlMixin extends EndpointBase
 	}
 
 	/** Removes all cached user code status and code values from the value DB */
-	private _purgeAllCachedUserCodes(): void {
-		const valueDB = this.tryGetNode()?.valueDB;
+	#purgeAllCachedUserCodes(): void {
+		const valueDB = this.endpoint.tryGetNode()?.valueDB;
 		if (!valueDB) return;
 
 		const values = valueDB.findValues(
@@ -1122,7 +1067,7 @@ export class AccessControlMixin extends EndpointBase
 		}
 	}
 
-	private _assertValidSlot(type: UserCredentialType, slot: number): void {
+	#assertValidSlot(type: UserCredentialType, slot: number): void {
 		const caps = this.getCredentialCapabilitiesCached()
 			?.supportedCredentialTypes.get(type);
 		if (!caps || slot < 1 || slot > caps.numberOfCredentialSlots) {
@@ -1135,71 +1080,81 @@ export class AccessControlMixin extends EndpointBase
 		}
 	}
 
-	private _throwNoAccessControl(): never {
+	#throwNoAccessControl(): never {
 		throw new ZWaveError(
 			"This node does not support managing users or credentials",
 			ZWaveErrorCodes.CC_NotSupported,
 		);
 	}
 
-	private _getUserCached_U3C(userId: number): UserData | undefined {
-		const userType = this._getValue<UserCredentialUserType>(
-			UserCredentialCCValues.userType(userId).endpoint(this.index),
+	#getUserCached_U3C(userId: number): UserData | undefined {
+		const userType = this.getValue<UserCredentialUserType>(
+			UserCredentialCCValues.userType(userId).endpoint(
+				this.endpoint.index,
+			),
 		);
 		if (userType == undefined) return undefined;
 
 		return {
 			userId,
-			active: this._getValue<boolean>(
-				UserCredentialCCValues.userActive(userId).endpoint(this.index),
+			active: this.getValue<boolean>(
+				UserCredentialCCValues.userActive(userId).endpoint(
+					this.endpoint.index,
+				),
 			) ?? false,
 			userType,
-			userName: this._getValue<string>(
-				UserCredentialCCValues.userName(userId).endpoint(this.index),
-			) ?? undefined,
-			credentialRule: this._getValue<UserCredentialRule>(
-				UserCredentialCCValues.credentialRule(userId).endpoint(
-					this.index,
+			userName: this.getValue<string>(
+				UserCredentialCCValues.userName(userId).endpoint(
+					this.endpoint.index,
 				),
 			) ?? undefined,
-			expiringTimeoutMinutes: this._getValue<number>(
+			credentialRule: this.getValue<UserCredentialRule>(
+				UserCredentialCCValues.credentialRule(userId).endpoint(
+					this.endpoint.index,
+				),
+			) ?? undefined,
+			expiringTimeoutMinutes: this.getValue<number>(
 				UserCredentialCCValues.expiringTimeoutMinutes(userId).endpoint(
-					this.index,
+					this.endpoint.index,
 				),
 			) || undefined,
 		};
 	}
 
-	private _getCredentialCached_U3C(
+	#getCredentialCached_U3C(
 		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): CredentialData | undefined {
-		const data = this._getValue<Uint8Array>(
+		const data = this.getValue<Uint8Array>(
 			UserCredentialCCValues.credential(userId, type, slot).endpoint(
-				this.index,
+				this.endpoint.index,
 			),
 		);
 		if (data == undefined) return undefined;
 		return { userId, type, slot, data };
 	}
 
-	private _getUserCached_UC(userId: number): UserData | undefined {
-		const status = this._getValue<UserIDStatus>(
-			UserCodeCCValues.userIdStatus(userId).endpoint(this.index),
+	#getUserCached_UC(userId: number): UserData | undefined {
+		const status = this.getValue<UserIDStatus>(
+			UserCodeCCValues.userIdStatus(userId).endpoint(
+				this.endpoint.index,
+			),
 		);
 		if (status == undefined) return undefined;
-		return this._mapUserCodeStatusToUserData(userId, status);
+		return this.#mapUserCodeStatusToUserData(userId, status);
 	}
 
-	private _getCredentialCached_UC(
+	#getCredentialCached_UC(
 		userId: number,
 		type: UserCredentialType,
 		slot: number,
 	): CredentialData | undefined {
 		if (slot !== 1) return undefined;
-		const status = this._getValue<UserIDStatus>(
-			UserCodeCCValues.userIdStatus(userId).endpoint(this.index),
+		const status = this.getValue<UserIDStatus>(
+			UserCodeCCValues.userIdStatus(userId).endpoint(
+				this.endpoint.index,
+			),
 		);
 		if (
 			status == undefined
@@ -1208,8 +1163,8 @@ export class AccessControlMixin extends EndpointBase
 		) {
 			return undefined;
 		}
-		const data = this._getValue<string>(
-			UserCodeCCValues.userCode(userId).endpoint(this.index),
+		const data = this.getValue<string>(
+			UserCodeCCValues.userCode(userId).endpoint(this.endpoint.index),
 		);
 		if (data == undefined) return undefined;
 		return { userId, type, slot, data };

--- a/packages/zwave-js/src/lib/node/feature-apis/DeviceFeatures.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/DeviceFeatures.ts
@@ -1,0 +1,4 @@
+/** High-level device features that can be tested for support via `endpoint.supportsFeature()` */
+export enum DeviceFeatures {
+	AccessControl,
+}

--- a/packages/zwave-js/src/lib/node/feature-apis/FeatureAPI.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/FeatureAPI.ts
@@ -1,0 +1,14 @@
+import { type MaybeNotKnown, type ValueID } from "@zwave-js/core";
+import type { EndpointBase } from "../endpoint-mixins/00_Base.js";
+
+/**
+ * Base class for high-level feature APIs exposed on endpoints via namespace getters.
+ * Each subclass represents a group of related functionality (e.g. access control, covers).
+ */
+export abstract class FeatureAPI {
+	public constructor(public readonly endpoint: EndpointBase) {}
+
+	protected getValue<T = unknown>(valueId: ValueID): MaybeNotKnown<T> {
+		return this.endpoint.tryGetNode()?.getValue(valueId);
+	}
+}

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -45,7 +45,7 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// User capabilities
-			const userCaps = node.getUserCapabilitiesCached();
+			const userCaps = node.accessControl.getUserCapabilitiesCached();
 			t.expect(userCaps).toBeDefined();
 			t.expect(userCaps!.maxUsers).toBe(10);
 			t.expect(userCaps!.supportedUserTypes).toStrictEqual([
@@ -58,7 +58,8 @@ integrationTest(
 			]);
 
 			// Credential capabilities
-			const credCaps = node.getCredentialCapabilitiesCached();
+			const credCaps = node.accessControl
+				.getCredentialCapabilitiesCached();
 			t.expect(credCaps).toBeDefined();
 			t.expect(credCaps!.supportsAdminCode).toBe(true);
 			t.expect(credCaps!.supportsAdminCodeDeactivation).toBe(true);
@@ -97,7 +98,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			const caps = node.getUserCapabilitiesCached();
+			const caps = node.accessControl.getUserCapabilitiesCached();
 			t.expect(caps!.supportedUserTypes).toStrictEqual([
 				UserCredentialUserType.General,
 			]);
@@ -149,28 +150,28 @@ integrationTest(
 			node.valueDB.setValue(UserCodeCCValues.userCode(3).id, "9999");
 
 			// User 1: Enabled -> active: true, userType: General
-			const user1 = node.getUserCached(1);
+			const user1 = node.accessControl.getUserCached(1);
 			t.expect(user1).toBeDefined();
 			t.expect(user1!.active).toBe(true);
 			t.expect(user1!.userType).toBe(UserCredentialUserType.General);
 
 			// User 2: Disabled -> active: false, userType: General
-			const user2 = node.getUserCached(2);
+			const user2 = node.accessControl.getUserCached(2);
 			t.expect(user2).toBeDefined();
 			t.expect(user2!.active).toBe(false);
 			t.expect(user2!.userType).toBe(UserCredentialUserType.General);
 
 			// User 3: Messaging -> active: true, userType: NonAccess
-			const user3 = node.getUserCached(3);
+			const user3 = node.accessControl.getUserCached(3);
 			t.expect(user3).toBeDefined();
 			t.expect(user3!.active).toBe(true);
 			t.expect(user3!.userType).toBe(UserCredentialUserType.NonAccess);
 
 			// User 4: not set -> undefined
-			t.expect(node.getUserCached(4)).toBeUndefined();
+			t.expect(node.accessControl.getUserCached(4)).toBeUndefined();
 
 			// getUsers should return 3 users
-			const users = node.getUsersCached();
+			const users = node.accessControl.getUsersCached();
 			t.expect(users.length).toBe(3);
 		},
 	},
@@ -203,14 +204,14 @@ integrationTest(
 			);
 			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
 
-			const creds = node.getCredentialsCached(1);
+			const creds = node.accessControl.getCredentialsCached(1);
 			t.expect(creds.length).toBe(1);
 			t.expect(creds[0].type).toBe(UserCredentialType.PINCode);
 			t.expect(creds[0].slot).toBe(1);
 			t.expect(creds[0].data).toBe("1234");
 
 			// Non-existent user has no credentials
-			t.expect(node.getCredentialsCached(2).length).toBe(0);
+			t.expect(node.accessControl.getCredentialsCached(2).length).toBe(0);
 		},
 	},
 );
@@ -245,7 +246,7 @@ integrationTest(
 				(_node, args) => credEvent.resolve(args),
 			);
 
-			await node.setCredential(
+			await node.accessControl.setCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -295,7 +296,7 @@ integrationTest(
 				(_node, args) => credEvent.resolve(args),
 			);
 
-			await node.setCredential(
+			await node.accessControl.setCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -347,7 +348,7 @@ integrationTest(
 				(_node, args) => credEvent.resolve(args),
 			);
 
-			await node.deleteUser(1);
+			await node.accessControl.deleteUser(1);
 
 			t.expect(await userEvent).toMatchObject({ userId: 1 });
 			t.expect(await credEvent).toMatchObject({
@@ -384,7 +385,7 @@ integrationTest(
 			node.on("credential deleted", () => eventEmitted = true);
 
 			// User 5 is within range but was never set
-			await node.deleteUser(5);
+			await node.accessControl.deleteUser(5);
 
 			// Give the driver time to process
 			await new Promise((resolve) => setTimeout(resolve, 100));
@@ -417,7 +418,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.setCredential(
+			await node.accessControl.setCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -460,7 +461,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.setCredential(
+			await node.accessControl.setCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -506,7 +507,7 @@ integrationTest(
 			const userEvent = createDeferredPromise<unknown>();
 			node.on("user added", (_node, args) => userEvent.resolve(args));
 
-			await node.setUser(1, {
+			await node.accessControl.setUser(1, {
 				active: true,
 				userType: UserCredentialUserType.General,
 			});
@@ -553,7 +554,7 @@ integrationTest(
 				(_node, args) => credEvent.resolve(args),
 			);
 
-			await node.deleteCredential(
+			await node.accessControl.deleteCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -588,7 +589,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.deleteAllUsers();
+			await node.accessControl.deleteAllUsers();
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -629,8 +630,8 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// Set admin code, then read it back
-			await node.setAdminCode("9999");
-			const code = await node.getAdminCode();
+			await node.accessControl.setAdminCode("9999");
+			const code = await node.accessControl.getAdminCode();
 			t.expect(code).toBe("9999");
 		},
 	},
@@ -659,7 +660,7 @@ integrationTest(
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
 
-			await node.setUser(1, {
+			await node.accessControl.setUser(1, {
 				active: false,
 				userType: UserCredentialUserType.General,
 			});
@@ -706,7 +707,7 @@ integrationTest(
 			);
 			node.valueDB.setValue(UserCodeCCValues.userCode(1).id, "1234");
 
-			await node.deleteCredential(
+			await node.accessControl.deleteCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -749,7 +750,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.setAdminCode("9999");
+			await node.accessControl.setAdminCode("9999");
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -784,7 +785,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.getAdminCode();
+			await node.accessControl.getAdminCode();
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -818,7 +819,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.deleteUser(1);
+			await node.accessControl.deleteUser(1);
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -90,7 +90,7 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			// User capabilities
-			const userCaps = node.getUserCapabilitiesCached();
+			const userCaps = node.accessControl.getUserCapabilitiesCached();
 			t.expect(userCaps).toBeDefined();
 			t.expect(userCaps!.maxUsers).toBe(20);
 			t.expect(userCaps!.maxUserNameLength).toBe(64);
@@ -105,7 +105,8 @@ integrationTest(
 			]);
 
 			// Credential capabilities
-			const credCaps = node.getCredentialCapabilitiesCached();
+			const credCaps = node.accessControl
+				.getCredentialCapabilitiesCached();
 			t.expect(credCaps).toBeDefined();
 			t.expect(credCaps!.supportsAdminCode).toBe(true);
 			t.expect(credCaps!.supportsAdminCodeDeactivation).toBe(true);
@@ -163,7 +164,7 @@ integrationTest(
 			// the mock's response has been processed and cached.
 			const userCreated = createDeferredPromise<void>();
 			node.once("user added", () => userCreated.resolve());
-			await node.setUser(1, {
+			await node.accessControl.setUser(1, {
 				active: true,
 				userType: UserCredentialUserType.General,
 				userName: "Alice",
@@ -172,7 +173,7 @@ integrationTest(
 
 			const credCreated = createDeferredPromise<void>();
 			node.once("credential added", () => credCreated.resolve());
-			await node.setCredential(
+			await node.accessControl.setCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -181,18 +182,18 @@ integrationTest(
 			await credCreated;
 
 			// Now verify reads return the correct data
-			const user = node.getUserCached(1);
+			const user = node.accessControl.getUserCached(1);
 			t.expect(user).toBeDefined();
 			t.expect(user!.active).toBe(true);
 			t.expect(user!.userType).toBe(UserCredentialUserType.General);
 			t.expect(user!.userName).toBe("Alice");
 
-			t.expect(node.getUserCached(2)).toBeUndefined();
+			t.expect(node.accessControl.getUserCached(2)).toBeUndefined();
 
-			const users = node.getUsersCached();
+			const users = node.accessControl.getUsersCached();
 			t.expect(users.length).toBe(1);
 
-			const creds = node.getCredentialsCached(1);
+			const creds = node.accessControl.getCredentialsCached(1);
 			t.expect(creds.length).toBe(1);
 			t.expect(creds[0].type).toBe(UserCredentialType.PINCode);
 			t.expect(creds[0].slot).toBe(1);
@@ -567,7 +568,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.setUser(1, {
+			await node.accessControl.setUser(1, {
 				active: true,
 				userType: UserCredentialUserType.General,
 				userName: "Charlie",
@@ -612,7 +613,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.setCredential(
+			await node.accessControl.setCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -662,7 +663,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.deleteUser(5);
+			await node.accessControl.deleteUser(5);
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -704,7 +705,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.deleteAllUsers();
+			await node.accessControl.deleteAllUsers();
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -746,7 +747,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.deleteCredential(
+			await node.accessControl.deleteCredential(
 				1,
 				UserCredentialType.PINCode,
 				1,
@@ -794,7 +795,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.setAdminCode("9876");
+			await node.accessControl.setAdminCode("9876");
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -833,7 +834,7 @@ integrationTest(
 		},
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
-			await node.getAdminCode();
+			await node.accessControl.getAdminCode();
 
 			mockNode.assertReceivedControllerFrame(
 				(frame) =>
@@ -869,7 +870,7 @@ async function populateUserAndCredential(
 ) {
 	const userCreated = createDeferredPromise<void>();
 	node.once("user added", () => userCreated.resolve());
-	await node.setUser(1, {
+	await node.accessControl.setUser(1, {
 		active: true,
 		userType: UserCredentialUserType.General,
 		userName: "Test",
@@ -878,7 +879,12 @@ async function populateUserAndCredential(
 
 	const credCreated = createDeferredPromise<void>();
 	node.once("credential added", () => credCreated.resolve());
-	await node.setCredential(1, UserCredentialType.PINCode, 1, "1234");
+	await node.accessControl.setCredential(
+		1,
+		UserCredentialType.PINCode,
+		1,
+		"1234",
+	);
 	await credCreated;
 }
 
@@ -896,18 +902,18 @@ integrationTest(
 			await populateUserAndCredential(node);
 
 			// Verify data is cached
-			t.expect(node.getUserCached(1)).toBeDefined();
-			t.expect(node.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl.getUserCached(1)).toBeDefined();
+			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
 
 			const deleted = createDeferredPromise<void>();
 			node.once("user deleted", () => deleted.resolve());
-			await node.deleteUser(1);
+			await node.accessControl.deleteUser(1);
 			await deleted;
 
 			// User values are purged by the CC report handler,
 			// credentials must be purged by the AccessControl mixin
-			t.expect(node.getUserCached(1)).toBeUndefined();
-			t.expect(node.getCredentialsCached(1).length).toBe(0);
+			t.expect(node.accessControl.getUserCached(1)).toBeUndefined();
+			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(0);
 		},
 	},
 );
@@ -946,14 +952,14 @@ integrationTest(
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await populateUserAndCredential(node);
 
-			t.expect(node.getUserCached(1)).toBeDefined();
-			t.expect(node.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl.getUserCached(1)).toBeDefined();
+			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
 
-			await node.deleteUser(1);
+			await node.accessControl.deleteUser(1);
 
 			// Supervised command failed — cache must remain intact
-			t.expect(node.getUserCached(1)).toBeDefined();
-			t.expect(node.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl.getUserCached(1)).toBeDefined();
+			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
 		},
 	},
 );
@@ -971,15 +977,15 @@ integrationTest(
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await populateUserAndCredential(node);
 
-			t.expect(node.getUsersCached().length).toBe(1);
-			t.expect(node.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl.getUsersCached().length).toBe(1);
+			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
 
 			// deleteAllUsers returns after the API call completes;
 			// the purge happens synchronously before returning
-			await node.deleteAllUsers();
+			await node.accessControl.deleteAllUsers();
 
-			t.expect(node.getUsersCached().length).toBe(0);
-			t.expect(node.getCredentialsCached(1).length).toBe(0);
+			t.expect(node.accessControl.getUsersCached().length).toBe(0);
+			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(0);
 		},
 	},
 );
@@ -1017,14 +1023,14 @@ integrationTest(
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			await populateUserAndCredential(node);
 
-			t.expect(node.getUsersCached().length).toBe(1);
-			t.expect(node.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl.getUsersCached().length).toBe(1);
+			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
 
-			await node.deleteAllUsers();
+			await node.accessControl.deleteAllUsers();
 
 			// Supervised command failed — cache must remain intact
-			t.expect(node.getUsersCached().length).toBe(1);
-			t.expect(node.getCredentialsCached(1).length).toBe(1);
+			t.expect(node.accessControl.getUsersCached().length).toBe(1);
+			t.expect(node.accessControl.getCredentialsCached(1).length).toBe(1);
 		},
 	},
 );


### PR DESCRIPTION
As mentioned in https://github.com/zwave-js/zwave-js-server/pull/1544#pullrequestreview-4101107871, it makes sense to namespace these high-level feature APIs, given that we're going to add more in the future. Technically breaking, but it is unlikely to be used out in the wild yet.