### PR TITLE
refactor: make `endpoint.accessControl` `undefined` if unsupported

### DIFF
--- a/docs/api/endpoint.md
+++ b/docs/api/endpoint.md
@@ -295,25 +295,22 @@ Retrieves the version of the given CommandClass this endpoint implements.
 
 Z-Wave JS provides a unified API for managing users and credentials on access control devices such as door locks. This API transparently supports both the **User Credential CC** and the legacy **User Code CC**, abstracting away the differences between the two.
 
-The credential management API is accessed via the `accessControl` property on endpoints and nodes. Before accessing it, use `endpoint.supportsFeature` to check for support:
+The credential management API is accessed via the `accessControl` property on endpoints and nodes. The property is `undefined` when the endpoint does not support access control, so use it as the support check:
 
 ```ts
-// Check if the endpoint supports access control
-if (endpoint.supportsFeature(DeviceFeatures.AccessControl)) {
+if (endpoint.accessControl) {
 	const user = await endpoint.accessControl.getUser(1);
 }
 ```
 
 > [!NOTE] For nodes using the **User Code CC**, only a subset of the functionality is available. Each user supports a single credential in slot 1, user names and credential rules are not supported, and credential learning is unavailable.
 
-> [!NOTE] Methods that read data return `undefined` when the endpoint does not support access control. Methods that write data will throw if neither the **User Credential CC** nor the **User Code CC** is supported.
-
 ### Querying capabilities
 
 #### `getUserCapabilitiesCached`
 
 ```ts
-getUserCapabilitiesCached(): UserCapabilities | undefined
+getUserCapabilitiesCached(): UserCapabilities
 ```
 
 Returns user-related capabilities of the endpoint. This method uses cached information from the most recent interview.
@@ -332,7 +329,7 @@ interface UserCapabilities {
 #### `getCredentialCapabilitiesCached`
 
 ```ts
-getCredentialCapabilitiesCached(): CredentialCapabilities | undefined
+getCredentialCapabilitiesCached(): CredentialCapabilities
 ```
 
 Returns credential-related capabilities of the endpoint. This method uses cached information from the most recent interview.

--- a/packages/zwave-js/src/Node.ts
+++ b/packages/zwave-js/src/Node.ts
@@ -27,5 +27,4 @@ export type {
 	UserCapabilities,
 	UserData,
 } from "./lib/node/feature-apis/AccessControl.js";
-export { DeviceFeatures } from "./lib/node/feature-apis/DeviceFeatures.js";
 export { FeatureAPI } from "./lib/node/feature-apis/FeatureAPI.js";

--- a/packages/zwave-js/src/lib/node/VirtualEndpoint.test.ts
+++ b/packages/zwave-js/src/lib/node/VirtualEndpoint.test.ts
@@ -21,7 +21,7 @@ import {
 	getDefaultSupportedFunctionTypes,
 } from "@zwave-js/testing";
 import { wait } from "alcalzone-shared/async";
-import { test as baseTest } from "vitest";
+import { describe, test as baseTest } from "vitest";
 import {
 	createDefaultMockControllerBehaviors,
 	createDefaultMockNodeBehaviors,
@@ -116,255 +116,266 @@ const test = baseTest.extend<LocalTestContext>({
 	],
 });
 
-test.sequential(
-	"createAPI() throws if a non-implemented API should be created",
-	({ context, expect }) => {
-		const { driver } = context;
-		const broadcast = driver.controller.getBroadcastNode();
-		assertZWaveError(expect, () => broadcast.createAPI(0xbada55 as any), {
-			errorCode: ZWaveErrorCodes.CC_NoAPI,
-			messageMatches: "no associated API",
-		});
-	},
-);
-
-test.sequential(
-	"the broadcast API throws when trying to access a non-supported CC",
-	async ({ context, expect }) => {
-		const { driver, makePhysicalNode } = context;
-		await makePhysicalNode(2);
-		await makePhysicalNode(3);
-		const broadcast = driver.controller.getBroadcastNode();
-
-		// We must not use Basic CC here, because that is assumed to be always supported
-		const api = broadcast.createAPI(
-			CommandClasses["Binary Switch"],
-		) as BinarySensorCCAPI;
-
-		// this does not throw
-		api.isSupported();
-		// this does
-		await assertZWaveError(expect, () => api.get(), {
-			errorCode: ZWaveErrorCodes.CC_NotSupported,
-		});
-	},
-);
-
-test.sequential(
-	"the broadcast API should know it is a broadcast API",
-	async ({ context, expect }) => {
-		const { driver, makePhysicalNode } = context;
-		await makePhysicalNode(2);
-		await makePhysicalNode(3);
-		const broadcast = driver.controller.getBroadcastNode();
-
-		expect(broadcast.createAPI(CommandClasses.Basic)["isBroadcast"]())
-			.toBe(true);
-	},
-);
-
-test.sequential(
-	"the multicast API should know it is a multicast API",
-	async ({ context, expect }) => {
-		const { driver, makePhysicalNode } = context;
-		await makePhysicalNode(2);
-		await makePhysicalNode(3);
-		const multicast = driver.controller.getMulticastGroup([2, 3]);
-
-		expect(multicast.createAPI(CommandClasses.Basic)["isMulticast"]())
-			.toBe(true);
-	},
-);
-
-{
-	async function prepareTest(
-		context: LocalTestContext["context"],
-	): Promise<{ node2: ZWaveNode; node3: ZWaveNode }> {
-		return {
-			node2: await context.makePhysicalNode(2),
-			node3: await context.makePhysicalNode(3),
-		};
-	}
-
+// This test sometimes runs slow on CI, give them a higher timeout
+describe("VirtualEndpoint", { timeout: 30_000 }, () => {
 	test.sequential(
-		"the commandClasses dictionary throws when trying to access a non-implemented CC",
-		async ({ context, expect }) => {
+		"createAPI() throws if a non-implemented API should be created",
+		({ context, expect }) => {
 			const { driver } = context;
-			await prepareTest(context);
-
 			const broadcast = driver.controller.getBroadcastNode();
-
 			assertZWaveError(
 				expect,
-				// @ts-expect-error
-				() => broadcast.commandClasses.FOOBAR,
+				() => broadcast.createAPI(0xbada55 as any),
 				{
-					errorCode: ZWaveErrorCodes.CC_NotImplemented,
-					messageMatches: "FOOBAR is not implemented",
+					errorCode: ZWaveErrorCodes.CC_NoAPI,
+					messageMatches: "no associated API",
 				},
 			);
 		},
 	);
 
-	// This test never worked:
-	// test.serial.only(
-	// 	"the commandClasses dictionary throws when trying to use a command of an unsupported CC",
-	// 	({ context, expect }) => {
-	// 		const { driver } = context;
-	// 		prepareTest(context);
-
-	// 		const broadcast = driver.controller.getBroadcastNode();
-	// 		assertZWaveError(
-	// 			t,
-	// 			() => broadcast.commandClasses["Binary Switch"].set(true),
-	// 			{
-	// 				errorCode: ZWaveErrorCodes.CC_NotSupported,
-	// 				messageMatches:
-	// 					"does not support the Command Class Binary Switch",
-	// 			},
-	// 		);
-	// 	},
-	// );
-
 	test.sequential(
-		"the commandClasses dictionary does not throw when checking support of a CC",
+		"the broadcast API throws when trying to access a non-supported CC",
 		async ({ context, expect }) => {
-			const { driver } = context;
-			await prepareTest(context);
-
+			const { driver, makePhysicalNode } = context;
+			await makePhysicalNode(2);
+			await makePhysicalNode(3);
 			const broadcast = driver.controller.getBroadcastNode();
-			expect(broadcast.commandClasses["Binary Switch"].isSupported())
-				.toBe(false);
+
+			// We must not use Basic CC here, because that is assumed to be always supported
+			const api = broadcast.createAPI(
+				CommandClasses["Binary Switch"],
+			) as BinarySensorCCAPI;
+
+			// this does not throw
+			api.isSupported();
+			// this does
+			await assertZWaveError(expect, () => api.get(), {
+				errorCode: ZWaveErrorCodes.CC_NotSupported,
+			});
 		},
 	);
 
 	test.sequential(
-		"the commandClasses dictionary does not throw when accessing the ID of a CC",
+		"the broadcast API should know it is a broadcast API",
 		async ({ context, expect }) => {
-			const { driver } = context;
-			await prepareTest(context);
-
+			const { driver, makePhysicalNode } = context;
+			await makePhysicalNode(2);
+			await makePhysicalNode(3);
 			const broadcast = driver.controller.getBroadcastNode();
-			expect(
-				broadcast.commandClasses["Binary Switch"].ccId,
-			).toBe(CommandClasses["Binary Switch"]);
+
+			expect(broadcast.createAPI(CommandClasses.Basic)["isBroadcast"]())
+				.toBe(true);
 		},
 	);
 
 	test.sequential(
-		"the commandClasses dictionary does not throw when scoping the API options",
+		"the multicast API should know it is a multicast API",
 		async ({ context, expect }) => {
-			const { driver } = context;
-			await prepareTest(context);
+			const { driver, makePhysicalNode } = context;
+			await makePhysicalNode(2);
+			await makePhysicalNode(3);
+			const multicast = driver.controller.getMulticastGroup([2, 3]);
 
-			const broadcast = driver.controller.getBroadcastNode();
-			expect(() =>
-				broadcast.commandClasses["Binary Switch"].withOptions({})
-			).not.toThrow();
+			expect(multicast.createAPI(CommandClasses.Basic)["isMulticast"]())
+				.toBe(true);
 		},
 	);
 
-	test.sequential(
-		"the commandClasses dictionary  returns all supported CCs when being enumerated",
-		async ({ context, expect }) => {
-			const { driver } = context;
-			const { node2, node3 } = await prepareTest(context);
+	{
+		async function prepareTest(
+			context: LocalTestContext["context"],
+		): Promise<{ node2: ZWaveNode; node3: ZWaveNode }> {
+			return {
+				node2: await context.makePhysicalNode(2),
+				node3: await context.makePhysicalNode(3),
+			};
+		}
 
-			// No supported CCs, empty array
-			let broadcast = driver.controller.getBroadcastNode();
-			let actual = [...broadcast.commandClasses];
-			expect(actual).toStrictEqual([]);
+		test.sequential(
+			"the commandClasses dictionary throws when trying to access a non-implemented CC",
+			async ({ context, expect }) => {
+				const { driver } = context;
+				await prepareTest(context);
 
-			// Supported and controlled CCs
-			node2.addCC(CommandClasses["Binary Switch"], { isSupported: true });
-			node2.addCC(CommandClasses["Wake Up"], { isControlled: true });
-			node3.addCC(CommandClasses["Binary Switch"], { isSupported: true });
-			node3.addCC(CommandClasses.Version, { isSupported: true });
-			broadcast = driver.controller.getBroadcastNode();
+				const broadcast = driver.controller.getBroadcastNode();
 
-			actual = [...broadcast.commandClasses];
-			expect(actual.length).toBe(1);
-			expect(
-				actual.map((api) => api.constructor),
-			).toStrictEqual([
-				BinarySwitchCCAPI,
-				// VersionCCAPI cannot be used in broadcast
-				// WakeUpCCAPI is not supported (only controlled), so no API!
-			]);
-		},
-	);
-
-	test.sequential(
-		"the commandClasses dictionary  returns [object Object] when turned into a string",
-		async ({ context, expect }) => {
-			const { driver } = context;
-			await prepareTest(context);
-
-			const broadcast = driver.controller.getBroadcastNode();
-			expect(
-				// @ts-expect-error
-				broadcast.commandClasses[Symbol.toStringTag],
-			).toBe("[object Object]");
-		},
-	);
-
-	test.sequential(
-		"the commandClasses dictionary  returns undefined for other symbol properties",
-		async ({ context, expect }) => {
-			const { driver } = context;
-			await prepareTest(context);
-
-			const broadcast = driver.controller.getBroadcastNode();
-			expect(
-				// @ts-expect-error
-				broadcast.commandClasses[Symbol.unscopables],
-			).toBeUndefined();
-		},
-	);
-}
-
-test.sequential(
-	"broadcast uses the correct commands behind the scenes",
-	async ({ context, expect }) => {
-		const { driver, controller, makePhysicalNode } = context;
-		await makePhysicalNode(2);
-		await makePhysicalNode(3);
-		const broadcast = driver.controller.getBroadcastNode();
-		broadcast.commandClasses.Basic.set(99).catch(noop);
-		await wait(1);
-		// » [Node 255] [REQ] [SendData]
-		//   │ transmit options: 0x25
-		//   │ callback id:        1
-		//   └─[BasicCCSet]
-		controller.assertReceivedHostMessage((msg) =>
-			msg instanceof SendDataRequest
-			&& msg.getNodeId() === 255
-			&& msg.serializedCC?.[0] === CommandClasses.Basic
-			&& msg.serializedCC?.[1] === BasicCommand.Set
+				assertZWaveError(
+					expect,
+					// @ts-expect-error
+					() => broadcast.commandClasses.FOOBAR,
+					{
+						errorCode: ZWaveErrorCodes.CC_NotImplemented,
+						messageMatches: "FOOBAR is not implemented",
+					},
+				);
+			},
 		);
-	},
-);
 
-test.sequential(
-	"multicast uses the correct commands behind the scenes",
-	async ({ context, expect }) => {
-		const { driver, controller, makePhysicalNode } = context;
-		await makePhysicalNode(2);
-		await makePhysicalNode(3);
-		const multicast = driver.controller.getMulticastGroup([2, 3]);
-		multicast.commandClasses.Basic.set(99).catch(noop);
-		await wait(1);
-		// » [Node 2, 3] [REQ] [SendData]
-		//   │ transmit options: 0x25
-		//   │ callback id:        1
-		//   └─[BasicCCSet]
-		controller.assertReceivedHostMessage((msg) =>
-			msg instanceof SendDataMulticastRequest
-			&& msg.nodeIds.length === 2
-			&& msg.nodeIds.includes(2)
-			&& msg.nodeIds.includes(3)
-			&& msg.serializedCC?.[0] === CommandClasses.Basic
-			&& msg.serializedCC?.[1] === BasicCommand.Set
+		// This test never worked:
+		// test.serial.only(
+		// 	"the commandClasses dictionary throws when trying to use a command of an unsupported CC",
+		// 	({ context, expect }) => {
+		// 		const { driver } = context;
+		// 		prepareTest(context);
+
+		// 		const broadcast = driver.controller.getBroadcastNode();
+		// 		assertZWaveError(
+		// 			t,
+		// 			() => broadcast.commandClasses["Binary Switch"].set(true),
+		// 			{
+		// 				errorCode: ZWaveErrorCodes.CC_NotSupported,
+		// 				messageMatches:
+		// 					"does not support the Command Class Binary Switch",
+		// 			},
+		// 		);
+		// 	},
+		// );
+
+		test.sequential(
+			"the commandClasses dictionary does not throw when checking support of a CC",
+			async ({ context, expect }) => {
+				const { driver } = context;
+				await prepareTest(context);
+
+				const broadcast = driver.controller.getBroadcastNode();
+				expect(broadcast.commandClasses["Binary Switch"].isSupported())
+					.toBe(false);
+			},
 		);
-	},
-);
+
+		test.sequential(
+			"the commandClasses dictionary does not throw when accessing the ID of a CC",
+			async ({ context, expect }) => {
+				const { driver } = context;
+				await prepareTest(context);
+
+				const broadcast = driver.controller.getBroadcastNode();
+				expect(
+					broadcast.commandClasses["Binary Switch"].ccId,
+				).toBe(CommandClasses["Binary Switch"]);
+			},
+		);
+
+		test.sequential(
+			"the commandClasses dictionary does not throw when scoping the API options",
+			async ({ context, expect }) => {
+				const { driver } = context;
+				await prepareTest(context);
+
+				const broadcast = driver.controller.getBroadcastNode();
+				expect(() =>
+					broadcast.commandClasses["Binary Switch"].withOptions({})
+				).not.toThrow();
+			},
+		);
+
+		test.sequential(
+			"the commandClasses dictionary  returns all supported CCs when being enumerated",
+			async ({ context, expect }) => {
+				const { driver } = context;
+				const { node2, node3 } = await prepareTest(context);
+
+				// No supported CCs, empty array
+				let broadcast = driver.controller.getBroadcastNode();
+				let actual = [...broadcast.commandClasses];
+				expect(actual).toStrictEqual([]);
+
+				// Supported and controlled CCs
+				node2.addCC(CommandClasses["Binary Switch"], {
+					isSupported: true,
+				});
+				node2.addCC(CommandClasses["Wake Up"], { isControlled: true });
+				node3.addCC(CommandClasses["Binary Switch"], {
+					isSupported: true,
+				});
+				node3.addCC(CommandClasses.Version, { isSupported: true });
+				broadcast = driver.controller.getBroadcastNode();
+
+				actual = [...broadcast.commandClasses];
+				expect(actual.length).toBe(1);
+				expect(
+					actual.map((api) => api.constructor),
+				).toStrictEqual([
+					BinarySwitchCCAPI,
+					// VersionCCAPI cannot be used in broadcast
+					// WakeUpCCAPI is not supported (only controlled), so no API!
+				]);
+			},
+		);
+
+		test.sequential(
+			"the commandClasses dictionary  returns [object Object] when turned into a string",
+			async ({ context, expect }) => {
+				const { driver } = context;
+				await prepareTest(context);
+
+				const broadcast = driver.controller.getBroadcastNode();
+				expect(
+					// @ts-expect-error
+					broadcast.commandClasses[Symbol.toStringTag],
+				).toBe("[object Object]");
+			},
+		);
+
+		test.sequential(
+			"the commandClasses dictionary  returns undefined for other symbol properties",
+			async ({ context, expect }) => {
+				const { driver } = context;
+				await prepareTest(context);
+
+				const broadcast = driver.controller.getBroadcastNode();
+				expect(
+					// @ts-expect-error
+					broadcast.commandClasses[Symbol.unscopables],
+				).toBeUndefined();
+			},
+		);
+	}
+
+	test.sequential(
+		"broadcast uses the correct commands behind the scenes",
+		async ({ context, expect }) => {
+			const { driver, controller, makePhysicalNode } = context;
+			await makePhysicalNode(2);
+			await makePhysicalNode(3);
+			const broadcast = driver.controller.getBroadcastNode();
+			broadcast.commandClasses.Basic.set(99).catch(noop);
+			await wait(1);
+			// » [Node 255] [REQ] [SendData]
+			//   │ transmit options: 0x25
+			//   │ callback id:        1
+			//   └─[BasicCCSet]
+			controller.assertReceivedHostMessage((msg) =>
+				msg instanceof SendDataRequest
+				&& msg.getNodeId() === 255
+				&& msg.serializedCC?.[0] === CommandClasses.Basic
+				&& msg.serializedCC?.[1] === BasicCommand.Set
+			);
+		},
+	);
+
+	test.sequential(
+		"multicast uses the correct commands behind the scenes",
+		async ({ context, expect }) => {
+			const { driver, controller, makePhysicalNode } = context;
+			await makePhysicalNode(2);
+			await makePhysicalNode(3);
+			const multicast = driver.controller.getMulticastGroup([2, 3]);
+			multicast.commandClasses.Basic.set(99).catch(noop);
+			await wait(1);
+			// » [Node 2, 3] [REQ] [SendData]
+			//   │ transmit options: 0x25
+			//   │ callback id:        1
+			//   └─[BasicCCSet]
+			controller.assertReceivedHostMessage((msg) =>
+				msg instanceof SendDataMulticastRequest
+				&& msg.nodeIds.length === 2
+				&& msg.nodeIds.includes(2)
+				&& msg.nodeIds.includes(3)
+				&& msg.serializedCC?.[0] === CommandClasses.Basic
+				&& msg.serializedCC?.[1] === BasicCommand.Set
+			);
+		},
+	);
+});

--- a/packages/zwave-js/src/lib/node/endpoint-mixins/index.ts
+++ b/packages/zwave-js/src/lib/node/endpoint-mixins/index.ts
@@ -1,22 +1,24 @@
 import { CommandClasses } from "@zwave-js/core";
 import { AccessControlAPI } from "../feature-apis/AccessControl.js";
-import { DeviceFeatures } from "../feature-apis/DeviceFeatures.js";
 import { EndpointBase } from "./00_Base.js";
 
 export class FeatureAPIsMixin extends EndpointBase {
 	private _accessControl?: AccessControlAPI;
 
-	public get accessControl(): AccessControlAPI {
-		return this._accessControl ??= new AccessControlAPI(this);
-	}
-
-	/** Tests whether this endpoint supports the given high-level device feature */
-	public supportsFeature(feature: DeviceFeatures): boolean {
-		switch (feature) {
-			case DeviceFeatures.AccessControl:
-				return this.supportsCC(CommandClasses["User Credential"])
-					|| this.supportsCC(CommandClasses["User Code"]);
+	/**
+	 * High-level API for managing users and credentials on access control
+	 * devices. Returns `undefined` if the endpoint supports neither the
+	 * **User Credential CC** nor the **User Code CC**.
+	 */
+	public get accessControl(): AccessControlAPI | undefined {
+		if (
+			!this.supportsCC(CommandClasses["User Credential"])
+			&& !this.supportsCC(CommandClasses["User Code"])
+		) {
+			return undefined;
 		}
+		this._accessControl ??= new AccessControlAPI(this);
+		return this._accessControl;
 	}
 }
 

--- a/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/AccessControl.ts
@@ -83,19 +83,11 @@ export class AccessControlAPI extends FeatureAPI {
 		return this.endpoint.supportsCC(CommandClasses["User Credential"]);
 	}
 
-	get #usesUserCodeCC(): boolean {
-		return !this.#usesUserCredentialCC
-			&& this.endpoint.supportsCC(CommandClasses["User Code"]);
-	}
-
 	/**
 	 * Returns the user-related capabilities of this endpoint.
 	 * This method uses cached information from the most recent interview.
 	 */
-	public getUserCapabilitiesCached():
-		| UserCapabilities
-		| undefined
-	{
+	public getUserCapabilitiesCached(): UserCapabilities {
 		if (this.#usesUserCredentialCC) {
 			return {
 				maxUsers: this.getValue<number>(
@@ -119,7 +111,7 @@ export class AccessControlAPI extends FeatureAPI {
 					),
 				) ?? [],
 			};
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const supportedStatuses = this.getValue<UserIDStatus[]>(
 				UserCodeCCValues.supportedUserIDStatuses.endpoint(
 					this.endpoint.index,
@@ -146,17 +138,13 @@ export class AccessControlAPI extends FeatureAPI {
 				supportedCredentialRules: [UserCredentialRule.Single],
 			};
 		}
-		return undefined;
 	}
 
 	/**
 	 * Returns the credential-related capabilities of this endpoint.
 	 * This method uses cached information from the most recent interview.
 	 */
-	public getCredentialCapabilitiesCached():
-		| CredentialCapabilities
-		| undefined
-	{
+	public getCredentialCapabilitiesCached(): CredentialCapabilities {
 		if (this.#usesUserCredentialCC) {
 			const supportedTypes = this.getValue<UserCredentialType[]>(
 				UserCredentialCCValues.supportedCredentialTypes.endpoint(
@@ -190,7 +178,7 @@ export class AccessControlAPI extends FeatureAPI {
 						.endpoint(this.endpoint.index),
 				) ?? false,
 			};
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			// User Code CC only supports a single credential per user
 			// with a length of 4-10 characters (CC:0063.01.01.11.006).
 			// Despite the spec calling them "PIN codes", v1 devices often
@@ -221,7 +209,6 @@ export class AccessControlAPI extends FeatureAPI {
 				) ?? false,
 			};
 		}
-		return undefined;
 	}
 
 	/**
@@ -242,7 +229,7 @@ export class AccessControlAPI extends FeatureAPI {
 				expiringTimeoutMinutes: result.expiringTimeoutMinutes
 					|| undefined,
 			};
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const api = this.#ucAPI();
 			const result = await api.get(userId);
 			if (!result) return undefined;
@@ -251,7 +238,6 @@ export class AccessControlAPI extends FeatureAPI {
 				result.userIdStatus,
 			);
 		}
-		return undefined;
 	}
 
 	/**
@@ -261,10 +247,9 @@ export class AccessControlAPI extends FeatureAPI {
 	public getUserCached(userId: number): UserData | undefined {
 		if (this.#usesUserCredentialCC) {
 			return this.#getUserCached_U3C(userId);
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			return this.#getUserCached_UC(userId);
 		}
-		return undefined;
 	}
 
 	/**
@@ -293,7 +278,7 @@ export class AccessControlAPI extends FeatureAPI {
 				nextUserId = result.nextUserId;
 			} while (nextUserId > 0);
 			return users;
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const api = this.#ucAPI();
 			const maxUsers = await api.getUsersCount();
 			if (!maxUsers) return [];
@@ -335,7 +320,6 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return users;
 		}
-		return [];
 	}
 
 	/**
@@ -355,7 +339,7 @@ export class AccessControlAPI extends FeatureAPI {
 				if (user) users.push(user);
 			}
 			return users;
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const maxUsers = this.getValue<number>(
 				UserCodeCCValues.supportedUsers.endpoint(this.endpoint.index),
 			) ?? 0;
@@ -366,7 +350,6 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return users;
 		}
-		return [];
 	}
 
 	/**
@@ -412,7 +395,7 @@ export class AccessControlAPI extends FeatureAPI {
 					?? existing?.credentialRule,
 				userName: options.userName ?? existing?.userName,
 			});
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const api = this.#ucAPI();
 			const existing = this.#getUserCached_UC(userId);
 			const existingStatus = this.getValue<UserIDStatus>(
@@ -479,7 +462,6 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return result;
 		}
-		this.#throwNoAccessControl();
 	}
 
 	/**
@@ -499,7 +481,7 @@ export class AccessControlAPI extends FeatureAPI {
 				this.#purgeCachedCredentials(userId);
 			}
 			return result;
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			// User Code CC ties each user to their code, so clearing
 			// the code implicitly deletes the user and vice versa
 			const existed = this.#getUserCached_UC(userId) != undefined;
@@ -527,7 +509,6 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return result;
 		}
-		this.#throwNoAccessControl();
 	}
 
 	/**
@@ -545,7 +526,7 @@ export class AccessControlAPI extends FeatureAPI {
 				this.#purgeAllCachedUsersAndCredentials();
 			}
 			return result;
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const api = this.#ucAPI();
 			const result = await api.clear(0);
 			// Verifying all users being deleted is unrealistic
@@ -556,7 +537,6 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return result;
 		}
-		this.#throwNoAccessControl();
 	}
 
 	/**
@@ -580,7 +560,7 @@ export class AccessControlAPI extends FeatureAPI {
 				slot: result.credentialSlot,
 				data: result.credentialData,
 			};
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const api = this.#ucAPI();
 			const result = await api.get(userId);
 			if (!result) return undefined;
@@ -592,7 +572,6 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return { userId, type, slot, data: result.userCode };
 		}
-		return undefined;
 	}
 
 	/**
@@ -608,10 +587,9 @@ export class AccessControlAPI extends FeatureAPI {
 
 		if (this.#usesUserCredentialCC) {
 			return this.#getCredentialCached_U3C(userId, type, slot);
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			return this.#getCredentialCached_UC(userId, type, slot);
 		}
-		return undefined;
 	}
 
 	/**
@@ -645,7 +623,7 @@ export class AccessControlAPI extends FeatureAPI {
 				|| nextCredSlot !== 0
 			);
 			return credentials;
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const cred = await this.getCredential(
 				userId,
 				this.#ucCredentialType,
@@ -653,7 +631,6 @@ export class AccessControlAPI extends FeatureAPI {
 			);
 			return cred ? [cred] : [];
 		}
-		return [];
 	}
 
 	/**
@@ -691,7 +668,7 @@ export class AccessControlAPI extends FeatureAPI {
 				}
 			}
 			return credentials;
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const cred = this.#getCredentialCached_UC(
 				userId,
 				this.#ucCredentialType,
@@ -699,7 +676,6 @@ export class AccessControlAPI extends FeatureAPI {
 			);
 			return cred ? [cred] : [];
 		}
-		return [];
 	}
 
 	/**
@@ -729,7 +705,7 @@ export class AccessControlAPI extends FeatureAPI {
 				credentialSlot: slot,
 				credentialData,
 			});
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const api = this.#ucAPI();
 
 			// Determine the current status; default to Enabled for new users
@@ -785,7 +761,6 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return result;
 		}
-		this.#throwNoAccessControl();
 	}
 
 	/**
@@ -807,7 +782,7 @@ export class AccessControlAPI extends FeatureAPI {
 				credentialType: type,
 				credentialSlot: slot,
 			});
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			// User Code CC ties each user to their code, so clearing
 			// the credential also deletes the user
 			const existed = this.#getCredentialCached_UC(userId, type, slot)
@@ -835,7 +810,6 @@ export class AccessControlAPI extends FeatureAPI {
 			}
 			return result;
 		}
-		this.#throwNoAccessControl();
 	}
 
 	/**
@@ -865,7 +839,7 @@ export class AccessControlAPI extends FeatureAPI {
 			: UserCredentialOperationType.Add;
 
 		timeout ??= this.getCredentialCapabilitiesCached()
-			?.supportedCredentialTypes
+			.supportedCredentialTypes
 			.get(type)?.credentialLearnRecommendedTimeout;
 
 		if (timeout == undefined) {
@@ -913,11 +887,10 @@ export class AccessControlAPI extends FeatureAPI {
 		if (this.#usesUserCredentialCC) {
 			const api = this.#u3cAPI();
 			return api.getAdminPinCode();
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const api = this.#ucAPI();
 			return api.getAdminCode();
 		}
-		return undefined;
 	}
 
 	/**
@@ -930,11 +903,10 @@ export class AccessControlAPI extends FeatureAPI {
 		if (this.#usesUserCredentialCC) {
 			const api = this.#u3cAPI();
 			return api.setAdminPinCode({ pinCode: code });
-		} else if (this.#usesUserCodeCC) {
+		} else {
 			const api = this.#ucAPI();
 			return api.setAdminCode(code);
 		}
-		this.#throwNoAccessControl();
 	}
 
 	#ucAPI(): UserCodeCCAPI {
@@ -1069,7 +1041,7 @@ export class AccessControlAPI extends FeatureAPI {
 
 	#assertValidSlot(type: UserCredentialType, slot: number): void {
 		const caps = this.getCredentialCapabilitiesCached()
-			?.supportedCredentialTypes.get(type);
+			.supportedCredentialTypes.get(type);
 		if (!caps || slot < 1 || slot > caps.numberOfCredentialSlots) {
 			throw new ZWaveError(
 				`Credential slot ${slot} is out of range for credential type ${
@@ -1078,13 +1050,6 @@ export class AccessControlAPI extends FeatureAPI {
 				ZWaveErrorCodes.Argument_Invalid,
 			);
 		}
-	}
-
-	#throwNoAccessControl(): never {
-		throw new ZWaveError(
-			"This node does not support managing users or credentials",
-			ZWaveErrorCodes.CC_NotSupported,
-		);
 	}
 
 	#getUserCached_U3C(userId: number): UserData | undefined {

--- a/packages/zwave-js/src/lib/node/feature-apis/DeviceFeatures.ts
+++ b/packages/zwave-js/src/lib/node/feature-apis/DeviceFeatures.ts
@@ -1,4 +1,0 @@
-/** High-level device features that can be tested for support via `endpoint.supportsFeature()` */
-export enum DeviceFeatures {
-	AccessControl,
-}

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCode.test.ts
@@ -47,13 +47,13 @@ integrationTest(
 			// User capabilities
 			const userCaps = node.accessControl.getUserCapabilitiesCached();
 			t.expect(userCaps).toBeDefined();
-			t.expect(userCaps!.maxUsers).toBe(10);
-			t.expect(userCaps!.supportedUserTypes).toStrictEqual([
+			t.expect(userCaps.maxUsers).toBe(10);
+			t.expect(userCaps.supportedUserTypes).toStrictEqual([
 				UserCredentialUserType.General,
 				UserCredentialUserType.NonAccess,
 			]);
-			t.expect(userCaps!.maxUserNameLength).toBeUndefined();
-			t.expect(userCaps!.supportedCredentialRules).toStrictEqual([
+			t.expect(userCaps.maxUserNameLength).toBeUndefined();
+			t.expect(userCaps.supportedCredentialRules).toStrictEqual([
 				UserCredentialRule.Single,
 			]);
 
@@ -61,11 +61,11 @@ integrationTest(
 			const credCaps = node.accessControl
 				.getCredentialCapabilitiesCached();
 			t.expect(credCaps).toBeDefined();
-			t.expect(credCaps!.supportsAdminCode).toBe(true);
-			t.expect(credCaps!.supportsAdminCodeDeactivation).toBe(true);
-			t.expect(credCaps!.supportedCredentialTypes.size).toBe(1);
+			t.expect(credCaps.supportsAdminCode).toBe(true);
+			t.expect(credCaps.supportsAdminCodeDeactivation).toBe(true);
+			t.expect(credCaps.supportedCredentialTypes.size).toBe(1);
 
-			const pinCap = credCaps!.supportedCredentialTypes.get(
+			const pinCap = credCaps.supportedCredentialTypes.get(
 				UserCredentialType.PINCode,
 			);
 			t.expect(pinCap).toBeDefined();
@@ -99,7 +99,7 @@ integrationTest(
 
 		testBody: async (t, driver, node, mockController, mockNode) => {
 			const caps = node.accessControl.getUserCapabilitiesCached();
-			t.expect(caps!.supportedUserTypes).toStrictEqual([
+			t.expect(caps.supportedUserTypes).toStrictEqual([
 				UserCredentialUserType.General,
 			]);
 		},

--- a/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
+++ b/packages/zwave-js/src/lib/test/node/accessControl.UserCredential.test.ts
@@ -92,14 +92,14 @@ integrationTest(
 			// User capabilities
 			const userCaps = node.accessControl.getUserCapabilitiesCached();
 			t.expect(userCaps).toBeDefined();
-			t.expect(userCaps!.maxUsers).toBe(20);
-			t.expect(userCaps!.maxUserNameLength).toBe(64);
-			t.expect(userCaps!.supportedUserTypes).toStrictEqual([
+			t.expect(userCaps.maxUsers).toBe(20);
+			t.expect(userCaps.maxUserNameLength).toBe(64);
+			t.expect(userCaps.supportedUserTypes).toStrictEqual([
 				UserCredentialUserType.General,
 				UserCredentialUserType.NonAccess,
 				UserCredentialUserType.Expiring,
 			]);
-			t.expect(userCaps!.supportedCredentialRules).toStrictEqual([
+			t.expect(userCaps.supportedCredentialRules).toStrictEqual([
 				UserCredentialRule.Single,
 				UserCredentialRule.Dual,
 			]);
@@ -108,21 +108,21 @@ integrationTest(
 			const credCaps = node.accessControl
 				.getCredentialCapabilitiesCached();
 			t.expect(credCaps).toBeDefined();
-			t.expect(credCaps!.supportsAdminCode).toBe(true);
-			t.expect(credCaps!.supportsAdminCodeDeactivation).toBe(true);
-			t.expect(credCaps!.supportedCredentialTypes.size).toBe(2);
+			t.expect(credCaps.supportsAdminCode).toBe(true);
+			t.expect(credCaps.supportsAdminCodeDeactivation).toBe(true);
+			t.expect(credCaps.supportedCredentialTypes.size).toBe(2);
 			t.expect(
-				credCaps!.supportedCredentialTypes.has(
+				credCaps.supportedCredentialTypes.has(
 					UserCredentialType.PINCode,
 				),
 			).toBe(true);
 			t.expect(
-				credCaps!.supportedCredentialTypes.has(
+				credCaps.supportedCredentialTypes.has(
 					UserCredentialType.RFIDCode,
 				),
 			).toBe(true);
 
-			const rfid = credCaps!.supportedCredentialTypes.get(
+			const rfid = credCaps.supportedCredentialTypes.get(
 				UserCredentialType.RFIDCode,
 			);
 			t.expect(rfid!.supportsCredentialLearn).toBe(true);


### PR DESCRIPTION
Having an entirely separate feature enum and checking support with unrelated functions felt awkward, so we're going to make the feature APIs possibly undefined to indicate no support.